### PR TITLE
chore(ci): run the bash test suite on PRs and master pushes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+# Runs the zero-dependency bash test suite on every PR and on master pushes.
+# The suite needs only bash + coreutils + git (all in ubuntu-latest) and
+# python3 for the migration-script fixtures. Backstop for changes committed
+# from a dirty local tree: the local suite reads the working tree, so an
+# untracked-but-load-bearing file keeps local runs green while the pushed
+# commit is broken — CI runs from a clean checkout and catches exactly that.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run test suite
+        run: bash tests/run.sh


### PR DESCRIPTION
Adds `.github/workflows/tests.yml`: `bash tests/run.sh` on every `pull_request` and on pushes to `master`. Ubuntu runner, 15-minute timeout, no dependencies beyond the checkout (the suite is bash + coreutils + git, with python3 for the migration fixtures — all present on `ubuntu-latest`).

Motivation: during the M4 review (#59) a dispatched critic caught three load-bearing files that were untracked while the tracked `install.sh` referenced one of them through a silently-skipping `copy_if_missing`. The local suite stayed green because it reads the working tree; only a clean-checkout run would have failed. This workflow is that backstop.

Verified: suite green on this branch from a fresh worktree (15/15 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)