### PR TITLE
feat(glossary): accreting concept glossary with one-time bootstrap sweep (M4)

### DIFF
--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -71,14 +71,32 @@ The narrative log records what happened, not learnings:
 - Learnings captured: [links to the tasks/solutions/ documents, or "none"]
 ```
 
-### 7. Confirm
-Reply: "Learnings captured: [N] documents in `tasks/solutions/` ([updated/created]), history entry appended."
+### 7. Capture New Concepts (side effect — never a separate prompt)
+If a learning surfaced project-specific vocabulary — an entity, named process,
+or status term whose meaning is local to this project — add it to
+`tasks/concepts.md` under the matching section, keeping the entry format
+(`- **term** — definition.`, alphabetical). A term that already exists gets its
+definition refined in place, never a duplicate bullet. Standard industry terms
+do not qualify — `/memory-maintain` prunes them.
+
+If `tasks/concepts.md` is absent (project predates the seed), recreate the
+template seed in full — the format header, a `> Sweep: pending` marker line,
+the `## Harness vocabulary` section **with its six entries** (tier, gate,
+register, drift, ceiling, store — Phase 0 sweeps only the project's own
+material and will not refill them), and the `## Project vocabulary` section —
+so the next `/memory-maintain` run still performs its one-time bootstrap sweep
+and later writers find the sections they file under.
+
+Most sessions surface no new vocabulary; write nothing in that case.
+
+### 8. Confirm
+Reply: "Learnings captured: [N] documents in `tasks/solutions/` ([updated/created]), history entry appended[, [M] glossary terms added/refined]."
 
 ---
 
 ## Optional: `--cleanup`
 
-When invoked as `/learn --cleanup`, after completing Steps 1–7, run a folder sweep to surface legacy or unused files for archival.
+When invoked as `/learn --cleanup`, after completing Steps 1–8, run a folder sweep to surface legacy or unused files for archival.
 
 For each directory that has accumulated session artifacts:
 1. List all files and check creation dates via `git log --follow --oneline -- <file>`

