### PR TITLE
fix(wrap-up): re-sync stale PR descriptions + repair CRLF-broken doc guard

### DIFF
--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -307,9 +307,39 @@ If no specs were touched: skip this gate silently.
 2. Commit with type prefix: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 3. Append optional trailers: `Constraint:`, `Rejected:`, `Not-tested:`, `Confidence:`
 4. Push: `git push -u origin <branch>`
-5. Create PR if none exists for this branch
+5. Open the PR, or re-sync its description if one already exists — see *PR Description Sync*
 
 **Do not push if**: any test is failing, uncommitted changes unreviewed, MUST-FIX skipped.
+
+### PR Description Sync
+
+`gh pr create` writes the description once, from the branch as it stood at that
+moment. Every later commit can falsify it — a follow-up session, a review fix, a
+resolved deferral — and nothing re-reads it. The body is what reviewers act on, so
+a stale one is not cosmetic: a PR whose notes still list a defect as "deferred" is
+asking for review of work that no longer exists.
+
+**No PR for this branch** → create it.
+
+**A PR already exists** → reconcile the body against the branch before reporting done:
+
+1. Read it: `gh pr view <n> --json body -q .body`. List every factual claim —
+   counts (files changed, tests, assertions) and every item marked deferred,
+   known-gap, unresolved, or not-yet-done.
+2. Check each against the branch now. `git log <sha-when-body-was-written>..HEAD`
+   names what landed since; anything a later commit resolved is now false.
+3. Rewrite every claim that no longer holds.
+
+**Correct, do not erase.** When a later commit resolved something the body called
+deferred, say so and name the commit — do not silently delete the bullet. A
+reviewer who read the earlier version needs to see what changed, and a description
+edited to look as though the gap never existed hides the decision that mattered.
+Same rule as a commit that fixes an earlier commit: the history stays visible.
+
+This runs on **every** push to a branch with an open PR, including a
+`/wrap-up-session` run that adds a single commit. Report the outcome on the `PR:`
+line of the Done report — a sync step with no visible result is one that silently
+stops happening.
 
 ### Push Failure Handling
 
@@ -389,6 +419,7 @@ Session wrapped up.
 - Tests: [PASS — suite name] or [FAIL] or [SKIPPED — no suite]
 - E2E coverage: [N user-facing ACs verified / NONE / GAP — N acknowledged]
 - Pushed: [yes / no — reason]
