### PR TITLE
feat(skills): harden sub-agent dispatch against hangs and compaction conflicts

### DIFF
--- a/.agents/skills/auto-improve/SKILL.md
+++ b/.agents/skills/auto-improve/SKILL.md
@@ -7,6 +7,11 @@ harness: universal
 
 # /auto-improve — Triage First, Discover When Dry, Ship One Improvement
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 An unattended cousin of `/auto-push`. Nobody hands you a plan. You **act on already-flagged work first**, fall back to **fresh discovery only when there's nothing ready to act on** (or on the weekly deep-sweep day), then implement the single highest-value improvement with TDD, verify no regressions, and open a PR — all in one run, no user prompts.
 
 Designed to run daily on the cloud. Be conservative: one focused, reviewable change per run beats a sprawling risky diff, and cheap days (act on backlog) should not pay for a full deep scan.

--- a/.agents/skills/auto-push/SKILL.md
+++ b/.agents/skills/auto-push/SKILL.md
@@ -9,6 +9,11 @@ harness: universal
 
 # /auto-push — Approve-Once, Ship-Hands-Free
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 A supervised cousin of `/yolo`. The user describes a feature; you produce a spec and plan; you **wait for an explicit `y` approval**; then the rest of the pipeline (build → review → tests → commit → push → deploy) runs autonomously with no further prompts.
 
 The single approval gate is the whole point. After it, you don't ask again.

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -321,7 +321,11 @@ Read `.agents/skills/build/references/subagent-resilience.md` before dispatching
   degraded return your fallbacks can see
 - Symbol-level tools over whole-file `Read` for anything above ~400 lines
 - Retry only with a **changed strategy**; an identical prompt fails identically
-- Stall monitor armed for unattended runs; report what was dropped when a fallback fires
+- Monitor **progress** (results landed, retries started), not file activity — a retry loop
+  writes constantly and looks perfectly healthy to an idle-time check
+- Budget for the **return**, not just the work — an agent that writes its artifact and dies
+  before returning looks identical to total failure, and gets retried from scratch
+- Report what was dropped when a fallback fires
 - **Implementation failure**: Retry once with additional context. If still failing, surface to user and pause.
 - **Test regression**: Fix with `code-debugger`. Max 3 fix attempts per regression (see circuit breaker).
 - **Spec gap found late**: Add tasks dynamically and loop back. Do not silently skip criteria.

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -325,6 +325,10 @@ Read `.agents/skills/build/references/subagent-resilience.md` before dispatching
   writes constantly and looks perfectly healthy to an idle-time check
 - Budget for the **return**, not just the work — an agent that writes its artifact and dies
   before returning looks identical to total failure, and gets retried from scratch
+- Cap the artifact size in the prompt, and never ask for the artifact back in the return
+  schema — emitting it twice lands the second copy when context is tightest
+- If the output is a mechanical transform (merge, reformat, de-dup), use a **script**, not an
+  agent — an LLM re-emitting text verbatim is the most expensive way to run `cat`
 - Report what was dropped when a fallback fires
 - **Implementation failure**: Retry once with additional context. If still failing, surface to user and pause.
 - **Test regression**: Fix with `code-debugger`. Max 3 fix attempts per regression (see circuit breaker).

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -107,6 +107,10 @@ Before processing tasks sequentially, assess if any can run in parallel.
    it structurally true, so a mis-grouping surfaces as a merge conflict you can
    see rather than two agents silently overwriting each other.
 3. Wait for all to return; check for file conflicts
+   Before dispatching, give every sub-agent a tool-call budget with an explicit
+   "stop and write partial work" escape hatch, and arm a stall monitor. A hung agent
+   returns nothing, so null-check fallbacks never fire and this barrier never releases.
+   See `.agents/skills/build/references/subagent-resilience.md`.
 4. Run the full test suite **centrally, once** — never instruct the sub-agents to
    run it themselves. Fanning verification out to every agent multiplies context
    for no added signal and is a known way to lose a whole fleet to autocompact
@@ -299,6 +303,25 @@ Next: /wrap-up-session
 
 ## Error Handling
 
+
+### Sub-Agent Failure (hangs, silent stops, compaction conflicts)
+
+A sub-agent that **crashes** returns null and your fallback catches it. One that **hangs**
+returns nothing — no result, no error, no event — so every null-check fallback is downstream of
+a return that never happens. Under parallel dispatch this holds the entire phase.
+
+Most common cause: output-compression / compaction layers replace a large tool result with a
+placeholder, the agent loops on a failing retrieval call, and it is killed rather than erroring.
+This selects agents doing heavy source reading, so the most load-bearing agent is the one that
+dies while its siblings complete normally.
+
+Read `.agents/skills/build/references/subagent-resilience.md` before dispatching. Minimum bar:
+
+- Tool-call budget with a "write partial work and stop" escape hatch — converts a hang into a
+  degraded return your fallbacks can see
+- Symbol-level tools over whole-file `Read` for anything above ~400 lines
+- Retry only with a **changed strategy**; an identical prompt fails identically
+- Stall monitor armed for unattended runs; report what was dropped when a fallback fires
 - **Implementation failure**: Retry once with additional context. If still failing, surface to user and pause.
 - **Test regression**: Fix with `code-debugger`. Max 3 fix attempts per regression (see circuit breaker).
 - **Spec gap found late**: Add tasks dynamically and loop back. Do not silently skip criteria.

