### PR TITLE
feat(review): compound-engineering Tier 2 — independence accounting, four-axis findings

### DIFF
--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -47,6 +47,34 @@ Every finding MUST be classified with exactly one severity tag:
 - `NITPICK` is ONLY for cosmetic issues with zero logic/behavior impact. If a finding involves logic, architecture, correctness, error handling, or security, it MUST be `SHOULD-FIX` or higher.
 - When in doubt between two levels, choose the higher severity.
 
+**The other three axes:**
+
+Severity alone cannot carry a finding — an urgent finding may be a guess, and a certain
+finding may be cosmetic. Every finding also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on caller behavior you did not read. |
+
+`owner`: `agent` — in this diff's scope. `human` — needs a decision or access you do not
+have. `release` — real but not blocking this branch.
+
+**Evidence gate (hard):** every finding at `conf=75` or `conf=100` MUST carry an
+`evidence:` line quoting the verbatim motivating source line with `file:line`. If you
+cannot quote the line, the finding is `conf=50`. Do not drop it — downgrade it. Never
+invent an evidence line to reach a higher anchor.
+
+Do not promote your own confidence because two of your own lenses agree.
+You are one context, so that is one witness.
+
 **Your Output Format:**
 
 Structure your review as follows:
@@ -60,23 +88,26 @@ Structure your review as follows:
 
 ## Findings
 
-[MUST-FIX] file.py:42 — Description of the issue and its impact
+[MUST-FIX] conf=100 fix=gated_auto owner=agent file.py:42 — Description of the issue and its impact
+  evidence: `except Exception: pass` (file.py:42)
   **Suggestion**: How to fix
 
-[MUST-FIX] file.py:88 — Description of the issue and its impact
+[MUST-FIX] conf=75 fix=manual owner=human file.py:88 — Description of the issue and its impact
+  evidence: `session["role"] = payload["role"]` (file.py:88)
   **Suggestion**: How to fix
 
-[SHOULD-FIX] handler.py:120 — Description of the issue and its impact
+[SHOULD-FIX] conf=75 fix=gated_auto owner=agent handler.py:120 — Description of the issue and its impact
+  evidence: `return cache.get(k) or {}` (handler.py:120)
   **Suggestion**: How to fix
 
-[NITPICK] utils.py:30 — Description of the issue
+[NITPICK] conf=50 fix=advisory owner=release utils.py:30 — Description of the issue
   **Suggestion**: How to fix
 
 ## Recommendations
 1. [Prioritized list of actions to take]
 ```
 
-**Important:** Do NOT use the old section-based format (Critical Issues, Bugs, Performance, etc.). Use the flat `[SEVERITY] file:line — description` format above so findings can be parsed and tracked by the orchestrating agent.
+**Important:** Do NOT use the old section-based format (Critical Issues, Bugs, Performance, etc.). Use the flat `[SEVERITY] conf= fix= owner= file:line — description` format above so findings can be parsed and tracked by the orchestrating agent. Emit all four axes on every finding: the orchestrator's apply gate keys on `autofix_class` and `confidence`, and a finding missing them is degraded to `conf=50` / `fix=manual` and never auto-applied.
 
 **Key Principles:**
 - Be specific - point to exact lines or patterns, not vague concerns

--- a/.agents/agents/critic.md
+++ b/.agents/agents/critic.md
@@ -94,6 +94,47 @@ Before synthesizing, pressure-test your own findings:
 | **MAJOR** | Significant rework needed — design flaw, missing requirement, broken contract | Direct quote from work + codebase reference contradicting it |
 | **MINOR** | Suboptimal but functional — unclear naming, missing edge case test, style inconsistency | Specific example demonstrating the issue |
 
+Your severity labels map onto the orchestrator's enum: **CRITICAL** and **MAJOR** →
+`MUST-FIX`, **MINOR** → `SHOULD-FIX`, or `NITPICK` when purely cosmetic. Emit the
+orchestrator tag alongside your own label so findings parse.
+
+## The Other Three Axes
+
+Severity alone cannot carry a finding — an urgent finding may be a guess, and a certain
+finding may be cosmetic. Every finding also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on behavior you did not read. |
+
+Use the anchors, not `HIGH`/`MEDIUM`/`LOW`. A three-word scale invites feel; the anchors
+are tied to what you actually did.
+
+`owner`: `agent` — in this diff's scope. `human` — needs a decision or access you do not
+have. `release` — real but not blocking this branch.
+
+Gap-analysis and missing-requirement findings are `advisory` or `manual` — a missing AC
+is not something to patch unattended.
+
+**Evidence gate (hard):** every finding at `conf=75` or `conf=100` MUST carry an
+`Evidence:` line quoting the verbatim motivating line with `file:line`. If you cannot
+quote it, the finding is `conf=50`. Downgrade — never drop, and never invent an evidence
+line to reach a higher anchor. This binds your Phase 2 verification duty to the output:
+an unverifiable claim cannot present itself as a certain one.
+
+Your five phases run inside a single context. Phase 3's multiple perspectives are
+perspectives, not witnesses — never promote a finding's confidence because two of your
+own lenses agree.
+You are one context, so that is one witness.
+
 ## Escalation — Adversarial Mode
 
 Activate heightened scrutiny when:
@@ -129,10 +170,9 @@ In adversarial mode:
 ### Findings
 
 #### CRITICAL
-- **[Finding title]**
-  Evidence: [file:line or quote]
+- **[Finding title]** — [MUST-FIX] conf=100 fix=manual owner=agent file.py:42
+  Evidence: `[verbatim source line]` (file.py:42)
   Impact: [what happens if this ships]
-  Confidence: [HIGH/MEDIUM/LOW]
   Fix: [specific actionable remediation]
 
 #### MAJOR

--- a/.agents/agents/security-reviewer.md
+++ b/.agents/agents/security-reviewer.md
@@ -77,6 +77,41 @@ Exclude: lock files, generated files, migrations (unless they contain raw SQL), 
 - Unbounded file uploads or query results
 - Regex patterns vulnerable to catastrophic backtracking (ReDoS)
 
+## The Four Finding Axes
+
+Your CRITICAL / HIGH / MEDIUM labels answer *how urgent*. That is one axis of four, and
+the orchestrator's apply gate keys on two of the others. Every issue also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `severity` | how urgent | `MUST-FIX` (CRITICAL, HIGH) / `SHOULD-FIX` (MEDIUM) / `NITPICK` |
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The vulnerability is demonstrated, or it is visible in the quoted line without inference (e.g. a raw f-string interpolated into SQL). |
+| `75` | A concrete attack input is named and the quoted line plainly permits it, but you did not execute it. |
+| `50` | Pattern-matched, inferred from naming, or dependent on a sanitizer or caller you did not read. |
+
+`owner`: `agent` — in this diff's scope. `human` — needs a decision, a secret rotation,
+or an access you do not have. `release` — real but not blocking this branch.
+
+Auth, crypto, and trust-boundary findings are `manual` or `advisory` by default. Reserve
+`gated_auto` for mechanical fixes with no policy content (a parameterized query
+substituted for an interpolated one). A silent auto-fix to an auth path is worse than a
+reported one, even when correct.
+
+**Evidence gate (hard):** every issue at `conf=75` or `conf=100` MUST carry the
+**Current Code** snippet with its `file:line`. If you cannot quote the line, the issue is
+`conf=50`. Downgrade it — never drop it, and never invent a snippet to reach a higher
+anchor. A speculative CRITICAL at `conf=50` is honest and still gets read; a fabricated
+one at `conf=100` poisons the gate.
+
+Do not promote confidence because two of your checklist categories flag the same line.
+You are one context, so that is one witness.
+
 ## Output Format
 
 ```markdown
@@ -90,6 +125,7 @@ Exclude: lock files, generated files, migrations (unless they contain raw SQL), 
 
 #### [Issue Title]
 - **File**: `path/to/file.py:42`
+- **Axes**: `[MUST-FIX] conf=100 fix=manual owner=agent`
 - **Vulnerability**: [type — e.g., SQL Injection]
 - **Risk**: [What an attacker could do]
 - **Current Code**:

--- a/.agents/agents/software-design-expert-review.md
+++ b/.agents/agents/software-design-expert-review.md
@@ -97,26 +97,67 @@ Every finding MUST use exactly one of these tags. Map the intrinsic APOSD severi
 
 ---
 
