### PR TITLE
fix(install): stop destroying user skills; drop invalid settings key

### DIFF
--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -54,6 +54,10 @@ For each file in scope:
 
 **Iron law: deletion over rewriting.**
 
+**Never delete `TODO`, `FIXME`, or `TODO(shortcut):` markers.** They record a known
+limitation and its upgrade path, so they must survive this phase even when the
+surrounding comment is reworded. A deliberate shortcut is not slop.
+
 For each file in scope:
 
 ### 2.1 Hedge Words in Comments

--- a/.claude/project.md
+++ b/.claude/project.md
@@ -55,7 +55,7 @@ shown below — not active in this template):
 ### Code Economy
 
 A **generation-time** gate that runs *before* you write code — the preventive
-counterpart to the post-hoc `/simplify`, `/deslop`, and `/quality-gate` passes.
+counterpart to the post-hoc `/quality-gate` passes.
 Apply to every code-writing turn (main thread and sub-agents). The cheapest line
 to review is the one never written.
 
@@ -97,7 +97,8 @@ prevents data loss, and anything the user explicitly requested.
 
 **Intentional shortcuts** — when you deliberately pick a minimal solution with a
 known limitation, mark it with a `TODO(shortcut):` comment stating the limit and
-the upgrade path. `/deslop` preserves `TODO/FIXME`, so the marker survives cleanup.
+the upgrade path. `/quality-gate` Phase 2 preserves `TODO/FIXME`, so the marker
+survives cleanup.
 
 ### Surgical Changes
 

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -54,6 +54,10 @@ For each file in scope:
 
 **Iron law: deletion over rewriting.**
 
+**Never delete `TODO`, `FIXME`, or `TODO(shortcut):` markers.** They record a known
+limitation and its upgrade path, so they must survive this phase even when the
+surrounding comment is reworded. A deliberate shortcut is not slop.
+
 For each file in scope:
 
 ### 2.1 Hedge Words in Comments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 ### Code Economy
 
 A **generation-time** gate that runs *before* you write code — the preventive
-counterpart to the post-hoc `/simplify`, `/deslop`, and `/quality-gate` passes.
+counterpart to the post-hoc `/quality-gate` passes.
 Apply to every code-writing turn. The cheapest line to review is the one never written.
 
 **Decision hierarchy** — walk top to bottom; stop at the first that applies:
@@ -51,7 +51,8 @@ data loss, and anything the user explicitly requested.
 
 **Intentional shortcuts** — when you deliberately pick a minimal solution with a
 known limitation, mark it with a `TODO(shortcut):` comment stating the limit and
-the upgrade path.
+the upgrade path. `/quality-gate` Phase 2 preserves `TODO/FIXME`, so the marker
+survives cleanup.
 
 ### Code Graph
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A reusable, project-agnostic configuration system that enforces **spec-driven, T
 | Layer | What it does |
 |-------|-------------|
 | **CLAUDE.md** | Core rules: Spec → Plan → TDD workflow, Clean Code, SOLID, quality gate |
-| **Skills** (`.claude/skills/`) | 16 skills: `/brainstorm`, `/plan`, `/build`, `/tdd`, `/debug`, `/verify`, `/simplify`, `/receive-review`, `/learn`, `/checkpoint`, `/security-scan`, `/start-qa`, `/wrap-up-session`, `/writing-skills`, `/sync`, `/folder-context-optimization` |
+| **Skills** (`.claude/skills/`) | 16 skills: `/brainstorm`, `/plan`, `/build`, `/tdd`, `/debug`, `/verify`, `/quality-gate`, `/receive-review`, `/learn`, `/checkpoint`, `/security-scan`, `/start-qa`, `/wrap-up-session`, `/writing-skills`, `/sync`, `/folder-context-optimization` |
 | **Agents** (`.claude/agents/`) | 8 specialized subagents for planning, coding, review, debugging, security |
 | **Hooks** (`.claude/hooks/`) | Session start orientation + auto test runner on file save |
 | **Memory** (`.claude/memory.md`) | Persistent patterns and session history, updated via `/learn` |