--- a/.agents/skills/build/references/subagent-resilience.md
+++ b/.agents/skills/build/references/subagent-resilience.md
@@ -1,0 +1,151 @@
+# Sub-Agent Resilience
+
+How to dispatch sub-agents so a failure surfaces as a **degraded result you can act on** instead of
+a phase that sits dead until a human notices.
+
+Applies to every skill that dispatches sub-agents: `/build`, `/auto-improve`, `/yolo`,
+`/auto-push`, `/quality-gate`, `/debug`.
+
+---
+
+## The failure that matters: a hang is not an error
+
+An agent that **crashes** returns null and your fallback catches it. An agent that **hangs**
+returns nothing at all — no result, no error, no event. Every null-check fallback is downstream of
+a return that never happens, so none of them fire.
+
+This is worse under parallel dispatch, because "wait for all to return" is a **barrier**: one hung
+agent holds the whole phase, including its own fallback, forever.
+
+> **Field incident.** Three agents dispatched in parallel; two returned in ~5 minutes, the third
+> hung. The phase sat dead for ~20 minutes. The orchestrator had a `.filter(Boolean)` fallback *and*
+> automatic retry — neither fired, because both live downstream of a return. The user was the only
+> liveness detector in the system.
+
+### Rule 1 — Give every agent a tool-call budget with an escape hatch
+
+This is the single highest-value line you can add to a sub-agent prompt. It converts a hang into a
+degraded return, which your existing fallbacks *can* see:
+
+```
+You have ~35 tool calls. If you approach that limit, STOP exploring and write your artifact
+immediately with what you have, listing what you could not verify under a "## Not verified"
+heading. A partial, honest artifact is SUCCESS. Hanging is the only failure.
+```
+
+Tune the number to the task (15 for a focused edit, 50 for a broad audit). The number matters less
+than the explicit permission to return incomplete work.
+
+### Rule 2 — Never put a risky agent inside a barrier
+
+Barrier (`parallel` / "wait for all to return") is correct only when the next step genuinely needs
+every prior result at once — dedup across a full set, an early-exit on a zero count, a merge.
+
+If a step only needs results *individually*, pipeline them so each flows on as it lands. When a
+barrier is genuinely required, keep the highest-risk agent (usually the one reading the most
+source) **outside** it, and let the barrier close on the predictable agents.
+
+### Rule 3 — Retry must vary the strategy, not repeat the prompt
+
+Retry helps **transient** faults: rate limits, network blips, provider errors. It does nothing for a
+**deterministic** one — an identical prompt against an identical environment fails identically, and
+three attempts cost 3× for the same outcome.
+
+Before retrying, ask: *what will be different this time?* If the answer is "nothing", change the
+approach instead — narrower scope, different tools, split into two agents.
+
+### Rule 4 — Arm a stall monitor, not a status poll
+
+The harness already notifies on **completion** and **error**. Polling "is it done yet?" is
+redundant and burns tokens. The uncovered case is silence.
+
+Arm a monitor at dispatch time that stays quiet while healthy and speaks only on trouble:
+
+```bash
+D=<transcript-dir>          # the workflow/agent transcript directory
+prev=-1; stalled=0
+for i in $(seq 1 70); do
+  n=$(cat "$D"/journal.jsonl 2>/dev/null | wc -l)
+  errs=$(grep -c '"type":"error"' "$D"/journal.jsonl 2>/dev/null || echo 0)
+  newest=$(ls -t "$D"/agent-*.jsonl 2>/dev/null | head -1)
+  idle=$(( $(date +%s) - $(stat -c %Y "$newest") ))
+  [ "$n" != "$prev" ] && { prev=$n; stalled=0; }
+  [ "$errs" -gt 0 ] && [ "$stalled" -ne 2 ] && { echo "ERROR entries: $errs"; stalled=2; }
+  [ "$idle" -gt 240 ] && [ "$stalled" -eq 0 ] && { echo "STALL: no write for ${idle}s"; stalled=1; }
+  sleep 20
+done
+```
+
+- **~240s threshold** — long enough that a slow model call or a large grep doesn't cry wolf, short
+  enough that a dead phase surfaces in minutes.
+- **Latch the flag** so one stall episode emits once. A monitor that fires every tick gets
+  auto-stopped for noise, which silently removes your only detector.
+- Use an event-driven monitor, **not** a cron/wakeup poll — polling harness-tracked work is waste.
+
+### Rule 5 — Report what was dropped
+
+A degraded run that reports "done" is indistinguishable from a clean one. Whenever a fallback fires,
+say so explicitly: which agent failed, what artifact is missing, what the downstream step ran
+without. Silent truncation reads as full coverage.
+
+---
+
+## Conflicts with compaction and compression layers
+
+Many setups run token-optimizing layers — output compressors, MCP proxies, harness autocompact.
+They are cheap for the orchestrator and hostile to sub-agents that read a lot of source.
+
+**The mechanism.** A large tool result is replaced by a placeholder such as
+`[N items compressed to M. Retrieve more: hash=…]`. The agent calls the retrieval tool to recover
+the text; retrieval can fail (`"Content not found. It may have expired or the hash may be
+incorrect."`); the agent retries; it loops until it is killed. It never errors — it **hangs**,
+which is exactly the case Rule 1 exists to catch.
+
+**It is not uniform.** The failure selects agents doing heavy *text* reads. Agents reading images
+(not text-compressed) or web results (small) are unaffected. So the agent that dies is usually the
+one doing the most load-bearing work, and the phase looks "mostly fine".
+
+> **Field incident.** A capabilities-documenting agent burned 17, then 22, then 4 retrieval calls
+> across three attempts and never returned, while its image-reading and web-searching siblings both
+> completed normally.
+
+**Do not fix this by disabling the layer.** It is the user's environment and it is saving them real
+tokens. Fix it by never generating a result large enough to trip it:
+
+| Instead of | Use |
+|---|---|
+| `Read` on a 2000-line source file | `mcp__serena__get_symbols_overview` (compact symbol map) |
+| `Read` to find one function | `mcp__serena__find_symbol` with `include_body` |
+| `Read` to understand file structure | `smart_outline` (signatures, bodies folded) |
+| `grep -r` across the repo | The `Grep` tool with a specific pattern |
+| Reading a file "to be safe" | `sed -n '1,120p'` on the range you actually need |
+
+Put these rules **verbatim** in the sub-agent prompt. They are never inferred:
+
+```
+- NEVER use Read on a file longer than ~400 lines. Use symbol-level tools or explicit line ranges.
+- NEVER call retrieval/decompression tools. If a result looks like a compression placeholder, do
+  NOT try to retrieve it — re-issue the SAME read at narrower scope. Retrieval will fail and burn
+  your budget.
+- NEVER grep generated index directories unscoped (graph/AST/embedding caches). A single unscoped
+  grep there can exhaust your context.
+```
+
+**Corollary — keep artifacts on disk, not in the reply.** Have each agent write its output to a
+file and return only a short summary plus a structured result. The orchestrator's context then holds
+pointers and deltas rather than file bodies, which keeps the whole run below the threshold that
+triggers compaction in the first place.
+
+---
+
+## Dispatch checklist
+
+Before dispatching any sub-agent:
+
+- [ ] Tool-call budget with an explicit "write partial work and stop" escape hatch
+- [ ] Compaction-layer rules pasted verbatim if the agent will read source
+- [ ] Artifact written to disk; only a summary + structured result returned
+- [ ] Risky agents kept out of barriers; barriers used only where all results are genuinely needed
+- [ ] Retry (if any) varies the strategy rather than repeating the prompt
+- [ ] Stall monitor armed for anything running unattended
+- [ ] Fallback path reports what was dropped instead of failing silently