+## The Other Three Axes
+
+Severity alone cannot carry a finding — an urgent finding may be a guess, and a certain
+finding may be cosmetic. Every finding also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The red flag is visible in the quoted line without inference (e.g. the pass-through body is right there). |
+| `75` | A concrete structural consequence is named and the quoted line plainly permits it, but you did not trace every caller. |
+| `50` | Pattern-matched, inferred from naming, or dependent on module behavior you did not read. |
+
+`owner`: `agent` — in this diff's scope. `human` — needs a design decision. `release` —
+real but not blocking this branch.
+
+Structural findings skew toward `manual` and `advisory`: a refactor that moves a module
+boundary is rarely safe to apply unattended. Reserve `gated_auto` for mechanical,
+behavior-preserving fixes (a pass-through deleted, a vague local renamed).
+
+**Evidence gate (hard):** every finding at `conf=75` or `conf=100` MUST carry an
+`evidence:` line quoting the verbatim motivating source line with `file:line`. If you
+cannot quote the line, the finding is `conf=50`. Downgrade it — never drop it, and never
+invent an evidence line to reach a higher anchor.
+
+Do not promote your own confidence because two of your own red flags point the same way.
+You are one context, so that is one witness.
+
+---
+
 ## Output Format
 
 Structure your review as a flat list — no top-level narrative sections wrapping the findings. The orchestrator parses these lines directly.
 
 ```
-[MUST-FIX] file.py:42 — R8 Unknown Unknowns: Hidden side effect mutates shared cache between requests. Impact: race conditions under concurrent load.
+[MUST-FIX] conf=100 fix=manual owner=agent file.py:42 — R8 Unknown Unknowns: Hidden side effect mutates shared cache between requests. Impact: race conditions under concurrent load.
+  evidence: `self._cache[key].append(row)` (file.py:42)
   **Suggestion**: Return a new object instead of mutating shared state, or use an immutable cache layer.
 
-[SHOULD-FIX] handler.py:120 — R1 Repetition: Same retry-with-backoff pattern appears in 4 handler methods. Impact: fixing a bug in one copy leaves 3 others broken.
+[SHOULD-FIX] conf=75 fix=manual owner=agent handler.py:120 — R1 Repetition: Same retry-with-backoff pattern appears in 4 handler methods. Impact: fixing a bug in one copy leaves 3 others broken.
+  evidence: `for attempt in range(3): time.sleep(2 ** attempt)` (handler.py:120)
   **Suggestion**: Extract `with_retry()` decorator or context manager.
 
-[SHOULD-FIX] models.py:88 — R11 Errors Not Defined Away: `User.parse_email()` raises `InvalidEmailError` on malformed input. Impact: every caller must handle this; better to accept only `EmailAddress` type at construction.
+[SHOULD-FIX] conf=75 fix=advisory owner=human models.py:88 — R11 Errors Not Defined Away: `User.parse_email()` raises `InvalidEmailError` on malformed input. Impact: every caller must handle this; better to accept only `EmailAddress` type at construction.
+  evidence: `raise InvalidEmailError(raw)` (models.py:88)
   **Suggestion**: Introduce `EmailAddress` value object with validated constructor; eliminate the error path entirely.
 
-[NITPICK] utils.py:30 — R4 Vague Names: Variable `tmp` should encode type + intent.
+[NITPICK] conf=50 fix=advisory owner=release utils.py:30 — R4 Vague Names: Variable `tmp` should encode type + intent.
   **Suggestion**: Rename to `embedding_batch` or `parsed_text_content`.
 ```
 
 **Rules:**
 - One finding per block. Start with the tag on its own line.
+- Emit all four axes on every finding. The orchestrator's apply gate keys on
+  `autofix_class` and `confidence`; a finding missing them is degraded to `conf=50` /
+  `fix=manual` and never auto-applied.
+- Carry an `evidence:` line on every finding at `conf=75` or above.
 - Include the red flag ID (R1–R11) in the description so the symbol is machine-parseable.
 - Include **impact** — what will happen when the codebase grows.
 - Include a **concrete** suggestion, not vague advice.

--- a/.agents/skills/auto-push/SKILL.md
+++ b/.agents/skills/auto-push/SKILL.md
@@ -127,7 +127,7 @@ Invoke `/wrap-up-session` with these overrides:
 | `/wrap-up-session` step | Auto-push override |
 |---|---|
 | Step 6.3 — E2E coverage gate | If a user-facing AC lacks an e2e walkthrough, **do not prompt the user**. Run `/verify --scope e2e` automatically. The approval covered "ship it"; e2e verification is part of shipping. |