@@ -153,7 +153,7 @@ Feature Request
 /plan ──► interviews you → writes spec → task list in tasks/todo.md
     │
     ▼  (confirm with 'y')
-/build ──► autonomous TDD + sub-agents → 2-stage review → simplify → spec validation
+/build ──► autonomous TDD + sub-agents → 2-stage review → quality-gate → spec validation
     │
     ▼  (all tasks done)
 /security-scan ──► audit changed files for OWASP issues
@@ -178,7 +178,7 @@ flowchart TD
     D -->|"delegates to"| D1["/tdd\nRed-green-refactor cycle"]
     D -->|"after each task"| D2["code-reviewer\nSpec compliance + quality"]
     D -->|"on failure"| D3["/debug\nRoot cause analysis"]
-    D -->|"after all tasks"| D4["/simplify\nCode cleanup"]
+    D -->|"after all tasks"| D4["/quality-gate\nStructural + anti-pattern + design review"]
     D -->|"before claims"| D5["/verify\nEvidence-based verification"]
 
     %% Skills called by /debug
@@ -206,7 +206,7 @@ flowchart TD
 
 **Core workflow** (top row): brainstorm → plan → build → security-scan → wrap-up-session
 
-**Internal calls**: /build delegates to sub-agents for TDD, invokes code-reviewer for 2-stage review, /debug on failures, /simplify after all tasks, and /verify before any completion claims.
+**Internal calls**: /build delegates to sub-agents for TDD, invokes code-reviewer for 2-stage review, /debug on failures, /quality-gate after all tasks, and /verify before any completion claims.
 
 **Standalone skills** (bottom): Can be invoked independently at any time.
 
@@ -220,11 +220,11 @@ Invoke with `/skill-name` in any Claude Code session:
 |-------|-------------|
 | `/brainstorm` | Divergent design exploration: 2-3 approaches with trade-offs, design approval before `/plan` |
 | `/plan` | Interviews you, writes spec to `specs/`, creates TDD task plan in `tasks/todo.md` |
-| `/build` | Autonomous orchestrator: TDD + sub-agents + 2-stage review + parallel dispatch + simplify + spec validation |
+| `/build` | Autonomous orchestrator: TDD + sub-agents + 2-stage review + parallel dispatch + quality-gate + spec validation |
 | `/tdd` | Manual TDD loop with user checkpoints: failing test → code → pass → refactor → `[x]` |
 | `/debug` | Root cause analysis with architecture questioning after 3 fails, bug register, lessons |
 | `/verify` | Evidence-based verification gate — no completion claims without fresh command output |
-| `/simplify` | Review changed code for reuse, quality, complexity; fix issues found |
+| `/quality-gate` | 3-phase post-build review: structural quality, AI anti-patterns, APOSD design |
 | `/receive-review` | Process code review feedback: technical evaluation, pushback protocol, no performative agreement |
 | `/learn` | Extracts session patterns and appends them to `.claude/memory.md` |
 | `/checkpoint` | Saves progress snapshot to `tasks/checkpoint.md` for handoff or pause |

--- a/install.sh
+++ b/install.sh
@@ -6,14 +6,17 @@
 #   2. Copies .agents/ into ~/.agents/ (harness-neutral skills)
 #   3. Installs a global SessionStart hook that orients Claude in any project
 #   4. Sets up a git template dir so `git init` auto-installs a post-init hook
-#   5. Configures ~/.claude/settings.json with skills path
-#   6. Configures Pi (~/.pi/agent/settings.json) if installed
-#   7. Wires graphify into this project if the CLI is present (optional)
-#   8. Prints a `newproject` shell function to add to your .bashrc / .zshrc
+#   5. Configures Pi (~/.pi/agent/settings.json) if installed
+#   6. Wires graphify into this project if the CLI is present (optional)
+#   7. Prints a `newproject` shell function to add to your .bashrc / .zshrc
 #
 # Usage:
 #   git clone <this-repo> ~/coding-agent-workflow