--- a/.agents/skills/build/references/subagent-resilience.md
+++ b/.agents/skills/build/references/subagent-resilience.md
@@ -36,6 +36,22 @@ heading. A partial, honest artifact is SUCCESS. Hanging is the only failure.
 Tune the number to the task (15 for a focused edit, 50 for a broad audit). The number matters less
 than the explicit permission to return incomplete work.
 
+**Budget for the return, not just the work.** Writing the artifact and returning the structured
+result are two separate costs, and the return is the one that gets dropped. Say so explicitly:
+
+```
+The moment you write your artifact, STOP — your next action must be returning the result.
+Do no further exploration after the write.
+```
+
+> **Field incident.** An agent given a ~35-call budget used 41, wrote a complete and correct 18 KB
+> artifact, then died before emitting its structured result. The orchestrator saw no return, treated
+> it as a failure, and redid the entire job twice. The work was never the problem; the last turn was.
+
+**Watch which tools drain the budget.** The same agent spent **29 of its 41 calls on `Bash`**. It
+had been told not to `Read` large files and complied — then substituted shell `grep`/`sed` loops,
+which are correct but no cheaper. Name the tools you want it to *use*, not only the ones to avoid.
+
 ### Rule 2 — Never put a risky agent inside a barrier
 
 Barrier (`parallel` / "wait for all to return") is correct only when the next step genuinely needs
@@ -54,32 +70,50 @@ three attempts cost 3× for the same outcome.
 Before retrying, ask: *what will be different this time?* If the answer is "nothing", change the
 approach instead — narrower scope, different tools, split into two agents.
 
-### Rule 4 — Arm a stall monitor, not a status poll
+### Rule 4 — Monitor **progress**, not activity
 
 The harness already notifies on **completion** and **error**. Polling "is it done yet?" is
-redundant and burns tokens. The uncovered case is silence.
+redundant and burns tokens. The uncovered case is silence — so arm a monitor at dispatch time that
+stays quiet while healthy and speaks only on trouble.
 
-Arm a monitor at dispatch time that stays quiet while healthy and speaks only on trouble:
+**The trap: a retry loop is indistinguishable from healthy work if you watch file activity.**
+
+> **Field incident.** A monitor watched "has any agent transcript been written recently?" with a
+> 240s idle threshold. It ran its full 23-minute window and never fired once — while the workflow
+> was stuck retrying the same agent three times. Each retry wrote constantly, so idle time never
+> rose. The heartbeat was perfect and nothing was progressing.
+
+Measure **results landed** and **retries started**, not bytes written:
 
 ```bash
-D=<transcript-dir>          # the workflow/agent transcript directory
-prev=-1; stalled=0
-for i in $(seq 1 70); do
-  n=$(cat "$D"/journal.jsonl 2>/dev/null | wc -l)
-  errs=$(grep -c '"type":"error"' "$D"/journal.jsonl 2>/dev/null || echo 0)
-  newest=$(ls -t "$D"/agent-*.jsonl 2>/dev/null | head -1)
-  idle=$(( $(date +%s) - $(stat -c %Y "$newest") ))
-  [ "$n" != "$prev" ] && { prev=$n; stalled=0; }
-  [ "$errs" -gt 0 ] && [ "$stalled" -ne 2 ] && { echo "ERROR entries: $errs"; stalled=2; }
-  [ "$idle" -gt 240 ] && [ "$stalled" -eq 0 ] && { echo "STALL: no write for ${idle}s"; stalled=1; }
+D=<transcript-dir>
+EXPECTED=<number of agents the workflow defines>
+lastres=-1; since=$(date +%s); warned=0; retrywarn=0
+for i in $(seq 1 90); do
+  res=$(grep -c '"type":"result"' "$D"/journal.jsonl 2>/dev/null || echo 0)
+  errs=$(grep -c '"type":"error"'  "$D"/journal.jsonl 2>/dev/null || echo 0)
+  started=$(ls -1 "$D"/agent-*.jsonl 2>/dev/null | wc -l)
+  now=$(date +%s)
+  [ "$res" != "$lastres" ] && { lastres=$res; since=$now; warned=0; }
+  # no NEW RESULT in 6 min - activity is not progress
+  [ $((now-since)) -gt 360 ] && [ "$warned" -eq 0 ] && \
+    { echo "NO-PROGRESS: ${res}/${EXPECTED} results for $((now-since))s"; warned=1; }
+  # more agents started than the workflow defines => something is failing to return
+  [ "$started" -gt "$EXPECTED" ] && [ "$retrywarn" -eq 0 ] && \
+    { echo "RETRYING: $started started, $EXPECTED expected"; retrywarn=1; }
+  [ "$errs" -gt 0 ] && { echo "ERROR entries: $errs"; exit 0; }
+  [ "$res" -ge "$EXPECTED" ] && { echo "all agents returned ($res/$EXPECTED)"; exit 0; }
   sleep 20
 done
 ```
 