+- PR: [#N opened / #N description re-synced — what changed / #N already accurate / none]
 - Deployments: [results or SKIPPED / NONE]
 ```
 

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -307,9 +307,39 @@ If no specs were touched: skip this gate silently.
 2. Commit with type prefix: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 3. Append optional trailers: `Constraint:`, `Rejected:`, `Not-tested:`, `Confidence:`
 4. Push: `git push -u origin <branch>`
-5. Create PR if none exists for this branch
+5. Open the PR, or re-sync its description if one already exists — see *PR Description Sync*
 
 **Do not push if**: any test is failing, uncommitted changes unreviewed, MUST-FIX skipped.
+
+### PR Description Sync
+
+`gh pr create` writes the description once, from the branch as it stood at that
+moment. Every later commit can falsify it — a follow-up session, a review fix, a
+resolved deferral — and nothing re-reads it. The body is what reviewers act on, so
+a stale one is not cosmetic: a PR whose notes still list a defect as "deferred" is
+asking for review of work that no longer exists.
+
+**No PR for this branch** → create it.
+
+**A PR already exists** → reconcile the body against the branch before reporting done:
+
+1. Read it: `gh pr view <n> --json body -q .body`. List every factual claim —
+   counts (files changed, tests, assertions) and every item marked deferred,
+   known-gap, unresolved, or not-yet-done.
+2. Check each against the branch now. `git log <sha-when-body-was-written>..HEAD`
+   names what landed since; anything a later commit resolved is now false.
+3. Rewrite every claim that no longer holds.
+
+**Correct, do not erase.** When a later commit resolved something the body called
+deferred, say so and name the commit — do not silently delete the bullet. A
+reviewer who read the earlier version needs to see what changed, and a description
+edited to look as though the gap never existed hides the decision that mattered.
+Same rule as a commit that fixes an earlier commit: the history stays visible.
+
+This runs on **every** push to a branch with an open PR, including a
+`/wrap-up-session` run that adds a single commit. Report the outcome on the `PR:`
+line of the Done report — a sync step with no visible result is one that silently
+stops happening.
 
 ### Push Failure Handling
 
@@ -389,6 +419,7 @@ Session wrapped up.
 - Tests: [PASS — suite name] or [FAIL] or [SKIPPED — no suite]
 - E2E coverage: [N user-facing ACs verified / NONE / GAP — N acknowledged]
 - Pushed: [yes / no — reason]
+- PR: [#N opened / #N description re-synced — what changed / #N already accurate / none]
 - Deployments: [results or SKIPPED / NONE]
 ```
 

--- a/tests/test-doc-conventions.sh
+++ b/tests/test-doc-conventions.sh
@@ -93,14 +93,20 @@ INNER_EOF
 # These docs are hard-wrapped prose, so a pinned multi-word phrase can straddle a
 # newline. Match against a whitespace-collapsed rendering: the guard is about the
 # rule being stated, not about where the paragraph happens to wrap.
-flatten() { tr '\n' ' ' < "$1" | tr -s ' '; }
+#
+# `tr -d '\r'` first, and it is not optional. These files are checked out with CRLF
+# on Windows, so collapsing only '\n' leaves the '\r' behind and "dispatched\r
+# contexts" never matches "dispatched contexts". Without it the guard passes in a
+# worktree whose files were authored with LF and fails on a fresh clone of the same
+# commit -- which is exactly what it did.
+flatten() { tr -d '\r' < "$1" | tr '\n' ' ' | tr -s ' '; }
 
 assert_file_contains "CLAUDE.md" "### Independence Accounting" \
   "M1: CLAUDE.md has an Independence Accounting subsection"
 assert_contains "$(flatten CLAUDE.md)" "separately dispatched contexts" \
   "M1: CLAUDE.md requires separately dispatched contexts for corroboration"
 
-taxonomy="$(sed -n '/^## Review Gate Taxonomy/,/^## Finding Model/p' CLAUDE.md | tr '\n' ' ' | tr -s ' ')"
+taxonomy="$(sed -n '/^## Review Gate Taxonomy/,/^## Finding Model/p' CLAUDE.md | tr -d '\r' | tr '\n' ' ' | tr -s ' ')"
 assert_contains "$taxonomy" "Independence Accounting" \
   "M1: Review Gate Taxonomy cross-references Independence Accounting"
 assert_contains "$taxonomy" "Finding Model" \
@@ -177,6 +183,29 @@ for f in .claude/skills/yolo/SKILL.md .agents/skills/yolo/SKILL.md \
          .claude/skills/auto-improve/SKILL.md .agents/skills/auto-improve/SKILL.md; do
   assert_file_contains "$f" "gated_auto" \
     "M2: $f states how a non-gated_auto MUST-FIX is routed"
+done
+
+# --- /wrap-up-session re-syncs a stale PR description ------------------------
+# `gh pr create` writes the body once. Later commits falsify it and nothing
+# re-reads it, so a PR can keep advertising a defect as deferred after the commit
+# that fixed it already landed -- observed on PR #55. Two things are pinned: that
+# the step exists, and that Step 7 no longer says "create if none exists" without
+# handling the update case, which is the wording the gap lived in.
+for f in .claude/skills/wrap-up-session/SKILL.md .agents/skills/wrap-up-session/SKILL.md; do
+  assert_file_contains "$f" "PR Description Sync" \
+    "PRSync: $f carries the PR Description Sync step"
+  assert_contains "$(flatten "$f")" "Correct, do not erase" \
+    "PRSync: $f forbids silently deleting a superseded claim"
+  assert_file_contains "$f" "- PR: [" \
+    "PRSync: $f reports the sync outcome on the Done report's PR line"
+  # The create-only wording is the defect itself, not merely incomplete docs.
+  if grep -qF "Create PR if none exists" "$f"; then
+    assert_eq "absent" "present" \
+      "PRSync: $f must not describe PR creation as the only case"
+  else
+    assert_eq "absent" "absent" \
+      "PRSync: $f must not describe PR creation as the only case"
+  fi
 done
 
 finish


### PR DESCRIPTION
Two fixes. The first is urgent and independent of the second — **`master` is currently red on a fresh checkout** — so it is a separate commit (`4c5774b`) and can be cherry-picked if you want it in ahead of the rest.

## 1. `master` is red on a fresh checkout — `4c5774b`

`flatten()` in `test-doc-conventions.sh` collapsed only `\n`. On a CRLF checkout the `\r` survives, so `"separately dispatched\r contexts"` never matches `"separately dispatched contexts"`.

```
printf 'separately dispatched\r\ncontexts\r\n' | tr '\n' ' ' | grep -c 'dispatched contexts'              # 0
printf 'separately dispatched\r\ncontexts\r\n' | tr -d '\r' | tr '\n' ' ' | grep -c 'dispatched contexts' # 1
```

I introduced this in #55, and it has the worst shape a test bug can have: **it passed where I wrote it and fails on a clean clone of the same commit.** CI or a new machine goes red on code nobody touched.

Worth knowing *why* only one assertion failed rather than all of them: `CLAUDE.md` is committed with **mixed** line endings — the lines I inserted via editor are LF, the surrounding file is CRLF — so exactly one pinned phrase happened to straddle a CRLF boundary. Every other `flatten`-based pin was latently broken and passing on the luck of where paragraphs wrapped.

Fixed at the pipeline rather than by normalizing the content: a test asserting *that a rule is stated* must not care how the file was checked out. The same `tr -d '\r'` went into the taxonomy extraction, which had the identical pipeline and the identical latent bug.

## 2. Stale PR descriptions — `984afc8`

Step 7 said `Create PR if none exists for this branch` and stopped. `gh pr create` writes the body once, from the branch as it stood then, and nothing re-reads it — so every later commit can falsify it while the description keeps asserting the old state.

Observed on #55: a follow-up commit closed a gap the reviewer notes listed as "deferred", and the notes still advertised it as deferred. A reviewer acting on that body would have been reviewing work that no longer existed, and the stale claim outlived the code by three commits.

- Item 5 becomes **open-or-re-sync**, pointing at a new *PR Description Sync* step.
- The step names what goes stale — counts, and anything marked deferred / known-gap / unresolved — and how to find it: diff the body's claims against `git log <sha-when-written>..HEAD`.
- **"Correct, do not erase."** When a later commit resolved something the body called deferred, say so and name the commit. Editing the description to look as though the gap never existed hides the decision that mattered from anyone who read the earlier version. Same rule as a commit that fixes an earlier commit: history stays visible.
- Runs on **every** push to a branch with an open PR, single-commit runs included.
- Outcome reports on a new `PR:` line in the Done report — a sync step with no visible result is one that silently stops happening.

## Guards

Pin the step, the do-not-erase rule, the `PR:` Done line, and the **absence** of the create-only wording the gap lived in — in both tree copies. Verified red before the parity copy, green after. **290 assertions, 13 test files green on a fresh checkout.**

## Reviewer notes

- **Bundled deliberately.** Normally these would be two PRs, but both touch `test-doc-conventions.sh`, and splitting them would put two PRs in conflict over the same file while `master` stays red. The commits are clean and separable.
- **Prose-only mechanism.** Nothing here can force a description to be accurate; it can only make the check a step that gets reported. That is the honest ceiling for a skill-level fix.
- **Not fixed here**: the mixed line endings in `CLAUDE.md` itself. A root `.gitattributes` with `*.md text eol=lf` would normalize them, but that rewrites every markdown file in the repo and belongs in its own PR — the guard is now endian-agnostic either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)