-| Step 7 — Commit gate (MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed, STOP and report. Do NOT push partial work. The approval did not cover skipping safety gates. |
+| Step 7 — Commit gate (MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed, STOP and report. Do NOT push partial work. The approval did not cover skipping safety gates. A `MUST-FIX` at `conf 50` that failed the apply gate is reported, not blocking (per `/wrap-up-session` § 5.1). |
 | Step 7 — Push | Run normally. Push to the feature branch. |
 | Step 8 — Deployment verification | Run normally if configured. |
 

--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -23,6 +23,54 @@ Skip: generated files, lock files, migration files, test fixtures.
 
 ---
 
+## Finding Model (four axes)
+
+Every finding in every phase carries four orthogonal fields. One axis cannot answer
+another's question: an urgent finding may be a guess, and a certain finding may be
+cosmetic. Collapsing them hides which is which.
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `severity` | how urgent | `MUST-FIX` / `SHOULD-FIX` / `NITPICK` |
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+**Confidence anchors** — pick by the behavioral criterion, never by feel:
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on caller behavior that was not read. |
+
+**`owner` values**: `agent` — in this diff's scope, an agent applies it. `human` —
+needs a decision or an access an agent does not have. `release` — real but not
+blocking this branch.
+
+**Evidence gate**: anchors `75` and `100` require `evidence` — the verbatim motivating
+line with `file:line`. A finding at 75+ with no evidence is **demoted to 50**, never
+discarded.
+
+**Apply gate**: auto-apply a finding only when `autofix_class: gated_auto` **and**
+`confidence >= 75`. Everything else is reported, not applied.
+
+**On disagreement** between reviewers, synthesis takes the **more conservative**
+`autofix_class` — `advisory` is more conservative than `manual`, which is more
+conservative than `gated_auto`. Synthesis never widens.
+
+**Old-format degrade**: a finding arriving with no `confidence` is handled as anchor
+`50` / `autofix_class: manual` — reported, never auto-applied and never discarded.
+
+Per-finding output format:
+
+```
+[MUST-FIX] conf=100 fix=gated_auto owner=agent handler.py:120 — Description and impact
+  evidence: `except Exception: pass` (handler.py:120)
+```
+
+---
+
 ## Phase 1 — Structural Quality (simplify)
 
 **Mandate**: "Is this code structurally sound?" — function size, naming, reuse, SOLID.
@@ -105,7 +153,7 @@ try { doThing(); } catch (e) { throw e; }  // passthrough
 ```
 → Remove entirely.
 
-**Process**: Scan → list findings → apply deletions → run tests per file. Revert if tests fail.
+**Process**: Scan → list findings → apply deletions that clear the apply gate → run tests per file. Revert if tests fail.
 
 ---
 
@@ -125,11 +173,30 @@ Read all changed files together. For each module, check:
 6. **Vague names**: Any public name that requires reading the body to understand? → flag
 7. **Conjoined methods**: Methods so coupled you can't use one without the other? → flag
 
-Report findings as `file:line [MUST-FIX/SHOULD-FIX/NITPICK] — description`. Apply MUST-FIX and SHOULD-FIX fixes inline. Run tests after fixes.
+Report every finding in the four-axis format above. Apply only findings that clear the
+apply gate; report the rest. Run tests after fixes.
+
+### Independence disclosure (required)
+
+Phase 3 must state in its output which mode it ran in, because the two are otherwise
+indistinguishable downstream:
+
+- **Dispatched** — the design review ran as a separately dispatched agent. Its
+  agreement with a Phase 1 or Phase 2 finding is independent corroboration and
+  promotes `confidence` by exactly one anchor.
+- **Inline** — the checks above ran in this context. Agreement with Phase 1 or Phase 2
+  is same-context agreement and **never** promotes. Name the corroboration that was
+  unavailable.
+
+Per `CLAUDE.md` § *Independence Accounting*. Inline is the correct floor, not a failure.
 
 ## Claude Code Enhancements
 
-Dispatch the `software-design-expert-review` skill (invokes `software-design-expert-review` agent, model: sonnet) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply MUST-FIX and SHOULD-FIX findings in the main context after the agent returns. Run tests after applying fixes.
+Dispatch the `software-design-expert-review` skill (invokes the
+`software-design-expert-review` agent, model: sonnet) instead of running inline Phase 3.
+The agent is read-only — it reports findings only. In the main context, apply the
+returned findings that clear the apply gate and report the rest. Run tests after
+applying fixes. This is the **dispatched** mode for the disclosure above.
 
 ---
 
@@ -141,16 +208,22 @@ Dispatch the `software-design-expert-review` skill (invokes `software-design-exp
 ══════════════════════════════════════════
 
 Phase 1 — Structural Quality
-  Applied: [N changes — list with file:line]
+  Applied: [N changes — list with file:line, conf, fix, owner]
+  Reported only: [N findings below the apply gate — list with the axis that held them]
   Tests: [PASS / FAIL — N reverted]
 
 Phase 2 — AI Anti-Patterns
   Removed: [N lines — list with file:line and category]
+  Reported only: [N findings below the apply gate]
   Tests: [PASS / FAIL — N reverted]
 
 Phase 3 — APOSD Design (/software-design-expert-review)
+  Mode: DISPATCHED / INLINE — [when inline: corroboration unavailable, no promotion]
   Verdict: 🟢 GO / 🟡 HOLD (N refactors applied) / 🔴 STOP
+  Reported only: [N findings below the apply gate]
   Tests: [PASS / FAIL]
+
+Demoted: [N findings at 75+ with no file:line evidence → anchor 50]
 
 ══════════════════════════════════════════
 ```

--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -121,9 +121,19 @@ blocks the commit, and shortcuts are not bugs, so they do not go in
 Run 4 sequential self-review passes in the main context. For each pass:
 - Use `git diff --name-only <base-branch>...HEAD` to scope to changed files
 - Focus on issues **introduced** by this session, not pre-existing patterns
-- Classify every finding with exactly one severity tag: `MUST-FIX`, `SHOULD-FIX`, or `NITPICK`
+- Classify every finding on all four axes below
 
-### Severity Classification
+### Finding Model (four axes)
+
+Every finding carries four orthogonal fields. One axis cannot answer another's
+question: an urgent finding may be a guess, and a certain finding may be cosmetic.
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `severity` | how urgent | `MUST-FIX` / `SHOULD-FIX` / `NITPICK` |
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
 
 | Severity | Definition |
 |----------|-----------|
@@ -133,12 +143,47 @@ Run 4 sequential self-review passes in the main context. For each pass:
 
 `NITPICK` is ONLY for cosmetic issues. Any logic, architecture, or security finding is `SHOULD-FIX` or higher.
 
+**Confidence anchors** — pick by the behavioral criterion, never by feel:
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on caller behavior that was not read. |
+
+**`owner` values**: `agent` — in this diff's scope, an agent applies it. `human` —
+needs a decision or an access an agent does not have. `release` — real but not
+blocking this branch.
+
+**Evidence gate**: anchors `75` and `100` require `evidence` — the verbatim motivating
+line with `file:line`. A finding at 75+ with no evidence is **demoted to 50**, never
+discarded.
+
+**Old-format degrade**: a finding arriving with no `confidence` is handled as anchor
+`50` / `autofix_class: manual` — reported, never auto-applied and never discarded.
+
 **Output format for each finding**:
 ```
-[MUST-FIX] file.py:42 — Description and impact
-[SHOULD-FIX] handler.py:120 — Description and impact
-[NITPICK] utils.py:30 — Description
+[MUST-FIX] conf=100 fix=gated_auto owner=agent file.py:42 — Description and impact
+  evidence: `except Exception: pass` (file.py:42)
+[SHOULD-FIX] conf=75 fix=manual owner=agent handler.py:120 — Description and impact
+  evidence: `return cache.get(k) or {}` (handler.py:120)
+[NITPICK] conf=50 fix=advisory owner=release utils.py:30 — Description
 ```
+
+### Independence disclosure (required)
+
+State in the Step 4 output which mode the four passes ran in — inline and dispatched
+runs are otherwise indistinguishable downstream:
+
+- **Dispatched** — each pass ran as a separately dispatched agent (see § *Claude Code
+  Enhancements*). Two passes agreeing is independent corroboration and promotes
+  `confidence` by exactly one anchor.
+- **Inline** — the four passes ran sequentially in this context. Two passes agreeing is
+  same-context agreement and **never** promotes, however many passes agree. Name the
+  corroboration that was unavailable.
+
+Per `CLAUDE.md` § *Independence Accounting*. Inline is the correct floor, not a failure.
 
 ### Pass 1: Codebase Consistency
 - Duplicated logic that already exists elsewhere in the codebase
@@ -166,13 +211,29 @@ Run 4 sequential self-review passes in the main context. For each pass:
 
 ## Step 5 — Reconcile & Apply Fixes
 
-### 5.1 — Severity-Based Enforcement
+### 5.1 — Enforcement (keyed on severity × apply gate)
 
-| Severity | Action |
-|----------|--------|
-| `MUST-FIX` | Apply immediately. Cannot be skipped. |
-| `SHOULD-FIX` | Apply by default. May skip ≤3 total with code-specific justification. |
-| `NITPICK` | Auto-skip. |
+**Apply gate**: auto-apply a finding only when `autofix_class: gated_auto` **and**
+`confidence >= 75`. A finding that fails the gate is reported, not applied — including
+a `MUST-FIX`. Severity says how much it matters; the gate says whether an agent is
+entitled to change code unattended. They are different questions.
+
+| Severity | Clears the apply gate | Fails the apply gate |
+|----------|----------------------|----------------------|
+| `MUST-FIX` | Apply immediately. Cannot be skipped. | At `conf >= 75`: **blocking** — do not push, escalate to `owner`. At `conf 50`: report only, does not block. |
+| `SHOULD-FIX` | Apply by default. May skip ≤3 total with code-specific justification. | Report. Does not block the push. |
+| `NITPICK` | Auto-skip. | Auto-skip. |
+
+A `MUST-FIX` at `conf 50` is a suspicion, not a defect — blocking a push on it would
+stall an unattended loop on noise. A `MUST-FIX` at `conf >= 75` that an agent is not
+entitled to auto-fix is exactly the case a human must see, so it blocks.
+
+**On disagreement** between passes, synthesis takes the **more conservative**
+`autofix_class` — `advisory` is more conservative than `manual`, which is more
+conservative than `gated_auto`. Synthesis never widens.
+
+Same-context agreement between passes never promotes `confidence` (§ *Independence
+disclosure* in Step 4).
 
 ### 5.2 — Review Reconciliation Table
 
@@ -181,8 +242,10 @@ After processing all findings (skip if total findings ≤ 3):
 ```markdown
 ### Review Reconciliation
 
-| # | Pass | Severity | Finding | Action | Justification |
-|---|------|----------|---------|--------|---------------|
+Review mode: DISPATCHED / INLINE — [when inline: corroboration unavailable, no promotion]
+
+| # | Pass | Severity | Conf | Fix | Owner | Finding | Action | Justification |
+|---|------|----------|------|-----|-------|---------|--------|---------------|
 ```
 
 ### 5.3 — Review-Fix-Recheck Loop (max 2 iterations)
@@ -312,10 +375,12 @@ Session wrapped up.
 - Learnings: [N patterns / none]
 - Tasks: [X completed, Y pending]
 - Bugs: [N opened, N closed / no changes]
-- Code Review: [PASS / INCOMPLETE — N unresolved issues]
-  - MUST-FIX: [N found, N fixed]
+- Code Review: [PASS / INCOMPLETE — N unresolved issues] — mode: [DISPATCHED / INLINE]
+  - MUST-FIX: [N found, N fixed, N reported below the apply gate]
   - SHOULD-FIX: [N found, N fixed, N skipped]
   - NITPICK: [N found, skipped]
+  - Demoted: [N at 75+ with no file:line evidence → anchor 50]
+  - Promotions: [N on independent corroboration / none — inline run]
 - Security Scan: [PASS / N issues addressed]
 - Tests: [PASS — suite name] or [FAIL] or [SKIPPED — no suite]
 - E2E coverage: [N user-facing ACs verified / NONE / GAP — N acknowledged]
@@ -327,7 +392,11 @@ Session wrapped up.
 
 ### Step 4 — Parallel Code Review
 Launch all 4 review passes as parallel agents in a SINGLE message with multiple Agent tool calls.
-Each agent uses model: sonnet.
+`code-reviewer` and `critic` are **ceiling**-tier: pass no `model` override, so they
+inherit the session model (`CLAUDE.md` § *Model Routing*).
+
+This is the **dispatched** mode for the Step 4 independence disclosure: four separately
+dispatched contexts, so agreement between them is independent corroboration.
 
 Agent assignments:
 - Agent 1: `code-reviewer` — Codebase Consistency (Pass 1)

--- a/.agents/skills/yolo/SKILL.md
+++ b/.agents/skills/yolo/SKILL.md
@@ -164,7 +164,7 @@ Invoke `/wrap-up-session` with one override:
 | `/wrap-up-session` step | Yolo override |
 |---|---|
 | Step 6.3 — E2E coverage gate | If a user-facing AC lacks an e2e walkthrough, **do not prompt the user**. Run `/verify --scope e2e` automatically. If verify fails: log gap and continue. |
-| Step 7 — Commit gate (any MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed within the wrap-up loop, mark this iteration FAIL and **do not push**. The circuit breaker handles repeated failures. |
+| Step 7 — Commit gate (any MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed within the wrap-up loop, mark this iteration FAIL and **do not push**. The circuit breaker handles repeated failures. A `MUST-FIX` at `conf 50` that failed the apply gate is reported, not blocking (per `/wrap-up-session` § 5.1) — log it and continue rather than burning an iteration on a suspicion. |
 | Step 7 — Push | Run normally. Push to the feature branch. |
 | Step 8 — Deployment verification | Run normally if configured. |
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -47,6 +47,34 @@ Every finding MUST be classified with exactly one severity tag:
 - `NITPICK` is ONLY for cosmetic issues with zero logic/behavior impact. If a finding involves logic, architecture, correctness, error handling, or security, it MUST be `SHOULD-FIX` or higher.
 - When in doubt between two levels, choose the higher severity.
 
+**The other three axes:**
+
+Severity alone cannot carry a finding — an urgent finding may be a guess, and a certain
+finding may be cosmetic. Every finding also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on caller behavior you did not read. |
+
+`owner`: `agent` — in this diff's scope. `human` — needs a decision or access you do not
+have. `release` — real but not blocking this branch.
+
+**Evidence gate (hard):** every finding at `conf=75` or `conf=100` MUST carry an
+`evidence:` line quoting the verbatim motivating source line with `file:line`. If you
+cannot quote the line, the finding is `conf=50`. Do not drop it — downgrade it. Never
+invent an evidence line to reach a higher anchor.
+
+Do not promote your own confidence because two of your own lenses agree.
+You are one context, so that is one witness.
+
 **Your Output Format:**
 
 Structure your review as follows:
@@ -60,23 +88,26 @@ Structure your review as follows:
 
 ## Findings
 
-[MUST-FIX] file.py:42 — Description of the issue and its impact
+[MUST-FIX] conf=100 fix=gated_auto owner=agent file.py:42 — Description of the issue and its impact
+  evidence: `except Exception: pass` (file.py:42)
   **Suggestion**: How to fix
 
-[MUST-FIX] file.py:88 — Description of the issue and its impact
+[MUST-FIX] conf=75 fix=manual owner=human file.py:88 — Description of the issue and its impact
+  evidence: `session["role"] = payload["role"]` (file.py:88)
   **Suggestion**: How to fix
 
-[SHOULD-FIX] handler.py:120 — Description of the issue and its impact
+[SHOULD-FIX] conf=75 fix=gated_auto owner=agent handler.py:120 — Description of the issue and its impact
+  evidence: `return cache.get(k) or {}` (handler.py:120)
   **Suggestion**: How to fix
 
-[NITPICK] utils.py:30 — Description of the issue
+[NITPICK] conf=50 fix=advisory owner=release utils.py:30 — Description of the issue
   **Suggestion**: How to fix
 
 ## Recommendations
 1. [Prioritized list of actions to take]
 ```
 
-**Important:** Do NOT use the old section-based format (Critical Issues, Bugs, Performance, etc.). Use the flat `[SEVERITY] file:line — description` format above so findings can be parsed and tracked by the orchestrating agent.
+**Important:** Do NOT use the old section-based format (Critical Issues, Bugs, Performance, etc.). Use the flat `[SEVERITY] conf= fix= owner= file:line — description` format above so findings can be parsed and tracked by the orchestrating agent. Emit all four axes on every finding: the orchestrator's apply gate keys on `autofix_class` and `confidence`, and a finding missing them is degraded to `conf=50` / `fix=manual` and never auto-applied.
 
 **Key Principles:**
 - Be specific - point to exact lines or patterns, not vague concerns

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -94,6 +94,47 @@ Before synthesizing, pressure-test your own findings:
 | **MAJOR** | Significant rework needed — design flaw, missing requirement, broken contract | Direct quote from work + codebase reference contradicting it |
 | **MINOR** | Suboptimal but functional — unclear naming, missing edge case test, style inconsistency | Specific example demonstrating the issue |
 
+Your severity labels map onto the orchestrator's enum: **CRITICAL** and **MAJOR** →
+`MUST-FIX`, **MINOR** → `SHOULD-FIX`, or `NITPICK` when purely cosmetic. Emit the
+orchestrator tag alongside your own label so findings parse.
+
+## The Other Three Axes
+
+Severity alone cannot carry a finding — an urgent finding may be a guess, and a certain
+finding may be cosmetic. Every finding also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on behavior you did not read. |
+
+Use the anchors, not `HIGH`/`MEDIUM`/`LOW`. A three-word scale invites feel; the anchors
+are tied to what you actually did.
+
+`owner`: `agent` — in this diff's scope. `human` — needs a decision or access you do not
+have. `release` — real but not blocking this branch.
+
+Gap-analysis and missing-requirement findings are `advisory` or `manual` — a missing AC
+is not something to patch unattended.
+
+**Evidence gate (hard):** every finding at `conf=75` or `conf=100` MUST carry an
+`Evidence:` line quoting the verbatim motivating line with `file:line`. If you cannot
+quote it, the finding is `conf=50`. Downgrade — never drop, and never invent an evidence
+line to reach a higher anchor. This binds your Phase 2 verification duty to the output:
+an unverifiable claim cannot present itself as a certain one.
+
+Your five phases run inside a single context. Phase 3's multiple perspectives are
+perspectives, not witnesses — never promote a finding's confidence because two of your
+own lenses agree.
+You are one context, so that is one witness.
+
 ## Escalation — Adversarial Mode
 
 Activate heightened scrutiny when:
@@ -129,10 +170,9 @@ In adversarial mode:
 ### Findings
 
 #### CRITICAL
-- **[Finding title]**
-  Evidence: [file:line or quote]
+- **[Finding title]** — [MUST-FIX] conf=100 fix=manual owner=agent file.py:42
+  Evidence: `[verbatim source line]` (file.py:42)
   Impact: [what happens if this ships]
-  Confidence: [HIGH/MEDIUM/LOW]
   Fix: [specific actionable remediation]
 
 #### MAJOR

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -77,6 +77,41 @@ Exclude: lock files, generated files, migrations (unless they contain raw SQL), 
 - Unbounded file uploads or query results
 - Regex patterns vulnerable to catastrophic backtracking (ReDoS)
 
+## The Four Finding Axes
+
+Your CRITICAL / HIGH / MEDIUM labels answer *how urgent*. That is one axis of four, and
+the orchestrator's apply gate keys on two of the others. Every issue also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `severity` | how urgent | `MUST-FIX` (CRITICAL, HIGH) / `SHOULD-FIX` (MEDIUM) / `NITPICK` |
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The vulnerability is demonstrated, or it is visible in the quoted line without inference (e.g. a raw f-string interpolated into SQL). |
+| `75` | A concrete attack input is named and the quoted line plainly permits it, but you did not execute it. |
+| `50` | Pattern-matched, inferred from naming, or dependent on a sanitizer or caller you did not read. |
+
+`owner`: `agent` — in this diff's scope. `human` — needs a decision, a secret rotation,
+or an access you do not have. `release` — real but not blocking this branch.
+
+Auth, crypto, and trust-boundary findings are `manual` or `advisory` by default. Reserve
+`gated_auto` for mechanical fixes with no policy content (a parameterized query
+substituted for an interpolated one). A silent auto-fix to an auth path is worse than a
+reported one, even when correct.
+
+**Evidence gate (hard):** every issue at `conf=75` or `conf=100` MUST carry the
+**Current Code** snippet with its `file:line`. If you cannot quote the line, the issue is
+`conf=50`. Downgrade it — never drop it, and never invent a snippet to reach a higher
+anchor. A speculative CRITICAL at `conf=50` is honest and still gets read; a fabricated
+one at `conf=100` poisons the gate.
+
+Do not promote confidence because two of your checklist categories flag the same line.
+You are one context, so that is one witness.
+
 ## Output Format
 
 ```markdown
@@ -90,6 +125,7 @@ Exclude: lock files, generated files, migrations (unless they contain raw SQL), 
 
 #### [Issue Title]
 - **File**: `path/to/file.py:42`
+- **Axes**: `[MUST-FIX] conf=100 fix=manual owner=agent`
 - **Vulnerability**: [type — e.g., SQL Injection]
 - **Risk**: [What an attacker could do]
 - **Current Code**:

--- a/.claude/agents/software-design-expert-review.md
+++ b/.claude/agents/software-design-expert-review.md
@@ -98,26 +98,67 @@ Every finding MUST use exactly one of these tags. Map the intrinsic APOSD severi
 
 ---
 
+## The Other Three Axes
+
+Severity alone cannot carry a finding — an urgent finding may be a guess, and a certain
+finding may be cosmetic. Every finding also carries:
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The red flag is visible in the quoted line without inference (e.g. the pass-through body is right there). |
+| `75` | A concrete structural consequence is named and the quoted line plainly permits it, but you did not trace every caller. |
+| `50` | Pattern-matched, inferred from naming, or dependent on module behavior you did not read. |
+
+`owner`: `agent` — in this diff's scope. `human` — needs a design decision. `release` —
+real but not blocking this branch.
+
+Structural findings skew toward `manual` and `advisory`: a refactor that moves a module
+boundary is rarely safe to apply unattended. Reserve `gated_auto` for mechanical,
+behavior-preserving fixes (a pass-through deleted, a vague local renamed).
+
+**Evidence gate (hard):** every finding at `conf=75` or `conf=100` MUST carry an
+`evidence:` line quoting the verbatim motivating source line with `file:line`. If you
+cannot quote the line, the finding is `conf=50`. Downgrade it — never drop it, and never
+invent an evidence line to reach a higher anchor.
+
+Do not promote your own confidence because two of your own red flags point the same way.
+You are one context, so that is one witness.
+
+---
+
 ## Output Format
 
 Structure your review as a flat list — no top-level narrative sections wrapping the findings. The orchestrator parses these lines directly.
 
 ```
-[MUST-FIX] file.py:42 — R8 Unknown Unknowns: Hidden side effect mutates shared cache between requests. Impact: race conditions under concurrent load.
+[MUST-FIX] conf=100 fix=manual owner=agent file.py:42 — R8 Unknown Unknowns: Hidden side effect mutates shared cache between requests. Impact: race conditions under concurrent load.
+  evidence: `self._cache[key].append(row)` (file.py:42)
   **Suggestion**: Return a new object instead of mutating shared state, or use an immutable cache layer.
 
-[SHOULD-FIX] handler.py:120 — R1 Repetition: Same retry-with-backoff pattern appears in 4 handler methods. Impact: fixing a bug in one copy leaves 3 others broken.
+[SHOULD-FIX] conf=75 fix=manual owner=agent handler.py:120 — R1 Repetition: Same retry-with-backoff pattern appears in 4 handler methods. Impact: fixing a bug in one copy leaves 3 others broken.
+  evidence: `for attempt in range(3): time.sleep(2 ** attempt)` (handler.py:120)
   **Suggestion**: Extract `with_retry()` decorator or context manager.
 
-[SHOULD-FIX] models.py:88 — R11 Errors Not Defined Away: `User.parse_email()` raises `InvalidEmailError` on malformed input. Impact: every caller must handle this; better to accept only `EmailAddress` type at construction.
+[SHOULD-FIX] conf=75 fix=advisory owner=human models.py:88 — R11 Errors Not Defined Away: `User.parse_email()` raises `InvalidEmailError` on malformed input. Impact: every caller must handle this; better to accept only `EmailAddress` type at construction.
+  evidence: `raise InvalidEmailError(raw)` (models.py:88)
   **Suggestion**: Introduce `EmailAddress` value object with validated constructor; eliminate the error path entirely.
 
-[NITPICK] utils.py:30 — R4 Vague Names: Variable `tmp` should encode type + intent.
+[NITPICK] conf=50 fix=advisory owner=release utils.py:30 — R4 Vague Names: Variable `tmp` should encode type + intent.
   **Suggestion**: Rename to `embedding_batch` or `parsed_text_content`.
 ```
 
 **Rules:**
 - One finding per block. Start with the tag on its own line.
+- Emit all four axes on every finding. The orchestrator's apply gate keys on
+  `autofix_class` and `confidence`; a finding missing them is degraded to `conf=50` /
+  `fix=manual` and never auto-applied.
+- Carry an `evidence:` line on every finding at `conf=75` or above.
 - Include the red flag ID (R1–R11) in the description so the symbol is machine-parseable.
 - Include **impact** — what will happen when the codebase grows.
 - Include a **concrete** suggestion, not vague advice.

--- a/.claude/skills/auto-push/SKILL.md
+++ b/.claude/skills/auto-push/SKILL.md
@@ -127,7 +127,7 @@ Invoke `/wrap-up-session` with these overrides:
 | `/wrap-up-session` step | Auto-push override |
 |---|---|
 | Step 6.3 — E2E coverage gate | If a user-facing AC lacks an e2e walkthrough, **do not prompt the user**. Run `/verify --scope e2e` automatically. The approval covered "ship it"; e2e verification is part of shipping. |
-| Step 7 — Commit gate (MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed, STOP and report. Do NOT push partial work. The approval did not cover skipping safety gates. |
+| Step 7 — Commit gate (MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed, STOP and report. Do NOT push partial work. The approval did not cover skipping safety gates. A `MUST-FIX` at `conf 50` that failed the apply gate is reported, not blocking (per `/wrap-up-session` § 5.1). |
 | Step 7 — Push | Run normally. Push to the feature branch. |
 | Step 8 — Deployment verification | Run normally if configured. |
 

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -23,6 +23,54 @@ Skip: generated files, lock files, migration files, test fixtures.
 
 ---
 
+## Finding Model (four axes)
+
+Every finding in every phase carries four orthogonal fields. One axis cannot answer
+another's question: an urgent finding may be a guess, and a certain finding may be
+cosmetic. Collapsing them hides which is which.
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `severity` | how urgent | `MUST-FIX` / `SHOULD-FIX` / `NITPICK` |
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
+
+**Confidence anchors** — pick by the behavioral criterion, never by feel:
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on caller behavior that was not read. |
+
+**`owner` values**: `agent` — in this diff's scope, an agent applies it. `human` —
+needs a decision or an access an agent does not have. `release` — real but not
+blocking this branch.
+
+**Evidence gate**: anchors `75` and `100` require `evidence` — the verbatim motivating
+line with `file:line`. A finding at 75+ with no evidence is **demoted to 50**, never
+discarded.
+
+**Apply gate**: auto-apply a finding only when `autofix_class: gated_auto` **and**
+`confidence >= 75`. Everything else is reported, not applied.
+
+**On disagreement** between reviewers, synthesis takes the **more conservative**
+`autofix_class` — `advisory` is more conservative than `manual`, which is more
+conservative than `gated_auto`. Synthesis never widens.
+
+**Old-format degrade**: a finding arriving with no `confidence` is handled as anchor
+`50` / `autofix_class: manual` — reported, never auto-applied and never discarded.
+
+Per-finding output format:
+
+```
+[MUST-FIX] conf=100 fix=gated_auto owner=agent handler.py:120 — Description and impact
+  evidence: `except Exception: pass` (handler.py:120)
+```
+
+---
+
 ## Phase 1 — Structural Quality (simplify)
 
 **Mandate**: "Is this code structurally sound?" — function size, naming, reuse, SOLID.
@@ -105,7 +153,7 @@ try { doThing(); } catch (e) { throw e; }  // passthrough
 ```
 → Remove entirely.
 
-**Process**: Scan → list findings → apply deletions → run tests per file. Revert if tests fail.
+**Process**: Scan → list findings → apply deletions that clear the apply gate → run tests per file. Revert if tests fail.
 
 ---
 
@@ -125,11 +173,30 @@ Read all changed files together. For each module, check:
 6. **Vague names**: Any public name that requires reading the body to understand? → flag
 7. **Conjoined methods**: Methods so coupled you can't use one without the other? → flag
 
-Report findings as `file:line [MUST-FIX/SHOULD-FIX/NITPICK] — description`. Apply MUST-FIX and SHOULD-FIX fixes inline. Run tests after fixes.
+Report every finding in the four-axis format above. Apply only findings that clear the
+apply gate; report the rest. Run tests after fixes.
+
+### Independence disclosure (required)
+
+Phase 3 must state in its output which mode it ran in, because the two are otherwise
+indistinguishable downstream:
+
+- **Dispatched** — the design review ran as a separately dispatched agent. Its
+  agreement with a Phase 1 or Phase 2 finding is independent corroboration and
+  promotes `confidence` by exactly one anchor.
+- **Inline** — the checks above ran in this context. Agreement with Phase 1 or Phase 2
+  is same-context agreement and **never** promotes. Name the corroboration that was
+  unavailable.
+
+Per `CLAUDE.md` § *Independence Accounting*. Inline is the correct floor, not a failure.
 
 ## Claude Code Enhancements
 
-Dispatch the `software-design-expert-review` skill (invokes `software-design-expert-review` agent, model: sonnet) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply MUST-FIX and SHOULD-FIX findings in the main context after the agent returns. Run tests after applying fixes.
+Dispatch the `software-design-expert-review` skill (invokes the
+`software-design-expert-review` agent, model: sonnet) instead of running inline Phase 3.
+The agent is read-only — it reports findings only. In the main context, apply the
+returned findings that clear the apply gate and report the rest. Run tests after
+applying fixes. This is the **dispatched** mode for the disclosure above.
 
 ---
 
@@ -141,16 +208,22 @@ Dispatch the `software-design-expert-review` skill (invokes `software-design-exp
 ══════════════════════════════════════════
 
 Phase 1 — Structural Quality
-  Applied: [N changes — list with file:line]
+  Applied: [N changes — list with file:line, conf, fix, owner]
+  Reported only: [N findings below the apply gate — list with the axis that held them]
   Tests: [PASS / FAIL — N reverted]
 
 Phase 2 — AI Anti-Patterns
   Removed: [N lines — list with file:line and category]
+  Reported only: [N findings below the apply gate]
   Tests: [PASS / FAIL — N reverted]
 
 Phase 3 — APOSD Design (/software-design-expert-review)
+  Mode: DISPATCHED / INLINE — [when inline: corroboration unavailable, no promotion]
   Verdict: 🟢 GO / 🟡 HOLD (N refactors applied) / 🔴 STOP
+  Reported only: [N findings below the apply gate]
   Tests: [PASS / FAIL]
+
+Demoted: [N findings at 75+ with no file:line evidence → anchor 50]
 
 ══════════════════════════════════════════
 ```

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -121,9 +121,19 @@ blocks the commit, and shortcuts are not bugs, so they do not go in
 Run 4 sequential self-review passes in the main context. For each pass:
 - Use `git diff --name-only <base-branch>...HEAD` to scope to changed files
 - Focus on issues **introduced** by this session, not pre-existing patterns
-- Classify every finding with exactly one severity tag: `MUST-FIX`, `SHOULD-FIX`, or `NITPICK`
+- Classify every finding on all four axes below
 
-### Severity Classification
+### Finding Model (four axes)
+
+Every finding carries four orthogonal fields. One axis cannot answer another's
+question: an urgent finding may be a guess, and a certain finding may be cosmetic.
+
+| Field | Answers | Values |
+|-------|---------|--------|
+| `severity` | how urgent | `MUST-FIX` / `SHOULD-FIX` / `NITPICK` |
+| `confidence` | how sure | `50` / `75` / `100` |
+| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
+| `owner` | who acts | `agent` / `human` / `release` |
 
 | Severity | Definition |
 |----------|-----------|
@@ -133,12 +143,47 @@ Run 4 sequential self-review passes in the main context. For each pass:
 
 `NITPICK` is ONLY for cosmetic issues. Any logic, architecture, or security finding is `SHOULD-FIX` or higher.
 
+**Confidence anchors** — pick by the behavioral criterion, never by feel:
+
+| Anchor | Criterion |
+|--------|-----------|
+| `100` | The failure is reproduced, or the defect is visible in the quoted line without inference. |
+| `75` | A concrete failing input or state is named and the quoted line plainly permits it, but it was not run. |
+| `50` | Pattern-matched, inferred from naming, or dependent on caller behavior that was not read. |
+
+**`owner` values**: `agent` — in this diff's scope, an agent applies it. `human` —
+needs a decision or an access an agent does not have. `release` — real but not
+blocking this branch.
+
+**Evidence gate**: anchors `75` and `100` require `evidence` — the verbatim motivating
+line with `file:line`. A finding at 75+ with no evidence is **demoted to 50**, never
+discarded.
+
+**Old-format degrade**: a finding arriving with no `confidence` is handled as anchor
+`50` / `autofix_class: manual` — reported, never auto-applied and never discarded.
+
 **Output format for each finding**:
 ```
-[MUST-FIX] file.py:42 — Description and impact
-[SHOULD-FIX] handler.py:120 — Description and impact
-[NITPICK] utils.py:30 — Description
+[MUST-FIX] conf=100 fix=gated_auto owner=agent file.py:42 — Description and impact
+  evidence: `except Exception: pass` (file.py:42)
+[SHOULD-FIX] conf=75 fix=manual owner=agent handler.py:120 — Description and impact
+  evidence: `return cache.get(k) or {}` (handler.py:120)
+[NITPICK] conf=50 fix=advisory owner=release utils.py:30 — Description
 ```
+
+### Independence disclosure (required)
+
+State in the Step 4 output which mode the four passes ran in — inline and dispatched
+runs are otherwise indistinguishable downstream:
+
+- **Dispatched** — each pass ran as a separately dispatched agent (see § *Claude Code
+  Enhancements*). Two passes agreeing is independent corroboration and promotes
+  `confidence` by exactly one anchor.
+- **Inline** — the four passes ran sequentially in this context. Two passes agreeing is
+  same-context agreement and **never** promotes, however many passes agree. Name the
+  corroboration that was unavailable.
+
+Per `CLAUDE.md` § *Independence Accounting*. Inline is the correct floor, not a failure.
 
 ### Pass 1: Codebase Consistency
 - Duplicated logic that already exists elsewhere in the codebase
@@ -166,13 +211,29 @@ Run 4 sequential self-review passes in the main context. For each pass:
 
 ## Step 5 — Reconcile & Apply Fixes
 
-### 5.1 — Severity-Based Enforcement
+### 5.1 — Enforcement (keyed on severity × apply gate)
 
-| Severity | Action |
-|----------|--------|
-| `MUST-FIX` | Apply immediately. Cannot be skipped. |
-| `SHOULD-FIX` | Apply by default. May skip ≤3 total with code-specific justification. |
-| `NITPICK` | Auto-skip. |
+**Apply gate**: auto-apply a finding only when `autofix_class: gated_auto` **and**
+`confidence >= 75`. A finding that fails the gate is reported, not applied — including
+a `MUST-FIX`. Severity says how much it matters; the gate says whether an agent is
+entitled to change code unattended. They are different questions.
+
+| Severity | Clears the apply gate | Fails the apply gate |
+|----------|----------------------|----------------------|
+| `MUST-FIX` | Apply immediately. Cannot be skipped. | At `conf >= 75`: **blocking** — do not push, escalate to `owner`. At `conf 50`: report only, does not block. |
+| `SHOULD-FIX` | Apply by default. May skip ≤3 total with code-specific justification. | Report. Does not block the push. |
+| `NITPICK` | Auto-skip. | Auto-skip. |
+
+A `MUST-FIX` at `conf 50` is a suspicion, not a defect — blocking a push on it would
+stall an unattended loop on noise. A `MUST-FIX` at `conf >= 75` that an agent is not
+entitled to auto-fix is exactly the case a human must see, so it blocks.
+
+**On disagreement** between passes, synthesis takes the **more conservative**
+`autofix_class` — `advisory` is more conservative than `manual`, which is more
+conservative than `gated_auto`. Synthesis never widens.
+
+Same-context agreement between passes never promotes `confidence` (§ *Independence
+disclosure* in Step 4).
 
 ### 5.2 — Review Reconciliation Table
 
@@ -181,8 +242,10 @@ After processing all findings (skip if total findings ≤ 3):
 ```markdown
 ### Review Reconciliation
 
-| # | Pass | Severity | Finding | Action | Justification |
-|---|------|----------|---------|--------|---------------|
+Review mode: DISPATCHED / INLINE — [when inline: corroboration unavailable, no promotion]
+
+| # | Pass | Severity | Conf | Fix | Owner | Finding | Action | Justification |
+|---|------|----------|------|-----|-------|---------|--------|---------------|
 ```
 
 ### 5.3 — Review-Fix-Recheck Loop (max 2 iterations)
@@ -312,10 +375,12 @@ Session wrapped up.
 - Learnings: [N patterns / none]
 - Tasks: [X completed, Y pending]
 - Bugs: [N opened, N closed / no changes]
-- Code Review: [PASS / INCOMPLETE — N unresolved issues]
-  - MUST-FIX: [N found, N fixed]
+- Code Review: [PASS / INCOMPLETE — N unresolved issues] — mode: [DISPATCHED / INLINE]
+  - MUST-FIX: [N found, N fixed, N reported below the apply gate]
   - SHOULD-FIX: [N found, N fixed, N skipped]
   - NITPICK: [N found, skipped]
+  - Demoted: [N at 75+ with no file:line evidence → anchor 50]
+  - Promotions: [N on independent corroboration / none — inline run]
 - Security Scan: [PASS / N issues addressed]
 - Tests: [PASS — suite name] or [FAIL] or [SKIPPED — no suite]
 - E2E coverage: [N user-facing ACs verified / NONE / GAP — N acknowledged]
@@ -327,7 +392,11 @@ Session wrapped up.
 
 ### Step 4 — Parallel Code Review
 Launch all 4 review passes as parallel agents in a SINGLE message with multiple Agent tool calls.
-Each agent uses model: sonnet.
+`code-reviewer` and `critic` are **ceiling**-tier: pass no `model` override, so they
+inherit the session model (`CLAUDE.md` § *Model Routing*).
+
+This is the **dispatched** mode for the Step 4 independence disclosure: four separately
+dispatched contexts, so agreement between them is independent corroboration.
 
 Agent assignments:
 - Agent 1: `code-reviewer` — Codebase Consistency (Pass 1)

--- a/.claude/skills/yolo/SKILL.md
+++ b/.claude/skills/yolo/SKILL.md
@@ -164,7 +164,7 @@ Invoke `/wrap-up-session` with one override:
 | `/wrap-up-session` step | Yolo override |
 |---|---|
 | Step 6.3 — E2E coverage gate | If a user-facing AC lacks an e2e walkthrough, **do not prompt the user**. Run `/verify --scope e2e` automatically. If verify fails: log gap and continue. |
-| Step 7 — Commit gate (any MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed within the wrap-up loop, mark this iteration FAIL and **do not push**. The circuit breaker handles repeated failures. |
+| Step 7 — Commit gate (any MUST-FIX skipped → STOP) | If a MUST-FIX cannot be auto-fixed within the wrap-up loop, mark this iteration FAIL and **do not push**. The circuit breaker handles repeated failures. A `MUST-FIX` at `conf 50` that failed the apply gate is reported, not blocking (per `/wrap-up-session` § 5.1) — log it and continue rather than burning an iteration on a suspicion. |
 | Step 7 — Push | Run normally. Push to the feature branch. |
 | Step 8 — Deployment verification | Run normally if configured. |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,26 @@ Layer 3 — Pre-push in /wrap-up     codebase consistency, defensive audit,
                                    test coverage, adversarial critic
 ```
 
+Agreement *between* passes counts as corroboration only under the rule below.
+
+### Independence Accounting
+
+Corroboration between review findings counts **only** when the findings came from
+separately dispatched contexts. Two lenses reasoned inside one context are two
+perspectives, not two witnesses — they share the same priors, the same misreading of
+the diff, and the same blind spots, so their agreement is not evidence.
+
+- Independent corroboration promotes a finding's `confidence` by exactly one anchor.
+- Same-context agreement never promotes, however many lenses agree.
+- A run that could not dispatch still reports every finding, but states which
+  corroboration was unavailable instead of promoting on it. Inline is the correct
+  floor, not a failure.
+- Never claim independent corroboration from a model whose identity was only
+  *requested* rather than verified.
+
+`/quality-gate` Phase 3 and `/wrap-up-session` Step 4 each disclose whether their
+passes ran as dispatched agents or inline, and name the lost corroboration when inline.
+
 ---
 
 ## Core Principles

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -333,21 +333,21 @@ Run `tests/run.sh` after every task.
 
 ### Tier 2 — Review epistemics (M1, M2)
 
-[ ] TDD: `CLAUDE.md` has an Independence Accounting subsection stating corroboration requires separately dispatched contexts, and the Review Gate Taxonomy block cross-references it — verify by reading both -> Add the subsection and the taxonomy note
+[x] TDD: `CLAUDE.md` has an Independence Accounting subsection stating corroboration requires separately dispatched contexts, and the Review Gate Taxonomy block cross-references it — verify by reading both -> Add the subsection and the taxonomy note
 
-[ ] TDD: `/wrap-up-session` Step 4 emits whether the four passes ran dispatched or inline, and names the lost corroboration when inline; no promotion occurs on same-context agreement — verify by reading Step 4 and the output block -> Add the disclosure requirement and the no-promotion rule; add the disclosure line to the output template
+[x] TDD: `/wrap-up-session` Step 4 emits whether the four passes ran dispatched or inline, and names the lost corroboration when inline; no promotion occurs on same-context agreement — verify by reading Step 4 and the output block -> Add the disclosure requirement and the no-promotion rule; add the disclosure line to the output template
 
-[ ] TDD: `/quality-gate` emits the same disclosure for Phase 3 and never promotes on inline agreement — verify by reading Phase 3 and the output block -> Add the disclosure and no-promotion rule
+[x] TDD: `/quality-gate` emits the same disclosure for Phase 3 and never promotes on inline agreement — verify by reading Phase 3 and the output block -> Add the disclosure and no-promotion rule
 
-[ ] TDD: `/quality-gate` defines `severity`, `confidence`, `autofix_class`, and `owner` with a behavioral criterion for each of anchors 50/75/100, requires `file:line` evidence at 75+, demotes on absence, and auto-applies only `gated_auto` at 75+ — verify by reading against spec § M2 -> Rewrite the quality-gate finding model and apply gate
+[x] TDD: `/quality-gate` defines `severity`, `confidence`, `autofix_class`, and `owner` with a behavioral criterion for each of anchors 50/75/100, requires `file:line` evidence at 75+, demotes on absence, and auto-applies only `gated_auto` at 75+ — verify by reading against spec § M2 -> Rewrite the quality-gate finding model and apply gate
 
-[ ] TDD: `/wrap-up-session`'s severity table carries all four axes and Step 5.1 enforcement is keyed on the combination, taking the more conservative `autofix_class` on disagreement and never widening — verify by reading the table and 5.1 -> Rewrite the severity classification and enforcement sections
+[x] TDD: `/wrap-up-session`'s severity table carries all four axes and Step 5.1 enforcement is keyed on the combination, taking the more conservative `autofix_class` on disagreement and never widening — verify by reading the table and 5.1 -> Rewrite the severity classification and enforcement sections
 
-[ ] TDD: A finding arriving with no `confidence` is handled as anchor 50 / `manual` and is reported rather than applied or discarded — verify by reading the degrade rule in both skills -> Add the backwards-compatibility rule to both
+[x] TDD: A finding arriving with no `confidence` is handled as anchor 50 / `manual` and is reported rather than applied or discarded — verify by reading the degrade rule in both skills -> Add the backwards-compatibility rule to both
 
-[ ] TDD: `code-reviewer`, `critic`, `security-reviewer`, and `software-design-expert-review` each emit all four fields with the evidence gate, in both trees — verify by reading all eight files -> Update the four agent definitions and copy
+[x] TDD: `code-reviewer`, `critic`, `security-reviewer`, and `software-design-expert-review` each emit all four fields with the evidence gate, in both trees — verify by reading all eight files -> Update the four agent definitions and copy
 
-[ ] TDD: `/yolo`, `/auto-push`, and `/auto-improve` reach commit with no new user prompt introduced by the apply gate — verify by reading each skill's flow against the new gate -> Adjust the three loop skills only where the gate would otherwise block them
+[x] TDD: `/yolo`, `/auto-push`, and `/auto-improve` reach commit with no new user prompt introduced by the apply gate — verify by reading each skill's flow against the new gate -> Adjust the three loop skills only where the gate would otherwise block them
 
 ### Tier 3.1 — Store schema and migration script (M3)
 

--- a/tests/test-agents.sh
+++ b/tests/test-agents.sh
@@ -35,4 +35,19 @@ for f in "$CLAUDE"/*.md; do
     "Agents: canonical counterpart exists for .claude/agents/$base"
 done
 
+# 3. Review agents emit all four finding axes with the evidence gate (spec M2).
+# The orchestrator's apply gate keys on autofix_class + confidence, so an agent that
+# stops emitting them silently degrades every one of its findings to conf=50/manual.
+# Pinned per tree: a fix applied to only one copy is the regression this catches.
+for tree in "$CANONICAL" "$CLAUDE"; do
+  for base in code-reviewer critic security-reviewer software-design-expert-review; do
+    f="$tree/$base.md"
+    for token in "conf=" "fix=" "owner=" "Evidence gate" "conf=50"; do
+      assert_file_contains "$f" "$token" "M2: $f emits '$token'"
+    done
+    assert_file_contains "$f" "one witness" \
+      "M1: $f is told its own internal lenses are one witness"
+  done
+done
+
 finish

--- a/tests/test-doc-conventions.sh
+++ b/tests/test-doc-conventions.sh
@@ -86,4 +86,44 @@ done <<INNER_EOF
 $(find .agents/skills .claude/skills -name '*.md' -not -path '*/.claude/worktrees/*' | sort)
 INNER_EOF
 
+
+# --- Review epistemics: independence accounting + four-axis findings ---
+# Pins the smallest falsifiable units of spec M1/M2: the shared rule's location,
+# the four field names, the two numeric gates, and the mode disclosure. Deliberately
+# does NOT pin surrounding prose -- wording is free to change, the mechanism is not.
+assert_file_contains "CLAUDE.md" "Independence Accounting" \
+  "M1: CLAUDE.md carries the Independence Accounting subsection"
+assert_file_contains "CLAUDE.md" "separately dispatched contexts" \
+  "M1: corroboration is defined as requiring separately dispatched contexts"
+
+for f in .agents/skills/quality-gate/SKILL.md .claude/skills/quality-gate/SKILL.md \
+         .agents/skills/wrap-up-session/SKILL.md .claude/skills/wrap-up-session/SKILL.md; do
+  # all four axes named
+  for axis in "severity" "confidence" "autofix_class" "owner"; do
+    assert_file_contains "$f" "$axis" "M2: $f names the '$axis' axis"
+  done
+  # the three confidence anchors exist as an enum, not as prose adjectives
+  assert_file_contains "$f" '`50` / `75` / `100`' "M2: $f defines the 50/75/100 anchors"
+  # evidence gate + its demotion consequence
+  assert_file_contains "$f" "file:line" "M2: $f requires file:line evidence"
+  assert_file_contains "$f" "demoted to 50" "M2: $f demotes an unevidenced 75+ finding"
+  # apply gate -- both halves of the conjunction
+  assert_file_contains "$f" "gated_auto" "M2: $f gates auto-apply on autofix_class"
+  assert_file_contains "$f" 'confidence >= 75' "M2: $f gates auto-apply on the 75 anchor"
+  # old-format backwards compatibility
+  assert_file_contains "$f" "no \`confidence\`" "M2: $f handles a finding with no confidence"
+  # independence disclosure
+  assert_file_contains "$f" "Independence" "M1: $f carries the independence disclosure"
+  assert_file_contains "$f" "same-context agreement" \
+    "M1: $f names same-context agreement as the non-promoting case"
+  assert_file_contains "$f" "DISPATCHED / INLINE" "M1: $f discloses the run mode in its output"
+done
+
+# The dispatched path must not pin a model for ceiling-tier reviewers (M5 regression
+# guard at the call site -- test-model-tiers.sh covers the agent definitions).
+for f in .agents/skills/wrap-up-session/SKILL.md .claude/skills/wrap-up-session/SKILL.md; do
+  hits="$(grep -c 'Each agent uses model: sonnet' "$f" 2>/dev/null || true)"
+  assert_eq "0" "${hits:-0}" "M5: $f does not pin sonnet for the ceiling-tier review passes"
+done
+
 finish


### PR DESCRIPTION
Adopts mechanisms **M1** and **M2** from `specs/compound-engineering-adoption.md`. Tier 1 shipped in #53; this is the next tier. Tier 3 (typed learning store + migration) is deliberately **not** included — it retires `tasks/memory.md`/`bugs.md` and needs its own review.

## M1 — Independence accounting

Corroboration between review findings now counts **only** when the findings came from separately dispatched contexts. Two lenses reasoning inside one context are two perspectives, not two witnesses — same priors, same misreading of the diff, same blind spots — so their agreement never promotes confidence.

Before this change, `/wrap-up-session` Step 4 ran its four passes sequentially in the main context on the universal path and as four parallel agents only under *Claude Code Enhancements*, and **both paths fed the identical severity-enforcement table**. An inline run was indistinguishable from a real panel in the output. Both `/wrap-up-session` Step 4 and `/quality-gate` Phase 3 now disclose `DISPATCHED` or `INLINE` and name the corroboration lost when inline. Inline is documented as the correct floor, not a failure.

The shared rule lives in `CLAUDE.md` § *Independence Accounting* (per the spec's assumption 4 — `/sync` propagates `CLAUDE.md`, and both harnesses read it natively).

## M2 — Four-axis findings

A finding carried one axis. It now carries four orthogonal fields:

| Field | Answers | Values |
|-------|---------|--------|
| `severity` | how urgent | `MUST-FIX` / `SHOULD-FIX` / `NITPICK` |
| `confidence` | how sure | `50` / `75` / `100` |
| `autofix_class` | what shape the fix is | `gated_auto` / `manual` / `advisory` |
| `owner` | who acts | `agent` / `human` / `release` |

Each confidence anchor is tied to a behavioral criterion (reproduced / named-but-not-run / pattern-matched) rather than a feel. Gates:

- Anchors 75 and 100 require verbatim `file:line` evidence. Missing evidence **demotes to 50** — never drops the finding.
- Auto-apply requires `gated_auto` **and** `confidence >= 75`. Everything else is reported.
- On reviewer disagreement, synthesis takes the **more conservative** `autofix_class` and never widens.
- A finding arriving with no `confidence` degrades to `50`/`manual` — reported, never auto-applied, never discarded. No reviewer output is thrown away.

Security, auth, and structural findings are steered toward `manual`/`advisory` by default: a silent auto-fix to an auth path is worse than a reported one even when correct.

## Incidental fix — M5 leak from Tier 1

`/wrap-up-session`'s parallel review path still read `Each agent uses model: sonnet`, pinning `code-reviewer` and `critic` — both **ceiling**-tier — to Sonnet. That is the exact regression the ceiling tier exists to prevent: a session on Opus was getting Sonnet reviewers. Now passes no override so they inherit the session model. In scope because the spec's modified-files table assigns "tier-based models" to this skill.

## One decision the spec didn't settle

Whether a `MUST-FIX` that *fails* the apply gate blocks the push at any confidence, or only at 75+. I picked **only at 75+**: blocking an unattended loop on a `conf=50` suspicion would stall `/yolo` on noise, while `conf >= 75` is the anchor the spec already treats as actionable. `/yolo` and `/auto-push` carry that note on their commit-gate override rows. Worth a second opinion — it's the one judgment call here.

## Unattended loops

`/yolo`, `/auto-push`, and `/auto-improve` all already routed "MUST-FIX can't be auto-fixed" into an existing stop-and-report path, so the gate introduces **no new user prompt** in any of them.

## Guards

Both new assertion blocks pin the smallest falsifiable units per the spec's right-sizing rule — no snapshotting of skill bodies, no pinning of incidental wording.

- `tests/test-doc-conventions.sh` — the four axis names, both halves of the apply-gate conjunction, the evidence demotion, the mode disclosure, and the absence of the sonnet pin.
- `tests/test-agents.sh` — the four axes plus the evidence gate across **both** trees, so a fix applied to only one copy fails.

One assertion I wrote and then replaced: an initial `"never"` token was nearly tautological and would have passed on almost any file. It's now `"same-context agreement"`, the actual mechanism name.

The guards caught three real misses while I was writing them — two line-wrap artifacts where `one context` was split across a newline (line-based grep can't see it) and one case mismatch. Fixed in the sources, not worked around in the test.

## Verification

- `bash tests/run.sh` → **all 13 test files passed**
- `tests/test-skill-parity.sh` → 43 assertions, no drift between `.agents/` and `.claude/`
- `.claude/agents/software-design-expert-review.md` verified to differ from canonical by exactly its one intentional `model: sonnet` line, same as before this change
- All 8 Tier 2 acceptance criteria in `specs/compound-engineering-adoption.md` walked against the files and marked `[x]` in `tasks/todo.md`

Draft because the `conf=50` blocking decision above is worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAk9EwxA9cj2TsbmKRWYaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAk9EwxA9cj2TsbmKRWYaC)_