-- **~240s threshold** — long enough that a slow model call or a large grep doesn't cry wolf, short
-  enough that a dead phase surfaces in minutes.
-- **Latch the flag** so one stall episode emits once. A monitor that fires every tick gets
-  auto-stopped for noise, which silently removes your only detector.
+- **Retry detection is the highest-value signal** — `started > EXPECTED` catches a silently
+  looping agent within one cycle, long before any timeout would.
+- **~360s on results** — coarser than an idle threshold, because a single agent legitimately runs
+  for minutes. Progress is the thing with a deadline, not activity.
+- **Latch each flag** so one episode emits once. A monitor that fires every tick gets auto-stopped
+  for noise, which silently removes your only detector.
+- Exit on completion so the monitor doesn't outlive the run.
 - Use an event-driven monitor, **not** a cron/wakeup poll — polling harness-tracked work is waste.
 
 ### Rule 5 — Report what was dropped

--- a/.agents/skills/build/references/subagent-resilience.md
+++ b/.agents/skills/build/references/subagent-resilience.md
@@ -52,6 +52,38 @@ Do no further exploration after the write.
 had been told not to `Read` large files and complied — then substituted shell `grep`/`sed` loops,
 which are correct but no cheaper. Name the tools you want it to *use*, not only the ones to avoid.
 
+### Rule 1b — Generated size is the real budget, and never return the artifact twice
+
+Tool-call counts are a proxy. The thing that actually kills an agent is **how many tokens it must
+generate**, and the return is always last in line.
+
+Two rules follow, and they matter more than the call budget:
+
+**Cap the artifact, or don't use an agent at all.** An agent asked to emit a large document spends
+its whole budget transcribing and dies before returning. Give a concrete size target in the prompt
+("200–300 lines, hard cap 400; terse table rows, not prose").
+
+If the output is a *mechanical* transform of existing text — merging, concatenating, reformatting,
+de-duplicating — **do it with a script, not an agent.** An LLM re-emitting text verbatim is the
+most expensive way to run `cat`, and the volume is exactly what makes it fail.
+
+> **Field incident.** A "merge these two documents" agent had to emit ~40 KB (~12K output tokens)
+> of near-verbatim transcription. It produced a correct, complete document — and then had nothing
+> left to return, so the orchestrator retried the whole job. The task never needed a model.
+
+**Never ask for the artifact back in the return schema.** If the agent writes a table to a file and
+your schema also demands that table as structured output, it emits everything **twice**, and the
+second emission lands at the moment its context is tightest. Have the return be a receipt:
+
+```
+PATH:    <file written>
+COUNTS:  have=<n> partial=<n> missing=<n>
+VERDICT: <2-3 sentences>
+```
+
+Then read the file yourself for detail. A rich schema is a liability on any agent producing a large
+artifact — keep the payload to identifiers, counts, and a verdict.
+
 ### Rule 2 — Never put a risky agent inside a barrier
 
 Barrier (`parallel` / "wait for all to return") is correct only when the next step genuinely needs

--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -6,6 +6,11 @@ argument-hint: "[--scope <path>]"
 
 # /quality-gate — Post-Build Quality Review
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 3-phase sequential review run after all build tasks are complete. Each phase has a unique mandate.
 
 ## Scope

--- a/.agents/skills/yolo/SKILL.md
+++ b/.agents/skills/yolo/SKILL.md
@@ -9,6 +9,11 @@ harness: universal
 
 # /yolo — Fully Autonomous Plan → Build → Wrap-Up Loop
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 You-Only-Live-Once mode. The user gives you an idea; you take it from spec through merge with **no user prompts in between**. Modeled after the Ralph Loop pattern: a single prompt drives repeated `plan → build → wrap-up` iterations, with state persisted on disk (not in context) so each phase starts cold and finishes verifiable.
 
 ---

--- a/.claude/skills/auto-improve/SKILL.md
+++ b/.claude/skills/auto-improve/SKILL.md
@@ -7,6 +7,11 @@ harness: universal
 
 # /auto-improve — Triage First, Discover When Dry, Ship One Improvement
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 An unattended cousin of `/auto-push`. Nobody hands you a plan. You **act on already-flagged work first**, fall back to **fresh discovery only when there's nothing ready to act on** (or on the weekly deep-sweep day), then implement the single highest-value improvement with TDD, verify no regressions, and open a PR — all in one run, no user prompts.
 
 Designed to run daily on the cloud. Be conservative: one focused, reviewable change per run beats a sprawling risky diff, and cheap days (act on backlog) should not pay for a full deep scan.

--- a/.claude/skills/auto-push/SKILL.md
+++ b/.claude/skills/auto-push/SKILL.md
@@ -9,6 +9,11 @@ harness: universal
 
 # /auto-push — Approve-Once, Ship-Hands-Free
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 A supervised cousin of `/yolo`. The user describes a feature; you produce a spec and plan; you **wait for an explicit `y` approval**; then the rest of the pipeline (build → review → tests → commit → push → deploy) runs autonomously with no further prompts.
 
 The single approval gate is the whole point. After it, you don't ask again.

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -321,7 +321,11 @@ Read `.agents/skills/build/references/subagent-resilience.md` before dispatching
   degraded return your fallbacks can see
 - Symbol-level tools over whole-file `Read` for anything above ~400 lines
 - Retry only with a **changed strategy**; an identical prompt fails identically