--- a/.agents/skills/memory-maintain/SKILL.md
+++ b/.agents/skills/memory-maintain/SKILL.md
@@ -24,12 +24,18 @@ cheap light pass every session, and the heavy consolidation only every 5.
 
 Runs on **every** invocation (session start + wrap-up). Bounded work only:
 - Count documents and `needs_review` flags (`grep -rl 'needs_review: true' tasks/solutions/*/` — category dirs only, so the README's literal mention of the flag is not counted).
+- Check `tasks/concepts.md` for a `> Sweep: pending` marker line (cheap grep).
+  If present, run **Phase 0** now — the bootstrap sweep fires on the first
+  invocation that sees the marker, never waiting for the heavy-pass gate.
 - If any document written **this session** duplicates an existing one
   (same `module` + overlapping `tags` **and** >70% semantic overlap — the
   migration's generic `module: general` + `migrated` tag alone never qualify),
   merge into the more specific document and note the merge in its body.
 
-**If `tasks/solutions/` is absent or empty: silent no-op (exit 0, no output).**
+**If `tasks/solutions/` is absent or empty: silent no-op (exit 0, no output) —
+but the glossary marker check above runs regardless. A fresh install has an
+empty store and a `pending` glossary at the same time; the empty store must
+not swallow the one sweep that install exists to trigger.**
 
 ### Heavy pass — every 5 sessions (gated)
 
@@ -37,6 +43,28 @@ Count session entries in `tasks/history.md` (lines matching `^### \[\d{4}-\d{2}-
 - Run the full sweep below (Phases 1–4) if the count is a multiple of 5
   (5, 10, 15, …) OR --force flag passed
 - If neither condition met: skip the heavy pass (the light pass above still ran)
+
+## Phase 0 — Glossary Bootstrap Sweep (one-time)
+
+Runs only while `tasks/concepts.md` carries a `> Sweep: pending` marker line.
+If the marker reads `Sweep: done` or is absent entirely, this phase is a no-op —
+never launch a repo-wide sweep on a file that does not ask for one.
+
+1. Sweep the project's own material for vocabulary: README, `specs/`, docs, and
+   domain identifiers (model/schema/module names). Admit a term by the same test
+   pruning uses: project-specific meaning only — an entity, named process, or
+   status term whose meaning is local to this project. Standard industry terms
+   never qualify.
+2. Write the admitted terms in the glossary's entry format
+   (`- **term** — definition.`, alphabetical within section), refining in place
+   any term that already exists — never a duplicate bullet.
+3. Only after the entries land, flip the marker line to `> Sweep: done YYYY-MM-DD`
+   and drop the seed's "(While pending, …)" explanatory note — it describes a
+   state the file is no longer in. An interrupted sweep therefore re-runs whole
+   on the next invocation, and refine-in-place keeps the re-run idempotent.
+
+A near-empty project yields few or no terms; write what qualifies and flip the
+marker anyway — no "nothing found" noise.
 
 ## Phase 1 — Resolve `needs_review` Documents
 
@@ -87,6 +115,10 @@ For each document:
 - `tasks/history.md` stays a narrative log: any learning prose that leaked into
   it is extracted to a typed document and cross-linked, matching how the
   migration handled `- Pattern:` bullets.
+- `tasks/concepts.md` stays a glossary, not a catch-all: prune any entry whose
+  term has a standard industry meaning — a common word stays only if its
+  definition states the local twist. Keep entries alphabetical in the
+  `- **term** — definition.` format.
 
 ## Output
 
@@ -99,5 +131,6 @@ needs_review: [N resolved, N remaining, N archived as ungroundable]
 Duplicates: [N merged]
 Stale/contradicted: [N archived, N corrected]
 Schema violations fixed: [N]
+Glossary: [swept: N terms | N pruned, N kept | no change]
 ══════════════════════
 ```

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -71,14 +71,32 @@ The narrative log records what happened, not learnings:
 - Learnings captured: [links to the tasks/solutions/ documents, or "none"]
 ```
 
-### 7. Confirm
-Reply: "Learnings captured: [N] documents in `tasks/solutions/` ([updated/created]), history entry appended."
+### 7. Capture New Concepts (side effect — never a separate prompt)
+If a learning surfaced project-specific vocabulary — an entity, named process,
+or status term whose meaning is local to this project — add it to
+`tasks/concepts.md` under the matching section, keeping the entry format
+(`- **term** — definition.`, alphabetical). A term that already exists gets its
+definition refined in place, never a duplicate bullet. Standard industry terms
+do not qualify — `/memory-maintain` prunes them.
+
+If `tasks/concepts.md` is absent (project predates the seed), recreate the
+template seed in full — the format header, a `> Sweep: pending` marker line,
+the `## Harness vocabulary` section **with its six entries** (tier, gate,
+register, drift, ceiling, store — Phase 0 sweeps only the project's own
+material and will not refill them), and the `## Project vocabulary` section —
+so the next `/memory-maintain` run still performs its one-time bootstrap sweep
+and later writers find the sections they file under.
+
+Most sessions surface no new vocabulary; write nothing in that case.
+
+### 8. Confirm
+Reply: "Learnings captured: [N] documents in `tasks/solutions/` ([updated/created]), history entry appended[, [M] glossary terms added/refined]."
 
 ---
 
 ## Optional: `--cleanup`
 
-When invoked as `/learn --cleanup`, after completing Steps 1–7, run a folder sweep to surface legacy or unused files for archival.
+When invoked as `/learn --cleanup`, after completing Steps 1–8, run a folder sweep to surface legacy or unused files for archival.
 
 For each directory that has accumulated session artifacts:
 1. List all files and check creation dates via `git log --follow --oneline -- <file>`

--- a/.claude/skills/memory-maintain/SKILL.md
+++ b/.claude/skills/memory-maintain/SKILL.md
@@ -24,12 +24,18 @@ cheap light pass every session, and the heavy consolidation only every 5.
 
 Runs on **every** invocation (session start + wrap-up). Bounded work only:
 - Count documents and `needs_review` flags (`grep -rl 'needs_review: true' tasks/solutions/*/` — category dirs only, so the README's literal mention of the flag is not counted).
+- Check `tasks/concepts.md` for a `> Sweep: pending` marker line (cheap grep).
+  If present, run **Phase 0** now — the bootstrap sweep fires on the first
+  invocation that sees the marker, never waiting for the heavy-pass gate.
 - If any document written **this session** duplicates an existing one
   (same `module` + overlapping `tags` **and** >70% semantic overlap — the
   migration's generic `module: general` + `migrated` tag alone never qualify),
   merge into the more specific document and note the merge in its body.
 
-**If `tasks/solutions/` is absent or empty: silent no-op (exit 0, no output).**
+**If `tasks/solutions/` is absent or empty: silent no-op (exit 0, no output) —
+but the glossary marker check above runs regardless. A fresh install has an
+empty store and a `pending` glossary at the same time; the empty store must
+not swallow the one sweep that install exists to trigger.**
 
 ### Heavy pass — every 5 sessions (gated)
 
@@ -37,6 +43,28 @@ Count session entries in `tasks/history.md` (lines matching `^### \[\d{4}-\d{2}-
 - Run the full sweep below (Phases 1–4) if the count is a multiple of 5
   (5, 10, 15, …) OR --force flag passed
 - If neither condition met: skip the heavy pass (the light pass above still ran)
+
+## Phase 0 — Glossary Bootstrap Sweep (one-time)
+
+Runs only while `tasks/concepts.md` carries a `> Sweep: pending` marker line.
+If the marker reads `Sweep: done` or is absent entirely, this phase is a no-op —
+never launch a repo-wide sweep on a file that does not ask for one.
+
+1. Sweep the project's own material for vocabulary: README, `specs/`, docs, and
+   domain identifiers (model/schema/module names). Admit a term by the same test
+   pruning uses: project-specific meaning only — an entity, named process, or
+   status term whose meaning is local to this project. Standard industry terms
+   never qualify.
+2. Write the admitted terms in the glossary's entry format
+   (`- **term** — definition.`, alphabetical within section), refining in place
+   any term that already exists — never a duplicate bullet.
+3. Only after the entries land, flip the marker line to `> Sweep: done YYYY-MM-DD`
+   and drop the seed's "(While pending, …)" explanatory note — it describes a
+   state the file is no longer in. An interrupted sweep therefore re-runs whole
+   on the next invocation, and refine-in-place keeps the re-run idempotent.
+
+A near-empty project yields few or no terms; write what qualifies and flip the
+marker anyway — no "nothing found" noise.
 
 ## Phase 1 — Resolve `needs_review` Documents
 
@@ -87,6 +115,10 @@ For each document:
 - `tasks/history.md` stays a narrative log: any learning prose that leaked into
   it is extracted to a typed document and cross-linked, matching how the
   migration handled `- Pattern:` bullets.
+- `tasks/concepts.md` stays a glossary, not a catch-all: prune any entry whose
+  term has a standard industry meaning — a common word stays only if its
+  definition states the local twist. Keep entries alphabetical in the
+  `- **term** — definition.` format.
 
 ## Output
 
@@ -99,5 +131,6 @@ needs_review: [N resolved, N remaining, N archived as ungroundable]
 Duplicates: [N merged]
 Stale/contradicted: [N archived, N corrected]
 Schema violations fixed: [N]
+Glossary: [swept: N terms | N pruned, N kept | no change]
 ══════════════════════
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 
 ## Session Start Checklist
 
-1. Note the learning-store counts from the session-start banner; grep `tasks/solutions/` frontmatter (`problem_type`, `module`, `tags`) when a task touches a known area — never bulk-load the store. An unmigrated project (old monolithic store) is converted with the template repo's `scripts/migrate-learning-store.py` (dry-run by default; `/sync` Step 6.5 has the invocation)
+1. Note the learning-store counts from the session-start banner; grep `tasks/solutions/` frontmatter (`problem_type`, `module`, `tags`) when a task touches a known area — never bulk-load the store. Consult `tasks/concepts.md` when a task uses project terms you don't recognize, and use its vocabulary when naming things. An unmigrated project (old monolithic store) is converted with the template repo's `scripts/migrate-learning-store.py` (dry-run by default; `/sync` Step 6.5 has the invocation)
 2. Check `tasks/todo.md` for in-progress work
 3. Run `/memory-maintain` (self-gates — only does work every 5 sessions or when overdue)
 
@@ -204,6 +204,7 @@ tasks/backlog.md           → Ordered work items (from /prd)
 tasks/project-context.md   → Compressed agent briefing (auto-generated)
 tasks/solutions/           → Typed learning store: one doc per learning, grep-first retrieval (schema in its README.md)
 tasks/history.md           → Session narrative log (what happened, not learnings)
+tasks/concepts.md          → Concept glossary: project-specific vocabulary (populated once by /memory-maintain's bootstrap sweep, accreted by /learn, pruned by /memory-maintain)
 tasks/checkpoint.md        → Session snapshots
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Sets `git config --global init.templateDir ~/.git-templates`. Every time you run
 tasks/todo.md            ← active task plan
 tasks/solutions/         ← typed learning store (schema in its README.md)
 tasks/history.md         ← session narrative log
+tasks/concepts.md        ← concept glossary (swept once by /memory-maintain, then accreted)
 specs/                   ← feature specification directory
 CLAUDE.md           ← project-specific overrides
 ```
@@ -132,6 +133,7 @@ No need to use `newproject`. Just copy the scaffold files manually:
 cp ~/coding-agent-workflow/project-template/tasks/todo.md tasks/
 cp -r ~/coding-agent-workflow/project-template/tasks/solutions tasks/
 cp ~/coding-agent-workflow/project-template/tasks/history.md tasks/
+cp ~/coding-agent-workflow/project-template/tasks/concepts.md tasks/
 cp ~/coding-agent-workflow/project-template/CLAUDE.md .
 mkdir -p specs
 ```
@@ -292,6 +294,7 @@ Claude delegates to these automatically (or you can invoke them via the Agent to
 │   └── tasks/
 │       ├── todo.md
 │       ├── history.md
+│       ├── concepts.md
 │       └── solutions/
 ├── .claude/
 │   ├── AGENTS.md                    ← Agent reference documentation
@@ -304,6 +307,7 @@ Claude delegates to these automatically (or you can invoke them via the Agent to
 ├── tasks/
 │   ├── todo.md                      ← Active task plan
 │   ├── history.md                   ← Session narrative log
+│   ├── concepts.md                  ← Concept glossary (project vocabulary)
 │   └── solutions/                   ← Typed learning store (written via /learn)
 ├── specs/                           ← Feature specifications
 └── tests.md                         ← Project-specific test configuration

--- a/install.sh
+++ b/install.sh
@@ -288,6 +288,7 @@ copy_if_missing ".ignore"
 copy_if_missing "tasks/todo.md"
 copy_if_missing "tasks/solutions/README.md"
 copy_if_missing "tasks/history.md"
+copy_if_missing "tasks/concepts.md"
 
 if [ ! -d "$REPO_ROOT/specs" ]; then
   mkdir -p "$REPO_ROOT/specs"

--- a/project-template/.gitattributes
+++ b/project-template/.gitattributes
@@ -31,6 +31,9 @@ tasks/e2e-log.md     merge=union
 #   tasks/solutions/   one document per learning; concurrent sessions write
 #                      different files, and /memory-maintain curates — union
 #                      would defeat the deduplication that skill performs.
+#   tasks/concepts.md  entries are refined in place, not only appended; union
+#                      would keep both spellings of a refined definition and
+#                      could duplicate the sweep marker line.
 
 # Lockfiles: never merge, always regenerate. A textually merged lockfile can be
 # internally inconsistent while looking clean.

--- a/project-template/CLAUDE.md
+++ b/project-template/CLAUDE.md
@@ -13,7 +13,7 @@
 ```
 src/        → application source
 tests/      → test suite
-tasks/      → todo, solutions/ learning store, history (Claude workflow files)
+tasks/      → todo, solutions/ learning store, history, concepts.md glossary (Claude workflow files)
 specs/      → feature specifications
 ```
 

--- a/project-template/tasks/concepts.md
+++ b/project-template/tasks/concepts.md
@@ -1,0 +1,25 @@
+# Concepts — Project Glossary
+
+> Project-specific vocabulary: entities, named processes, and status terms whose
+> meaning is **local to this project**. Accretes as a side effect of `/learn`,
+> never as a separate chore; pruned by `/memory-maintain` — a term with a
+> standard industry meaning does not belong here. Entry format: one bullet per
+> term, alphabetical within its section: `- **term** — definition.`
+>
+> Sweep: pending
+> (While pending, the next `/memory-maintain` run performs a one-time full sweep
+> of README, `specs/`, docs, and domain identifiers to populate this file, then
+> flips the line above to `Sweep: done YYYY-MM-DD`. Maintenance mode after that.)
+
+## Harness vocabulary
+
+- **ceiling** — model-tier resolution meaning "omit the model override so the sub-agent inherits the session model"; not a model name. Reserved for the highest-stakes review roles.
+- **drift** — divergence between this project's synced workflow files and the template repo; caught by the session-start drift check.
+- **gate** — a hard checkpoint that blocks progress until its condition holds (plan confirmation, quality gate, evidence gate). A review reports; a gate stops.
+- **register** — a single append-oriented markdown file under `tasks/` recording one kind of thing (todo, history, checkpoint, this glossary).
+- **store** — the typed learning store at `tasks/solutions/`: one document per learning, YAML frontmatter, grep-first retrieval.
+- **tier** — a model-routing band (Ceiling / Planner / Builder / Reviewer / Scout).
+
+## Project vocabulary
+
+_Populated by the bootstrap sweep and by `/learn`; nothing captured yet._

--- a/tasks/concepts.md
+++ b/tasks/concepts.md
@@ -1,0 +1,31 @@
+# Concepts — Project Glossary
+
+> Project-specific vocabulary: entities, named processes, and status terms whose
+> meaning is **local to this project**. Accretes as a side effect of `/learn`,
+> never as a separate chore; pruned by `/memory-maintain` — a term with a
+> standard industry meaning does not belong here. Entry format: one bullet per
+> term, alphabetical within its section: `- **term** — definition.`
+>
+> Sweep: done 2026-08-13
+
+## Harness vocabulary
+
+- **ceiling** — model-tier resolution meaning "omit the model override so the sub-agent inherits the session model"; not a model name. Reserved for the highest-stakes review roles.
+- **drift** — divergence between the two skill trees (`.agents/` canonical vs `.claude/` copy) or between a downstream project and this template; caught by the parity tests and the session-start drift check.
+- **gate** — a hard checkpoint that blocks progress until its condition holds (plan confirmation, quality gate, evidence gate). A review reports; a gate stops.
+- **register** — a single append-oriented markdown file under `tasks/` recording one kind of thing (todo, history, checkpoint, this glossary).
+- **store** — the typed learning store at `tasks/solutions/`: one document per learning, YAML frontmatter, grep-first retrieval. Replaces the retired monolithic `tasks/memory.md`.
+- **tier** — a model-routing band (Ceiling / Planner / Builder / Reviewer / Scout), or an adoption phase in a multi-mechanism spec (Tier 1–3).
+
+## Project vocabulary
+
+- **canonical tree** — `.agents/`, the source of truth for skills and agent personas; `.claude/` holds the byte-identical copy. Edits land canonical-first, then are copied.
+- **circuit breaker** — the `/build`/`/yolo` failure escalation: repeated task failures trigger the `/refresh` backstop, then planner-tier review, then a loop stop — never a silent retry spiral.
+- **dispatch disclosure** — the required line in review output stating whether passes ran as separately dispatched agents or inline, naming the corroboration lost when inline.
+- **downstream** — a project that installed this template via `install.sh` and receives updates through `/sync`; this repo is the upstream template.
+- **harness** — an agent runtime the workflow supports (Claude Code, Pi); `harness: universal` prose must run identically on both.
+- **heavy pass** — `/memory-maintain`'s every-5-sessions consolidation (Phases 1–4); contrast **light pass**, the bounded per-session work.
+- **needs_review** — frontmatter flag marking a store document with inferred or missing required fields; resolved by `/memory-maintain` Phase 1.
+- **parity** — the byte-identical requirement between the canonical tree and its `.claude/` copy, enforced by `tests/test-skill-parity.sh`.
+- **shortcut** — a deliberate minimal implementation marked `TODO(shortcut):` with its limitation and upgrade path stated.
+- **track** — one of the store's two document kinds, selected by `problem_type`: bug track (`symptoms`/`root_cause`/`resolution`) or knowledge track (`applies_when`).

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -44,3 +44,8 @@
 - Pattern: To extend a `/sync`-managed skill's output without editing it, wrap it — a new skill owns a post-processor that operates on the managed skill's OUTPUT. Keeps the managed file untouched so `/sync` never clobbers the work. (extracted: tasks/solutions/patterns/to-extend-a-sync-managed-skill-s-output-without-editing-it-w.md)
 - Pattern: The bash test suite enforces `.agents/` ↔ `.claude/` byte-identical skill parity (`test-skill-parity.sh`) + doc-convention token greps (`test-doc-conventions.sh`). Any new skill must be authored in BOTH trees identically and wired into both tests. (extracted: tasks/solutions/patterns/the-bash-test-suite-enforces-agents-claude-byte-identical-sk.md)
 - Lessons added: none (captured as patterns above)
+
+### [2026-08-13] — M4 concept glossary
+
+- Key changes: Added `tasks/concepts.md` (accreting concept glossary) + template seed; `/memory-maintain` Phase 0 one-time bootstrap sweep keyed on a `> Sweep: pending` marker, fired from the light pass; `/learn` Step 7 concept capture; pruning rule in Phase 4; install.sh seed; guards in test-doc-conventions.sh + test-install-sh.sh. Dogfooded the sweep on this repo (10 terms admitted, marker flipped).
+- Learnings captured: tasks/solutions/patterns/first-run-triggers-must-precede-every-early-exit-above-them.md

--- a/tasks/solutions/patterns/first-run-triggers-must-precede-every-early-exit-above-them.md
+++ b/tasks/solutions/patterns/first-run-triggers-must-precede-every-early-exit-above-them.md
@@ -1,0 +1,44 @@
+---
+title: A first-run trigger added to a self-gating skill must be checked against every early exit above it
+date: 2026-08-13
+problem_type: pattern
+module: .agents/skills/memory-maintain
+tags: [skills, self-gating, bootstrap, early-exit, review]
+applies_when: adding a new trigger, phase, or check to a skill (or script) that already contains conditional no-op / early-exit rules
+---
+
+# A first-run trigger must be checked against every early exit above it
+
+## Context
+
+M4 added a one-time glossary bootstrap sweep (Phase 0) to `/memory-maintain`,
+keyed on a `> Sweep: pending` marker and fired from the light pass. The light
+pass already carried a blanket rule: *"If `tasks/solutions/` is absent or empty:
+silent no-op (exit 0, no output)."*
+
+A fresh install — the only scenario Phase 0 exists for — has an empty store and
+a `pending` glossary **at the same time**. The pre-existing early exit would
+have swallowed the new trigger silently, in both directions: the sweep never
+runs, and Phase 0 is specified to emit nothing when it finds nothing. Dead and
+green simultaneously. Caught by a dispatched critic at review
+(finding anchored to `.agents/skills/memory-maintain/SKILL.md:35`), not by any
+test — prose behavior is not mechanically guarded (M7 rule).
+
+## Pattern
+
+When adding a trigger to an existing skill or script, enumerate every
+conditional exit that executes **before** it and ask, for each: "can the state
+that fires my trigger coexist with the state that fires this exit?" If yes,
+exempt the trigger explicitly in the exit's own wording, not just by bullet
+ordering — ordering is not enforcement in prose.
+
+The fix here: *"silent no-op — but the glossary marker check above runs
+regardless. A fresh install has an empty store and a `pending` glossary at the
+same time."*
+
+## Evidence
+
+This session, branch `feat/compound-engineering-tier-3.3-glossary`; critic
+review verdict HOLD, MUST-FIX at confidence 75. The coexistence state was
+verified against `install.sh` (seeds `tasks/solutions/README.md` + a `pending`
+`tasks/concepts.md` together) rather than assumed.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -46,4 +46,24 @@
 ## Session Summary — 2026-08-13 [128952c..18e3304]
 - Completed: 9 tasks (M3 typed learning store + M3-MIG migration script, all ACs evidenced)
 - Pending: 0 tasks
-- Carry-forward: M4 (Tier 3.3 concepts glossary) deliberately out of scope — next spec item
+- Carry-forward: M4 (Tier 3.3 concepts glossary) — picked up below on `feat/compound-engineering-tier-3.3-glossary`
+
+---
+
+## Plan: M4 — Accreting Concept Glossary (Tier 3.3)
+> Spec: specs/compound-engineering-adoption.md § M4 / Tier 3.3, plus delta addendum specs/compound-engineering-m4-concept-glossary.md (both live untracked on the main clone, per the convention noted at the top of this file)
+> Branch: feat/compound-engineering-tier-3.3-glossary (worktree off worktree-m3-typed-learning-store)
+
+[x] Setup: worktree on `feat/compound-engineering-tier-3.3-glossary` off `worktree-m3-typed-learning-store` @ 53db64d; baseline `tests/run.sh` green (15 files)
+[x] TDD: doc-conventions asserts both glossary seeds exist, define the six terms (tier, gate, register, drift, ceiling, store) as anchored bullets, and carry exactly one legal-state sweep marker (template must be `pending`) -> `tasks/concepts.md` + `project-template/tasks/concepts.md` written
+[x] TDD: test-install-sh asserts `copy_if_missing "tasks/concepts.md"` -> install.sh seeds the glossary
+[x] TDD: doc-conventions asserts both `learn/SKILL.md` copies reference `tasks/concepts.md` + the pending marker -> /learn Step 7 concept capture (side effect, refine-in-place, seed-shape bootstrap when absent)
+[x] TDD: doc-conventions asserts both `memory-maintain/SKILL.md` copies carry Phase 0, both marker states, and the pruning rule -> Phase 0 bootstrap sweep fires from the light pass (exempt from the empty-store no-op), pruning in Phase 4, glossary line in Output
+[x] TDD: doc-conventions asserts CLAUDE.md Key Directories + project-template/CLAUDE.md list the glossary -> both registered; Session Start Checklist gained the read path (consult glossary for unknown project terms)
+[x] Evidence: Phase 0 dogfooded on this repo — swept 10 project terms into `## Project vocabulary`, marker flipped to `> Sweep: done 2026-08-13`; second run: `grep -c '^> Sweep: pending'` = 0 → no-op. README scaffold lists (post-init, manual copy, repo tree) and template `.gitattributes` exclusion list updated after critic review.
+[x] TDD: full `tests/run.sh` green + parity green; critic dispatched (ceiling tier), verdict HOLD → all MUST-FIX/SHOULD-FIX findings fixed (empty-store/Phase 0 interaction, legal-state marker guard, README drift, CLAUDE.md wording, .gitattributes, read path); re-run green
+
+## Session Summary — 2026-08-13 [53db64d..HEAD]
+- Completed: 8 tasks (M4 Tier 3.3 — glossary, bootstrap sweep, capture/prune hooks, guards, dogfood evidence)
+- Pending: 0 tasks
+- Carry-forward: stacked on unmerged `worktree-m3-typed-learning-store` — M3 PR merges first, then this branch's PR retargets/merges

--- a/tests/test-doc-conventions.sh
+++ b/tests/test-doc-conventions.sh
@@ -222,4 +222,63 @@ for f in .claude/skills/wrap-up-session/SKILL.md .agents/skills/wrap-up-session/
   fi
 done
 
+# --- Tier 3.3 (M4): accreting concept glossary --------------------------------
+# tasks/concepts.md is project vocabulary: seeded, populated once by a bootstrap
+# sweep, then accreted by /learn and pruned by /memory-maintain. Pinned tokens:
+# both seeds exist, the repo copy defines the six harness terms, and both carry
+# the Sweep marker that keys the one-time sweep.
+# The template seed must SHIP pending (downstream sweep not yet run); the repo
+# copy dogfooded the sweep, so its marker may read either legal state — but only
+# a legal state. A loose prefix match here would stay green while the marker
+# rots into a spelling the light pass's exact grep no longer recognizes.
+for f in tasks/concepts.md project-template/tasks/concepts.md; do
+  assert_eq "present" "$([ -f "$f" ] && echo present || echo missing)" \
+    "M4: $f exists"
+  assert_eq "1" "$(grep -cE '^> Sweep: (pending|done [0-9]{4}-[0-9]{2}-[0-9]{2})$' "$f" 2>/dev/null || true)" \
+    "M4: $f carries exactly one legal-state sweep marker"
+done
+assert_file_contains "project-template/tasks/concepts.md" "> Sweep: pending" \
+  "M4: template glossary seed ships unswept"
+# Anchored to the bullet form so a term surviving only in prose cannot pass.
+for term in tier gate register drift ceiling store; do
+  for f in tasks/concepts.md project-template/tasks/concepts.md; do
+    assert_file_contains "$f" "- **$term** — " \
+      "M4: $f defines '$term' as a glossary bullet"
+  done
+done
+# /learn accretes the glossary as a side effect (no separate prompt); a file it
+# bootstraps from scratch must still carry the pending marker so the sweep fires.
+for f in .claude/skills/learn/SKILL.md .agents/skills/learn/SKILL.md; do
+  assert_file_contains "$f" "tasks/concepts.md" \
+    "M4: $f captures concepts to the glossary"
+  assert_file_contains "$f" "Sweep: pending" \
+    "M4: $f bootstraps an absent glossary with the sweep marker"
+done
+# /memory-maintain owns both glossary lifecycles: the one-time bootstrap sweep
+# (keyed on the pending marker, fires from the LIGHT pass so a fresh install
+# does not wait 5 sessions) and steady-state pruning in the heavy pass.
+for f in .claude/skills/memory-maintain/SKILL.md .agents/skills/memory-maintain/SKILL.md; do
+  assert_file_contains "$f" "tasks/concepts.md" \
+    "M4: $f maintains the glossary"
+  assert_file_contains "$f" "standard industry meaning" \
+    "M4: $f prunes non-project-specific glossary entries"
+  assert_file_contains "$f" "Phase 0" \
+    "M4: $f defines the bootstrap sweep phase"
+  assert_file_contains "$f" "Sweep: pending" \
+    "M4: $f keys the sweep on the pending marker"
+  assert_file_contains "$f" "Sweep: done" \
+    "M4: $f flips the marker after the sweep"
+  # Pins the fix for the one regression this feature actually shipped with: the
+  # light pass's empty-store no-op swallowing Phase 0 on a fresh install. The
+  # exemption clause is the smallest falsifiable unit that fails if it returns.
+  assert_file_contains "$f" "runs regardless" \
+    "M4: $f exempts the glossary marker check from the empty-store no-op"
+done
+# Registration: the glossary is a listed register in both CLAUDE.md variants.
+keydirs="$(sed -n '/^## Key Directories/,/^## Agents/p' CLAUDE.md)"
+assert_contains "$keydirs" "tasks/concepts.md" \
+  "M4: CLAUDE.md Key Directories lists tasks/concepts.md"
+assert_file_contains "project-template/CLAUDE.md" "concepts.md" \
+  "M4: project-template CLAUDE.md lists the glossary"
+
 finish

--- a/tests/test-install-sh.sh
+++ b/tests/test-install-sh.sh
@@ -38,6 +38,9 @@ assert_contains "$src" 'copy_if_missing "tasks/solutions/README.md"' \
   "install.sh: seeds tasks/solutions/README.md"
 assert_contains "$src" 'copy_if_missing "tasks/history.md"' \
   "install.sh: seeds tasks/history.md"
+# M4: the concept glossary is a seeded task file too.
+assert_contains "$src" 'copy_if_missing "tasks/concepts.md"' \
+  "install.sh: seeds tasks/concepts.md"
 assert_eq "0" "$(count_matching 'copy_if_missing \"tasks/(bugs|lessons)\.md\"')" \
   "install.sh: no longer seeds retired lessons.md/bugs.md"
 assert_eq "present" "$([ -e "project-template/tasks/solutions/README.md" ] && echo present || echo missing)" \


### PR DESCRIPTION
Tier 3.3 of `specs/compound-engineering-adoption.md` — the last mechanism of the compound-engineering adoption. Follows #58 (M3 typed learning store); rebased onto its squash merge.

## What

- **`tasks/concepts.md` + `project-template/tasks/concepts.md`** — accreting concept glossary seeded with the six harness terms (tier, gate, register, drift, ceiling, store) and a `> Sweep:` lifecycle marker.
- **One-time bootstrap sweep** — `/memory-maintain` Phase 0 runs a full repo sweep (README, `specs/`, docs, domain identifiers) while the marker reads `pending`, then flips it to `done YYYY-MM-DD`. Fires from the *light pass* so a fresh install sweeps on its first session, and is explicitly exempt from the empty-store no-op (a fresh install has an empty store and a pending glossary at the same time). After the flip: maintenance mode only.
- **Accretion** — `/learn` Step 7 captures project-specific vocabulary as a side effect of learning extraction (refine-in-place, no separate prompt); recreates the full seed if the file predates it.
- **Pruning** — `/memory-maintain` Phase 4: any entry with a standard industry meaning goes; a common word stays only if its definition states the local twist.
- **Registration** — `install.sh` seeds the file; README (4 spots), `CLAUDE.md` Key Directories + Session Start read path, `project-template/CLAUDE.md`, template `.gitattributes` merge-exclusion list.
- **Guards** — legal-state marker regex (exactly one of `pending` | `done YYYY-MM-DD`), anchored term bullets in both seeds, skill-hook tokens, empty-store-exemption pin, install seed assertion. Per the M7 rule, sweep *behavior* is run evidence, not a test assertion.

## Evidence

Dogfooded on this repo: Phase 0 admitted 10 project terms (parity, canonical tree, dispatch disclosure, track, …) into `## Project vocabulary`, marker flipped to `done 2026-08-13`, second run no-ops. `bash tests/run.sh` green — all 15 files, 33 new M4 assertions.

Reviewed by two separately dispatched ceiling-tier agents (initial verdict HOLD → all MUST-FIX/SHOULD-FIX applied → re-verified GO). One learning captured to the store: a first-run trigger added to a self-gating skill must be checked against every early exit above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)