-#   cd ~/coding-agent-workflow && bash install.sh
+#   cd ~/coding-agent-workflow && bash install.sh [--prune-skills]
+#
+# Skill installation is additive: nothing already in ~/.claude/skills/ is deleted
+# unless you pass --prune-skills, which lists every non-template entry and waits
+# for a typed confirmation first.
 
 set -euo pipefail
 
@@ -28,6 +31,62 @@ RESET='\033[0m'
 step() { echo -e "\n${BOLD}▶ $1${RESET}"; }
 ok()   { echo -e "  ${GREEN}✓${RESET} $2"; }
 
+usage() {
+  echo "Usage: bash install.sh [--prune-skills]"
+  echo ""
+  echo "  --prune-skills  Offer to delete entries in ~/.claude/skills/ that this"
+  echo "                  template no longer ships. Lists them and requires a typed"
+  echo "                  confirmation. Without this flag nothing is ever deleted."
+  echo "  -h, --help      Show this message."
+}
+
+PRUNE_SKILLS=0
+for arg in "$@"; do
+  case "$arg" in
+    --prune-skills) PRUNE_SKILLS=1 ;;
+    -h|--help)      usage; exit 0 ;;
+    *)              echo "Unknown option: $arg" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# Entries in ~/.claude/skills/ that this template does not ship — the user's own
+# skills, plus template skills retired since their last install. One per line;
+# empty output means the two trees agree.
+extra_global_skills() {
+  local entry name
+  for entry in "$CLAUDE_HOME/skills"/*; do
+    [ -e "$entry" ] || continue
+    name="$(basename "$entry")"
+    [ -e "$REPO_DIR/.claude/skills/$name" ] || printf '%s\n' "$name"
+  done
+}
+
+# Delete those entries — but only after listing them and reading back the literal
+# word "delete". EOF or any other answer aborts, leaving everything in place.
+prune_extra_skills() {
+  local extras reply=""
+  extras="$(extra_global_skills)"
+  if [ -z "$extras" ]; then
+    ok "nothing to prune" "~/.claude/skills/ holds no non-template entries"
+    return 0
+  fi
+  echo ""
+  echo "  --prune-skills will PERMANENTLY DELETE these non-template entries from"
+  echo "  $CLAUDE_HOME/skills/ :"
+  printf '%s\n' "$extras" | sed 's/^/    - /'
+  echo ""
+  printf '  Type "delete" to confirm (anything else aborts): '
+  read -r reply || reply=""
+  if [ "$reply" != "delete" ]; then
+    echo "  Aborted — nothing deleted."
+    return 0
+  fi
+  printf '%s\n' "$extras" | while IFS= read -r name; do
+    [ -n "$name" ] && rm -rf "$CLAUDE_HOME/skills/$name"
+  done
+  ok "pruned" "$(printf '%s\n' "$extras" | wc -l | tr -d ' ') non-template entries deleted"
+}
+
 # ── 1. Global CLAUDE.md ───────────────────────────────────────────────────────
 step "Installing global CLAUDE.md"
 mkdir -p "$CLAUDE_HOME"
@@ -35,10 +94,26 @@ cp "$REPO_DIR/CLAUDE.md" "$CLAUDE_HOME/CLAUDE.md"
 ok "copied" "~/.claude/CLAUDE.md"
 
 # ── 2. Global skills (backwards-compat copy) ─────────────────────────────────
+# Copy INTO the directory (note the trailing /.) instead of replacing it. This
+# step used to run `rm -rf "$CLAUDE_HOME/skills"` first, which silently destroyed
+# every skill the user kept there that the template does not ship — personal
+# skills, and template skills retired since their last install. Overwriting the
+# template entries while leaving everything else alone is the safe default;
+# removing retired entries is opt-in via --prune-skills.
 step "Installing global skills → ~/.claude/skills/"
-rm -rf "$CLAUDE_HOME/skills"
-cp -r "$REPO_DIR/.claude/skills" "$CLAUDE_HOME/skills"
-ok "copied" "$(find "$CLAUDE_HOME/skills" -name 'SKILL.md' | wc -l | tr -d ' ') skills (backwards-compat)"
+mkdir -p "$CLAUDE_HOME/skills"
+cp -r "$REPO_DIR/.claude/skills/." "$CLAUDE_HOME/skills/"
+ok "copied" "$(find "$REPO_DIR/.claude/skills" -name 'SKILL.md' | wc -l | tr -d ' ') skills (backwards-compat)"
+
+EXTRA_SKILLS="$(extra_global_skills)"
+if [ -n "$EXTRA_SKILLS" ]; then
+  echo "  kept $(printf '%s\n' "$EXTRA_SKILLS" | wc -l | tr -d ' ') non-template entries: $(printf '%s\n' "$EXTRA_SKILLS" | tr '\n' ' ')"
+  echo "  (re-run with --prune-skills to review and delete them)"
+fi
+
+if [ "$PRUNE_SKILLS" -eq 1 ]; then
+  prune_extra_skills
+fi
 
 # ── 3. Shared workflow → ~/.agents/ ──────────────────────────────────────────
 step "Installing shared workflow → ~/.agents/"
@@ -98,21 +173,15 @@ else
   fi
 fi
 
-# ── 6. Configure skills path in ~/.claude/settings.json ──────────────────────
-step "Configuring skill paths in ~/.claude/settings.json"
-if command -v jq > /dev/null 2>&1; then
-  if jq -e '.skills | index("~/.agents/skills")' "$SETTINGS_FILE" > /dev/null 2>&1; then
-    ok "already" "~/.agents/skills already in settings"
-  else
-    jq '.skills = ((.skills // []) + ["~/.agents/skills"])' "$SETTINGS_FILE" > /tmp/settings_tmp.json && mv /tmp/settings_tmp.json "$SETTINGS_FILE"
-    ok "updated" "added ~/.agents/skills to settings.json skills array"
-  fi
-else
-  echo "  NOTE: jq not found — skill path not automatically added to settings.json."
-  echo "  Add manually: .skills = [\"~/.agents/skills\"] in $SETTINGS_FILE"
-fi
+# NOTE: there is deliberately no step here writing a top-level `skills` key into
+# ~/.claude/settings.json. Claude Code's settings schema is strict and has no such
+# field (verified against the CLI's own schema: it exposes `skillOverrides` and
+# `disableBundledSkills`, but no skill-path array), so writing one makes the CLI
+# report `Unrecognized field: skills`. It is also unnecessary — Claude Code reads
+# ~/.claude/skills/ natively, which step 2 populates. Pi is a separate schema and
+# is still configured below.
 
-# ── 7. Configure Pi if installed ─────────────────────────────────────────────
+# ── 6. Configure Pi if installed ─────────────────────────────────────────────
 PI_SETTINGS="$HOME/.pi/agent/settings.json"
 if [ -f "$PI_SETTINGS" ]; then
   step "Configuring Pi skill paths"
@@ -128,7 +197,7 @@ if [ -f "$PI_SETTINGS" ]; then
   fi
 fi
 
-# ── 8. Wire graphify into this project (optional) ────────────────────────────
+# ── 7. Wire graphify into this project (optional) ────────────────────────────
 # graphify is a per-machine CLI with per-project state (./graphify-out/graph.json),
 # so it has to be wired per repo. Entirely optional — never block the install.
 step "Wiring graphify (optional)"
@@ -180,7 +249,7 @@ else
   echo "  Install with: pip install graphify   (then re-run this installer)"
 fi
 
-# ── 9. Git template directory ─────────────────────────────────────────────────
+# ── 8. Git template directory ─────────────────────────────────────────────────
 step "Setting up git template dir → $GIT_TEMPLATE_DIR"
 mkdir -p "$GIT_TEMPLATE_DIR/hooks"
 
@@ -231,7 +300,7 @@ git config --global init.templateDir "$GIT_TEMPLATE_DIR"
 ok "set" "git config --global init.templateDir $GIT_TEMPLATE_DIR"
 ok "installed" "post-init hook (runs on every git init)"
 
-# ── 10. Print newproject shell function ───────────────────────────────────────
+# ── 9. Print newproject shell function ───────────────────────────────────────
 step "Shell function — add this to your ~/.bashrc or ~/.zshrc"
 cat <<'SHELLCONFIG'
 

--- a/tests/test-install-sh.sh
+++ b/tests/test-install-sh.sh
@@ -1,0 +1,119 @@
+# tests/test-install-sh.sh — install.sh must never destroy user skills, and must
+# not write invalid keys into ~/.claude/settings.json.
+#
+# The functional cases run install.sh for real against a throwaway $HOME and a
+# throwaway CWD, so nothing touches the developer's own ~/.claude.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+INSTALL="$REPO/install.sh"
+USER_SKILL="my-personal-skill"
+
+# ── Static checks ────────────────────────────────────────────────────────────
+src="$(cat "$INSTALL")"
+
+# Match live commands only — prose mentioning the old bug must not trip these.
+count_matching() { grep -c -E "$1" "$INSTALL" 2>/dev/null || true; }
+
+assert_eq "0" "$(count_matching '^[[:space:]]*rm -rf "\$CLAUDE_HOME/skills"[[:space:]]*$')" \
+  "install.sh: no live 'rm -rf ~/.claude/skills' command"
+assert_contains "$src" 'cp -r "$REPO_DIR/.claude/skills/." "$CLAUDE_HOME/skills/"' \
+  "install.sh: copies skills INTO the dir (non-destructive)"
+assert_contains "$src" "--prune-skills" \
+  "install.sh: pruning is behind an explicit --prune-skills flag"
+
+# The invalid key is a Claude Code concern only. Pi has its own schema where a
+# `skills` array IS valid, so that write must survive.
+assert_eq "0" "$(count_matching 'jq .*\.skills.*\$SETTINGS_FILE')" \
+  "install.sh: never writes a 'skills' key into ~/.claude/settings.json"
+assert_eq "0" "$(count_matching 'jq .*\.skills.*> /tmp/settings_tmp.json')" \
+  "install.sh: no leftover Claude-side skills-path jq write"
+assert_contains "$src" '$PI_SETTINGS' \
+  "install.sh: Pi skill-path configuration retained"
+
+# ── Functional harness ───────────────────────────────────────────────────────
+# Run install.sh with an isolated HOME. Plants a user-owned skill first so we can
+# prove it survives. Echoes the temp HOME path; caller inspects it.
+run_install() {
+  local confirm="$1"; shift
+  local sandbox home
+  sandbox="$(mktemp -d)"
+  home="$sandbox/home"
+  mkdir -p "$home/.claude/skills/$USER_SKILL"
+  printf 'name: %s\n' "$USER_SKILL" > "$home/.claude/skills/$USER_SKILL/SKILL.md"
+  # Empty confirm means a closed stdin (true EOF), not a blank line.
+  local stdin=/dev/null
+  if [ -n "$confirm" ]; then
+    stdin="$sandbox/stdin.txt"
+    printf '%s\n' "$confirm" > "$stdin"
+  fi
+  # Run from inside the sandbox: install.sh's optional graphify step writes to CWD.
+  ( cd "$sandbox" && HOME="$home" bash "$INSTALL" "$@" ) > "$sandbox/out.log" 2>&1 < "$stdin"
+  printf '%s\n' "$sandbox"
+}
+
+exists() { [ -e "$1" ] && echo present || echo missing; }
+
+# ── Case 1: default run is additive ──────────────────────────────────────────
+box="$(run_install "")"
+h="$box/home"
+
+assert_eq "present" "$(exists "$h/.claude/skills/$USER_SKILL/SKILL.md")" \
+  "default run: user's own skill survives installation"
+assert_eq "present" "$(exists "$h/.claude/skills/build/SKILL.md")" \
+  "default run: template skills are installed"
+assert_eq "present" "$(exists "$h/.claude/settings.json")" \
+  "default run: settings.json created"
+assert_not_contains "$(cat "$h/.claude/settings.json")" '"skills"' \
+  "default run: settings.json contains no invalid 'skills' key"
+assert_file_contains "$h/.claude/settings.json" "session-start.sh" \
+  "default run: SessionStart hook still registered"
+rm -rf "$box"
+
+# ── Case 2: retired template skills also survive a default run ───────────────
+# A skill the template dropped (e.g. deslop) is indistinguishable from a personal
+# skill, so the additive default must keep it too.
+box="$(run_install "")"
+h="$box/home"
+mkdir -p "$h/.claude/skills/retired-skill"
+touch "$h/.claude/skills/retired-skill/SKILL.md"
+( cd "$box" && HOME="$h" bash "$INSTALL" ) > "$box/out2.log" 2>&1 < /dev/null
+assert_eq "present" "$(exists "$h/.claude/skills/retired-skill/SKILL.md")" \
+  "re-run: retired template skill is not silently removed"
+assert_contains "$(cat "$box/out2.log")" "--prune-skills" \
+  "re-run: reports kept non-template entries and how to prune them"
+rm -rf "$box"
+
+# ── Case 3: --prune-skills refuses without confirmation ──────────────────────
+box="$(run_install "" --prune-skills)"
+h="$box/home"
+assert_eq "present" "$(exists "$h/.claude/skills/$USER_SKILL/SKILL.md")" \
+  "--prune-skills with no confirmation (EOF): nothing deleted"
+assert_contains "$(cat "$box/out.log")" "$USER_SKILL" \
+  "--prune-skills: lists what it would delete before asking"
+rm -rf "$box"
+
+box="$(run_install "no" --prune-skills)"
+h="$box/home"
+assert_eq "present" "$(exists "$h/.claude/skills/$USER_SKILL/SKILL.md")" \
+  "--prune-skills answered 'no': nothing deleted"
+rm -rf "$box"
+
+# ── Case 4: --prune-skills deletes only on explicit confirmation ─────────────
+box="$(run_install "delete" --prune-skills)"
+h="$box/home"
+assert_eq "missing" "$(exists "$h/.claude/skills/$USER_SKILL")" \
+  "--prune-skills confirmed: non-template entry deleted"
+assert_eq "present" "$(exists "$h/.claude/skills/build/SKILL.md")" \
+  "--prune-skills confirmed: template skills untouched"
+rm -rf "$box"
+
+# ── Case 5: unknown flags are rejected, not ignored ──────────────────────────
+box="$(mktemp -d)"
+( cd "$box" && HOME="$box/home" bash "$INSTALL" --bogus ) > "$box/out.log" 2>&1 < /dev/null
+assert_eq "1" "$?" "unknown flag: exits non-zero instead of installing"
+rm -rf "$box"
+
+finish


### PR DESCRIPTION
Two defects in `install.sh`, both found while running `/sync` on 2026-08-05.

## Defect 1a — data loss

Step 2 ran `rm -rf "$CLAUDE_HOME/skills"` before copying, silently deleting every skill in `~/.claude/skills/` that the template does not ship. On the reporter's machine that would have destroyed 4 skills, including `aws-saml2aws-auth` — a personal skill that exists nowhere in this repo and had no other copy.

The copy is now additive:

```bash
mkdir -p "$CLAUDE_HOME/skills"
cp -r "$REPO_DIR/.claude/skills/." "$CLAUDE_HOME/skills/"
```

Template entries are overwritten; everything else survives. Pruning retired entries is opt-in via `--prune-skills`, which lists what it will delete and requires the literal word `delete`. EOF or any other answer aborts, so a non-interactive run can never delete. Default runs report which extras were kept and how to prune them.

## Defect 1b — the missing skills were removed *deliberately*

`deslop`, `simplify`, and `verify-e2e` are referenced by docs but absent from both skill trees. Commit 447782b explains why:

> - simplify, deslop: REMOVED (superseded by /quality-gate inline phases)
> - verify-e2e: REMOVED (superseded by /verify --scope e2e)

I verified both successors genuinely carry the behaviour, so **the references were stale** — restoring the skills would have re-created the drift that commit closed. Updated `README.md` (4 refs), `.claude/project.md`, and `AGENTS.md` to name the successors.

One reference was more than a stale name. `.claude/project.md` promised *"`/deslop` preserves `TODO/FIXME`, so the marker survives cleanup"*, but quality-gate Phase 2 never inherited that clause while its §2.1/§2.2 delete comments — leaving the Code Economy `TODO(shortcut):` mechanism with no actual protection. Ported the guarantee into quality-gate Phase 2 rather than just deleting the sentence (both trees, byte-identical; parity test confirms).

`CLAUDE.md:61-62` is deliberately unchanged: `(simplify)` / `(deslop)` there label quality-gate's own phase headings rather than invoking skills.

## Defect 2 — invalid settings key

Step 6 wrote a top-level `skills` array into `~/.claude/settings.json`. Verified against the CLI's own bundled schema rather than assuming:

- The settings object is **strict** — the validator maps zod's `unrecognized_keys` to exactly the reported *"Unrecognized field: skills. Check for typos…"*.
- Extracting the schema's ~200 keys shows `skillOverrides`, `disableBundledSkills`, `skillListingMaxDescChars` — but **no `skills`**.
- Every `skills:` field in the binary belongs to a different schema (skill-index manifest, agent config, session config, telemetry).

There is no supported settings mechanism for adding skill directories; `~/.claude/skills/` is read natively, which step 2 already populates. The step is **removed**, with a comment recording why so it is not re-added. This also resolves its silent degradation when `jq` is absent — confirmed `jq` is missing from this machine's Git Bash PATH, which is why the reporter's real `settings.json` has no `skills` key today.

Step 7 (Pi) uses Pi's own schema, where a `skills` array *is* valid, and is untouched. A test asserts that write survives.

Remaining step banners renumbered 6–9 to close the gap.

## Not touched

`.claude/hooks/session-start.sh` and the SessionStart registration in step 5, per the report — that behaviour was verified correct separately.

## Verification

New `tests/test-install-sh.sh` — 19 assertions. Because this is a data-loss bug, it runs `install.sh` for real against a throwaway `$HOME` and CWD rather than only grepping source: plants a user skill, installs, asserts survival; covers the retired-skill case and all three prune paths (EOF, "no", "delete"). Confirmed the real `~/.claude` is never touched — `settings.json` unchanged and no `~/.git-templates` created.

**Mutation-tested**: reverting to the `rm -rf` form fails 8 assertions, including *"user's own skill survives installation"* — so the test would have caught the original bug.

Full suite: all 10 test files pass, including `test-skill-parity.sh` (42 assertions).

`shellcheck` is not installed on this machine, so linting was `bash -n` only.

## One thing needing a decision after merge

The reporter's `~/.claude/skills/` still holds the three retired skills, so an agent can still invoke dead skills. They now survive by default — correct, but stale. `bash install.sh --prune-skills` lists them, but **do not confirm blindly**: `aws-saml2aws-auth` is in the same list and would go with them. Removing just the three by hand is safer.

Also out of scope but worth noting: `README.md`'s skill inventory is broadly stale beyond the `/simplify` entry — it claims 16 skills where the repo ships 27, and omits `/prd`, `/yolo`, `/auto-improve`, `/graphify` and others. Only the references tied to these defects were fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