-- Stall monitor armed for unattended runs; report what was dropped when a fallback fires
+- Monitor **progress** (results landed, retries started), not file activity — a retry loop
+  writes constantly and looks perfectly healthy to an idle-time check
+- Budget for the **return**, not just the work — an agent that writes its artifact and dies
+  before returning looks identical to total failure, and gets retried from scratch
+- Report what was dropped when a fallback fires
 - **Implementation failure**: Retry once with additional context. If still failing, surface to user and pause.
 - **Test regression**: Fix with `code-debugger`. Max 3 fix attempts per regression (see circuit breaker).
 - **Spec gap found late**: Add tasks dynamically and loop back. Do not silently skip criteria.

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -325,6 +325,10 @@ Read `.agents/skills/build/references/subagent-resilience.md` before dispatching
   writes constantly and looks perfectly healthy to an idle-time check
 - Budget for the **return**, not just the work — an agent that writes its artifact and dies
   before returning looks identical to total failure, and gets retried from scratch
+- Cap the artifact size in the prompt, and never ask for the artifact back in the return
+  schema — emitting it twice lands the second copy when context is tightest
+- If the output is a mechanical transform (merge, reformat, de-dup), use a **script**, not an
+  agent — an LLM re-emitting text verbatim is the most expensive way to run `cat`
 - Report what was dropped when a fallback fires
 - **Implementation failure**: Retry once with additional context. If still failing, surface to user and pause.
 - **Test regression**: Fix with `code-debugger`. Max 3 fix attempts per regression (see circuit breaker).

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -107,6 +107,10 @@ Before processing tasks sequentially, assess if any can run in parallel.
    it structurally true, so a mis-grouping surfaces as a merge conflict you can
    see rather than two agents silently overwriting each other.
 3. Wait for all to return; check for file conflicts
+   Before dispatching, give every sub-agent a tool-call budget with an explicit
+   "stop and write partial work" escape hatch, and arm a stall monitor. A hung agent
+   returns nothing, so null-check fallbacks never fire and this barrier never releases.
+   See `.agents/skills/build/references/subagent-resilience.md`.
 4. Run the full test suite **centrally, once** — never instruct the sub-agents to
    run it themselves. Fanning verification out to every agent multiplies context
    for no added signal and is a known way to lose a whole fleet to autocompact
@@ -299,6 +303,25 @@ Next: /wrap-up-session
 
 ## Error Handling
 
+
+### Sub-Agent Failure (hangs, silent stops, compaction conflicts)
+
+A sub-agent that **crashes** returns null and your fallback catches it. One that **hangs**
+returns nothing — no result, no error, no event — so every null-check fallback is downstream of
+a return that never happens. Under parallel dispatch this holds the entire phase.
+
+Most common cause: output-compression / compaction layers replace a large tool result with a
+placeholder, the agent loops on a failing retrieval call, and it is killed rather than erroring.
+This selects agents doing heavy source reading, so the most load-bearing agent is the one that
+dies while its siblings complete normally.
+
+Read `.agents/skills/build/references/subagent-resilience.md` before dispatching. Minimum bar:
+
+- Tool-call budget with a "write partial work and stop" escape hatch — converts a hang into a
+  degraded return your fallbacks can see
+- Symbol-level tools over whole-file `Read` for anything above ~400 lines
+- Retry only with a **changed strategy**; an identical prompt fails identically
+- Stall monitor armed for unattended runs; report what was dropped when a fallback fires
 - **Implementation failure**: Retry once with additional context. If still failing, surface to user and pause.
 - **Test regression**: Fix with `code-debugger`. Max 3 fix attempts per regression (see circuit breaker).
 - **Spec gap found late**: Add tasks dynamically and loop back. Do not silently skip criteria.

--- a/.claude/skills/build/references/subagent-resilience.md
+++ b/.claude/skills/build/references/subagent-resilience.md
@@ -1,0 +1,151 @@
+# Sub-Agent Resilience
+
+How to dispatch sub-agents so a failure surfaces as a **degraded result you can act on** instead of
+a phase that sits dead until a human notices.
+
+Applies to every skill that dispatches sub-agents: `/build`, `/auto-improve`, `/yolo`,
+`/auto-push`, `/quality-gate`, `/debug`.
+
+---
+
+## The failure that matters: a hang is not an error
+
+An agent that **crashes** returns null and your fallback catches it. An agent that **hangs**
+returns nothing at all — no result, no error, no event. Every null-check fallback is downstream of
+a return that never happens, so none of them fire.
+
+This is worse under parallel dispatch, because "wait for all to return" is a **barrier**: one hung
+agent holds the whole phase, including its own fallback, forever.
+
+> **Field incident.** Three agents dispatched in parallel; two returned in ~5 minutes, the third
+> hung. The phase sat dead for ~20 minutes. The orchestrator had a `.filter(Boolean)` fallback *and*
+> automatic retry — neither fired, because both live downstream of a return. The user was the only
+> liveness detector in the system.
+
+### Rule 1 — Give every agent a tool-call budget with an escape hatch
+
+This is the single highest-value line you can add to a sub-agent prompt. It converts a hang into a
+degraded return, which your existing fallbacks *can* see:
+
+```
+You have ~35 tool calls. If you approach that limit, STOP exploring and write your artifact
+immediately with what you have, listing what you could not verify under a "## Not verified"
+heading. A partial, honest artifact is SUCCESS. Hanging is the only failure.
+```
+
+Tune the number to the task (15 for a focused edit, 50 for a broad audit). The number matters less
+than the explicit permission to return incomplete work.
+
+### Rule 2 — Never put a risky agent inside a barrier
+
+Barrier (`parallel` / "wait for all to return") is correct only when the next step genuinely needs
+every prior result at once — dedup across a full set, an early-exit on a zero count, a merge.
+
+If a step only needs results *individually*, pipeline them so each flows on as it lands. When a
+barrier is genuinely required, keep the highest-risk agent (usually the one reading the most
+source) **outside** it, and let the barrier close on the predictable agents.
+
+### Rule 3 — Retry must vary the strategy, not repeat the prompt
+
+Retry helps **transient** faults: rate limits, network blips, provider errors. It does nothing for a
+**deterministic** one — an identical prompt against an identical environment fails identically, and
+three attempts cost 3× for the same outcome.
+
+Before retrying, ask: *what will be different this time?* If the answer is "nothing", change the
+approach instead — narrower scope, different tools, split into two agents.
+
+### Rule 4 — Arm a stall monitor, not a status poll
+
+The harness already notifies on **completion** and **error**. Polling "is it done yet?" is
+redundant and burns tokens. The uncovered case is silence.
+
+Arm a monitor at dispatch time that stays quiet while healthy and speaks only on trouble:
+
+```bash
+D=<transcript-dir>          # the workflow/agent transcript directory
+prev=-1; stalled=0
+for i in $(seq 1 70); do
+  n=$(cat "$D"/journal.jsonl 2>/dev/null | wc -l)
+  errs=$(grep -c '"type":"error"' "$D"/journal.jsonl 2>/dev/null || echo 0)
+  newest=$(ls -t "$D"/agent-*.jsonl 2>/dev/null | head -1)
+  idle=$(( $(date +%s) - $(stat -c %Y "$newest") ))
+  [ "$n" != "$prev" ] && { prev=$n; stalled=0; }
+  [ "$errs" -gt 0 ] && [ "$stalled" -ne 2 ] && { echo "ERROR entries: $errs"; stalled=2; }
+  [ "$idle" -gt 240 ] && [ "$stalled" -eq 0 ] && { echo "STALL: no write for ${idle}s"; stalled=1; }
+  sleep 20
+done
+```
+
+- **~240s threshold** — long enough that a slow model call or a large grep doesn't cry wolf, short
+  enough that a dead phase surfaces in minutes.
+- **Latch the flag** so one stall episode emits once. A monitor that fires every tick gets
+  auto-stopped for noise, which silently removes your only detector.
+- Use an event-driven monitor, **not** a cron/wakeup poll — polling harness-tracked work is waste.
+
+### Rule 5 — Report what was dropped
+
+A degraded run that reports "done" is indistinguishable from a clean one. Whenever a fallback fires,
+say so explicitly: which agent failed, what artifact is missing, what the downstream step ran
+without. Silent truncation reads as full coverage.
+
+---
+
+## Conflicts with compaction and compression layers
+
+Many setups run token-optimizing layers — output compressors, MCP proxies, harness autocompact.
+They are cheap for the orchestrator and hostile to sub-agents that read a lot of source.
+
+**The mechanism.** A large tool result is replaced by a placeholder such as
+`[N items compressed to M. Retrieve more: hash=…]`. The agent calls the retrieval tool to recover
+the text; retrieval can fail (`"Content not found. It may have expired or the hash may be
+incorrect."`); the agent retries; it loops until it is killed. It never errors — it **hangs**,
+which is exactly the case Rule 1 exists to catch.
+
+**It is not uniform.** The failure selects agents doing heavy *text* reads. Agents reading images
+(not text-compressed) or web results (small) are unaffected. So the agent that dies is usually the
+one doing the most load-bearing work, and the phase looks "mostly fine".
+
+> **Field incident.** A capabilities-documenting agent burned 17, then 22, then 4 retrieval calls
+> across three attempts and never returned, while its image-reading and web-searching siblings both
+> completed normally.
+
+**Do not fix this by disabling the layer.** It is the user's environment and it is saving them real
+tokens. Fix it by never generating a result large enough to trip it:
+
+| Instead of | Use |
+|---|---|
+| `Read` on a 2000-line source file | `mcp__serena__get_symbols_overview` (compact symbol map) |
+| `Read` to find one function | `mcp__serena__find_symbol` with `include_body` |
+| `Read` to understand file structure | `smart_outline` (signatures, bodies folded) |
+| `grep -r` across the repo | The `Grep` tool with a specific pattern |
+| Reading a file "to be safe" | `sed -n '1,120p'` on the range you actually need |
+
+Put these rules **verbatim** in the sub-agent prompt. They are never inferred:
+
+```
+- NEVER use Read on a file longer than ~400 lines. Use symbol-level tools or explicit line ranges.
+- NEVER call retrieval/decompression tools. If a result looks like a compression placeholder, do
+  NOT try to retrieve it — re-issue the SAME read at narrower scope. Retrieval will fail and burn
+  your budget.
+- NEVER grep generated index directories unscoped (graph/AST/embedding caches). A single unscoped
+  grep there can exhaust your context.
+```
+
+**Corollary — keep artifacts on disk, not in the reply.** Have each agent write its output to a
+file and return only a short summary plus a structured result. The orchestrator's context then holds
+pointers and deltas rather than file bodies, which keeps the whole run below the threshold that
+triggers compaction in the first place.
+
+---
+
+## Dispatch checklist
+
+Before dispatching any sub-agent:
+
+- [ ] Tool-call budget with an explicit "write partial work and stop" escape hatch
+- [ ] Compaction-layer rules pasted verbatim if the agent will read source
+- [ ] Artifact written to disk; only a summary + structured result returned
+- [ ] Risky agents kept out of barriers; barriers used only where all results are genuinely needed
+- [ ] Retry (if any) varies the strategy rather than repeating the prompt
+- [ ] Stall monitor armed for anything running unattended
+- [ ] Fallback path reports what was dropped instead of failing silently

--- a/.claude/skills/build/references/subagent-resilience.md
+++ b/.claude/skills/build/references/subagent-resilience.md
@@ -36,6 +36,22 @@ heading. A partial, honest artifact is SUCCESS. Hanging is the only failure.
 Tune the number to the task (15 for a focused edit, 50 for a broad audit). The number matters less
 than the explicit permission to return incomplete work.
 
+**Budget for the return, not just the work.** Writing the artifact and returning the structured
+result are two separate costs, and the return is the one that gets dropped. Say so explicitly:
+
+```
+The moment you write your artifact, STOP — your next action must be returning the result.
+Do no further exploration after the write.
+```
+
+> **Field incident.** An agent given a ~35-call budget used 41, wrote a complete and correct 18 KB
+> artifact, then died before emitting its structured result. The orchestrator saw no return, treated
+> it as a failure, and redid the entire job twice. The work was never the problem; the last turn was.
+
+**Watch which tools drain the budget.** The same agent spent **29 of its 41 calls on `Bash`**. It
+had been told not to `Read` large files and complied — then substituted shell `grep`/`sed` loops,
+which are correct but no cheaper. Name the tools you want it to *use*, not only the ones to avoid.
+
 ### Rule 2 — Never put a risky agent inside a barrier
 
 Barrier (`parallel` / "wait for all to return") is correct only when the next step genuinely needs
@@ -54,32 +70,50 @@ three attempts cost 3× for the same outcome.
 Before retrying, ask: *what will be different this time?* If the answer is "nothing", change the
 approach instead — narrower scope, different tools, split into two agents.
 
-### Rule 4 — Arm a stall monitor, not a status poll
+### Rule 4 — Monitor **progress**, not activity
 
 The harness already notifies on **completion** and **error**. Polling "is it done yet?" is
-redundant and burns tokens. The uncovered case is silence.
+redundant and burns tokens. The uncovered case is silence — so arm a monitor at dispatch time that
+stays quiet while healthy and speaks only on trouble.
 
-Arm a monitor at dispatch time that stays quiet while healthy and speaks only on trouble:
+**The trap: a retry loop is indistinguishable from healthy work if you watch file activity.**
+
+> **Field incident.** A monitor watched "has any agent transcript been written recently?" with a
+> 240s idle threshold. It ran its full 23-minute window and never fired once — while the workflow
+> was stuck retrying the same agent three times. Each retry wrote constantly, so idle time never
+> rose. The heartbeat was perfect and nothing was progressing.
+
+Measure **results landed** and **retries started**, not bytes written:
 
 ```bash
-D=<transcript-dir>          # the workflow/agent transcript directory
-prev=-1; stalled=0
-for i in $(seq 1 70); do
-  n=$(cat "$D"/journal.jsonl 2>/dev/null | wc -l)
-  errs=$(grep -c '"type":"error"' "$D"/journal.jsonl 2>/dev/null || echo 0)
-  newest=$(ls -t "$D"/agent-*.jsonl 2>/dev/null | head -1)
-  idle=$(( $(date +%s) - $(stat -c %Y "$newest") ))
-  [ "$n" != "$prev" ] && { prev=$n; stalled=0; }
-  [ "$errs" -gt 0 ] && [ "$stalled" -ne 2 ] && { echo "ERROR entries: $errs"; stalled=2; }
-  [ "$idle" -gt 240 ] && [ "$stalled" -eq 0 ] && { echo "STALL: no write for ${idle}s"; stalled=1; }
+D=<transcript-dir>
+EXPECTED=<number of agents the workflow defines>
+lastres=-1; since=$(date +%s); warned=0; retrywarn=0
+for i in $(seq 1 90); do
+  res=$(grep -c '"type":"result"' "$D"/journal.jsonl 2>/dev/null || echo 0)
+  errs=$(grep -c '"type":"error"'  "$D"/journal.jsonl 2>/dev/null || echo 0)
+  started=$(ls -1 "$D"/agent-*.jsonl 2>/dev/null | wc -l)
+  now=$(date +%s)
+  [ "$res" != "$lastres" ] && { lastres=$res; since=$now; warned=0; }
+  # no NEW RESULT in 6 min - activity is not progress
+  [ $((now-since)) -gt 360 ] && [ "$warned" -eq 0 ] && \
+    { echo "NO-PROGRESS: ${res}/${EXPECTED} results for $((now-since))s"; warned=1; }
+  # more agents started than the workflow defines => something is failing to return
+  [ "$started" -gt "$EXPECTED" ] && [ "$retrywarn" -eq 0 ] && \
+    { echo "RETRYING: $started started, $EXPECTED expected"; retrywarn=1; }
+  [ "$errs" -gt 0 ] && { echo "ERROR entries: $errs"; exit 0; }
+  [ "$res" -ge "$EXPECTED" ] && { echo "all agents returned ($res/$EXPECTED)"; exit 0; }
   sleep 20
 done
 ```
 
-- **~240s threshold** — long enough that a slow model call or a large grep doesn't cry wolf, short
-  enough that a dead phase surfaces in minutes.
-- **Latch the flag** so one stall episode emits once. A monitor that fires every tick gets
-  auto-stopped for noise, which silently removes your only detector.
+- **Retry detection is the highest-value signal** — `started > EXPECTED` catches a silently
+  looping agent within one cycle, long before any timeout would.
+- **~360s on results** — coarser than an idle threshold, because a single agent legitimately runs
+  for minutes. Progress is the thing with a deadline, not activity.
+- **Latch each flag** so one episode emits once. A monitor that fires every tick gets auto-stopped
+  for noise, which silently removes your only detector.
+- Exit on completion so the monitor doesn't outlive the run.
 - Use an event-driven monitor, **not** a cron/wakeup poll — polling harness-tracked work is waste.
 
 ### Rule 5 — Report what was dropped

--- a/.claude/skills/build/references/subagent-resilience.md
+++ b/.claude/skills/build/references/subagent-resilience.md
@@ -52,6 +52,38 @@ Do no further exploration after the write.
 had been told not to `Read` large files and complied — then substituted shell `grep`/`sed` loops,
 which are correct but no cheaper. Name the tools you want it to *use*, not only the ones to avoid.
 
+### Rule 1b — Generated size is the real budget, and never return the artifact twice
+
+Tool-call counts are a proxy. The thing that actually kills an agent is **how many tokens it must
+generate**, and the return is always last in line.
+
+Two rules follow, and they matter more than the call budget:
+
+**Cap the artifact, or don't use an agent at all.** An agent asked to emit a large document spends
+its whole budget transcribing and dies before returning. Give a concrete size target in the prompt
+("200–300 lines, hard cap 400; terse table rows, not prose").
+
+If the output is a *mechanical* transform of existing text — merging, concatenating, reformatting,
+de-duplicating — **do it with a script, not an agent.** An LLM re-emitting text verbatim is the
+most expensive way to run `cat`, and the volume is exactly what makes it fail.
+
+> **Field incident.** A "merge these two documents" agent had to emit ~40 KB (~12K output tokens)
+> of near-verbatim transcription. It produced a correct, complete document — and then had nothing
+> left to return, so the orchestrator retried the whole job. The task never needed a model.
+
+**Never ask for the artifact back in the return schema.** If the agent writes a table to a file and
+your schema also demands that table as structured output, it emits everything **twice**, and the
+second emission lands at the moment its context is tightest. Have the return be a receipt:
+
+```
+PATH:    <file written>
+COUNTS:  have=<n> partial=<n> missing=<n>
+VERDICT: <2-3 sentences>
+```
+
+Then read the file yourself for detail. A rich schema is a liability on any agent producing a large
+artifact — keep the payload to identifiers, counts, and a verdict.
+
 ### Rule 2 — Never put a risky agent inside a barrier
 
 Barrier (`parallel` / "wait for all to return") is correct only when the next step genuinely needs

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -6,6 +6,11 @@ argument-hint: "[--scope <path>]"
 
 # /quality-gate — Post-Build Quality Review
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 3-phase sequential review run after all build tasks are complete. Each phase has a unique mandate.
 
 ## Scope

--- a/.claude/skills/yolo/SKILL.md
+++ b/.claude/skills/yolo/SKILL.md
@@ -9,6 +9,11 @@ harness: universal
 
 # /yolo — Fully Autonomous Plan → Build → Wrap-Up Loop
 
+> **Dispatching sub-agents?** Read `.agents/skills/build/references/subagent-resilience.md` first. This skill runs unattended, so a hung
+> sub-agent has no human watching it: give every agent a tool-call budget with a "write partial
+> work and stop" escape hatch, arm a stall monitor, and never retry a deterministic failure
+> with an identical prompt.
+
 You-Only-Live-Once mode. The user gives you an idea; you take it from spec through merge with **no user prompts in between**. Modeled after the Ralph Loop pattern: a single prompt drives repeated `plan → build → wrap-up` iterations, with state persisted on disk (not in context) so each phase starts cold and finishes verifiable.
 
 ---


### PR DESCRIPTION
## Problem

A sub-agent that **crashes** returns null and your fallback catches it. One that **hangs** returns nothing at all — no result, no error, no event. Every null-check fallback is downstream of a return that never happens, so none of them fire. Under parallel dispatch, "wait for all to return" is a barrier that then holds the whole phase — including its own fallback — until a human notices.

**Observed in the field.** Three agents dispatched in parallel; two returned in ~5 min, the third hung. The phase sat dead ~20 min. The orchestrator had `.filter(Boolean)` *and* automatic retry — neither fired. The retry also re-ran an identical prompt against a deterministic failure, so all three attempts died identically. The user was the only liveness detector in the system.

**Root cause: conflict with output-compression / compaction layers.** A large tool result is replaced by a placeholder (`[N items compressed … hash=…]`); the agent calls the retrieval tool, retrieval fails (`"Content not found…"`), and it loops until killed. It never errors — it hangs.

This does not hit uniformly. It selects agents doing heavy **text** reads; siblings reading images (not text-compressed) or web results (small) complete normally. So the agent that dies is usually the one doing the most load-bearing work, and the phase looks "mostly fine". In the incident above the code-reading agent burned **17, then 22, then 4** retrieval calls across three attempts and never returned.

## Change

New `.agents/skills/build/references/subagent-resilience.md` (151 lines), wired into the skills that dispatch sub-agents.

**Five rules:**
1. **Tool-call budget with an escape hatch** — the highest-value line you can add to a sub-agent prompt. Converts a hang into a degraded return that existing fallbacks *can* see.
2. **Keep risky agents out of barriers** — barriers only where all results are genuinely needed at once.
3. **Retry must vary the strategy** — an identical prompt against a deterministic failure costs 3× for the same outcome.
4. **Stall monitor, not a status poll** — the harness already notifies on completion and error; the uncovered case is silence. Includes a working latched monitor script (~240s threshold).
5. **Report what was dropped** — a degraded run that reports "done" is indistinguishable from a clean one.

**On compaction layers:** the guidance is explicitly *not* to disable them — they are the user's environment and save real tokens. Instead, never generate a result large enough to trip one. Includes a substitution table (`get_symbols_overview` / `find_symbol` / `smart_outline` / scoped `Grep` / `sed` ranges instead of whole-file `Read`) and verbatim prompt text, since these rules are never inferred.

## Files

- **new** `references/subagent-resilience.md` — the shared doc + dispatch checklist
- `build/SKILL.md` — hardens the parallel-dispatch barrier step; new "Sub-Agent Failure" subsection under Error Handling
- `auto-improve`, `yolo`, `auto-push`, `quality-gate` — unattended-run callout (these have no human watching by definition)
- Mirrored to `.claude/skills/`

## Test plan

- [x] `tests/run.sh` passes — 13 files, including `test-skill-parity.sh` (`.agents/` ↔ `.claude/` byte-identity) and `test-skill-references.sh` (the new `references/` path resolves)
- [x] `diff -rq .agents/skills/build .claude/skills/build` clean
- [x] Docs-only — no executable or hook changes, nothing to run at build time