### PR TITLE
fix(routing): close three gaps the Ceiling tier left open

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -22,7 +22,7 @@ Sub-agent model assignment for build orchestration. The Tier column is canonical
 | Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `sonnet` |
 | Highest-stakes review (correctness, security, design, adversarial) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | Ceiling | *inherit* (`critic`: planner floor) |
 | Search / recon | `scout` (extension builtin) | Scout | `haiku` |
-| Context / docs | `context-builder` (builtin), `context-document-optimizer` | Reviewer | `haiku` |
+| Context / docs | `context-builder` (builtin), `context-document-optimizer` | Scout | `haiku` |
 
 **Escalation ladder for test regressions:**
 1. 2 attempts at builder tier
@@ -374,8 +374,11 @@ On Claude Code, these resolve via built-in model name resolution (`sonnet`, `hai
 On Pi + OpenRouter, explicit model IDs from the Model Routing table are used.
 
 **Ceiling-tier agents take no `model` at all.** `code-reviewer`, `security-reviewer`,
-and `critic` inherit the session model — passing an override caps the highest-stakes
-review below the model the user chose. See `CLAUDE.md` § Model Routing.
+`software-design-expert-review`, and `critic` inherit the session model — passing an
+override caps the highest-stakes review below the model the user chose.
+`critic` is the one exception: it carries a **planner floor**, so pass the planner
+alias when the session model is below planner tier and omit `model` otherwise.
+See `CLAUDE.md` § Model Routing.
 
 ### Pi Dispatch
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -19,15 +19,17 @@ Sub-agent model assignment for build orchestration. The Tier column is canonical
 | Second opinion (advisory) | `oracle` (extension builtin) | Planner | `opus` |
 | Coding agents | `backend-developer`, `frontend-developer` | Builder | `sonnet` |
 | Debugger (attempts 1-2) | `code-debugger` | Builder | `sonnet` |
-| Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `sonnet` |
+| Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `ceiling (builder floor)` |
 | Highest-stakes review (correctness, security, design, adversarial) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | Ceiling | *inherit* (`critic`: planner floor) |
 | Search / recon | `scout` (extension builtin) | Scout | `haiku` |
 | Context / docs | `context-builder` (builtin), `context-document-optimizer` | Scout | `haiku` |
 
 **Escalation ladder for test regressions:**
 1. 2 attempts at builder tier
-2. 2 attempts at reviewer tier
+2. 2 attempts at reviewer tier — on Claude Code that resolves to `ceiling (builder floor)`, because Reviewer and Builder both map to `sonnet` there, so a plain reviewer-tier retry would re-run the model that just failed twice. The floor makes this rung strictly stronger than step 1 on every session. See `CLAUDE.md` § Model Routing → Floors.
 3. Circuit breaker — `planner` at planner tier analyzes all 4 attempts; then halt and escalate to user
+
+Steps 1 and 2 must never resolve to the same model. If they do, the ladder has no middle rung and the first genuine escalation is the circuit breaker — four failed attempts later than intended.
 
 > **For Pi + OpenRouter users:** Session-level routing goes in `~/.pi/agent/presets.json` (see `PI_SETUP.md`). **Sub-agent** routing requires the `pi-subagents` extension (`pi install npm:pi-subagents`) — set `subagents.agentOverrides` in `~/.pi/agent/settings.json` (agent name → model, plus `fallbackModels` for provider failures). Workflow agents live in `.agents/agents/` and are auto-discovered per project. See `PI_SETUP.md` § Sub-Agent Routing.
 
@@ -338,8 +340,8 @@ Read `.agents/skills/build/references/subagent-resilience.md` before dispatching
 
 When `code-debugger` fails on the same regression, escalate through two tiers before halting:
 
-**Tier 1 — Worker (2 attempts):** Standard debugging with the default coding model.
-**Tier 2 — Escalation (2 attempts):** Upgrade to the reasoning/review model for deeper analysis.
+**Tier 1 — Worker (2 attempts):** Standard debugging at builder tier.
+**Tier 2 — Escalation (2 attempts):** Upgrade to reviewer tier for deeper analysis. On Claude Code that resolves to `ceiling (builder floor)` — inherit the session model, but never at or below builder tier — so the retry genuinely escalates instead of re-running the model that just failed twice. Confirm it resolved to something stronger than Tier 1; if it did not, go straight to Tier 3 rather than burning two identical attempts.
 
 **Tier 3 — Circuit breaker (planner tier):**
 

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -11,24 +11,23 @@ Bridges the gap between `/plan` (design) and `/wrap-up-session` (close).
 
 ## Model Routing
 
-Sub-agent model assignment for build orchestration. Edit this table to match your provider setup.
+Sub-agent model assignment for build orchestration. The Tier column is canonical; concrete provider model IDs live in `PI_SETUP.md` § Sub-Agent Routing, which is their single source — do not copy them back here.
 
-| Role | Agent | Model ID (OpenRouter) | Claude Code built-in |
-|------|-------|----------------------|---------------------|
-| Planning / architecture / circuit breaker | `planner` | `moonshotai/kimi-k3` | `opus` |
-| Second opinion (advisory) | `oracle` (extension builtin) | `moonshotai/kimi-k3` | `opus` |
-| Coding agents | `backend-developer`, `frontend-developer` | `qwen/qwen3-coder-next` | `sonnet` |
-| Debugger (attempts 1-2) | `code-debugger` | `qwen/qwen3-coder-next` | `sonnet` |
-| Debugger (attempts 3-4, escalation) | `code-debugger` | `z-ai/glm-4.7` | `sonnet` |
-| Highest-stakes review (correctness, security, adversarial) | `code-reviewer`, `security-reviewer`, `critic` | *inherit* | *inherit* |
-| Design review | `software-design-expert-review` | `z-ai/glm-4.7` | `sonnet` |
-| Search / recon | `scout` (extension builtin) | `deepseek/deepseek-v4-flash` | `haiku` |
-| Context / docs | `context-builder` (builtin), `context-document-optimizer` | `deepseek/deepseek-v4-flash` | `haiku` |
+| Role | Agent | Tier | Claude Code |
+|------|-------|------|-------------|
+| Planning / architecture / circuit breaker | `planner` | Planner | `opus` |
+| Second opinion (advisory) | `oracle` (extension builtin) | Planner | `opus` |
+| Coding agents | `backend-developer`, `frontend-developer` | Builder | `sonnet` |
+| Debugger (attempts 1-2) | `code-debugger` | Builder | `sonnet` |
+| Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `sonnet` |
+| Highest-stakes review (correctness, security, design, adversarial) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | Ceiling | *inherit* (`critic`: planner floor) |
+| Search / recon | `scout` (extension builtin) | Scout | `haiku` |
+| Context / docs | `context-builder` (builtin), `context-document-optimizer` | Reviewer | `haiku` |
 
 **Escalation ladder for test regressions:**
-1. 2 attempts with coding/debug model (`qwen3-coder-next` / worker tier)
-2. 2 attempts with escalated model (`glm-4.7` / reasoning tier)
-3. Circuit breaker — `planner` on `kimi-k3` analyzes all 4 attempts; then halt and escalate to user
+1. 2 attempts at builder tier
+2. 2 attempts at reviewer tier
+3. Circuit breaker — `planner` at planner tier analyzes all 4 attempts; then halt and escalate to user
 
 > **For Pi + OpenRouter users:** Session-level routing goes in `~/.pi/agent/presets.json` (see `PI_SETUP.md`). **Sub-agent** routing requires the `pi-subagents` extension (`pi install npm:pi-subagents`) — set `subagents.agentOverrides` in `~/.pi/agent/settings.json` (agent name → model, plus `fallbackModels` for provider failures). Workflow agents live in `.agents/agents/` and are auto-discovered per project. See `PI_SETUP.md` § Sub-Agent Routing.
 
@@ -342,7 +341,7 @@ When `code-debugger` fails on the same regression, escalate through two tiers be
 **Tier 1 — Worker (2 attempts):** Standard debugging with the default coding model.
 **Tier 2 — Escalation (2 attempts):** Upgrade to the reasoning/review model for deeper analysis.
 
-**Tier 3 — Circuit breaker (premium model, e.g. `anthropic/claude-opus-4.8`):**
+**Tier 3 — Circuit breaker (planner tier):**
 
 1. **STOP** fixing symptoms — the design may be the problem.
 2. Spawn a `planner` with: the failing test output (all 4 attempts), the files changed across all attempts, the original spec and task description.

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -14,8 +14,10 @@ Enter plan mode to define a spec and task breakdown **before any code is written
 
 Sub-agent delegations follow the Model Routing table in `/build` (planner tier for planning/architecture, scout tier for exploration).
 - **Claude Code** — pass `model` explicitly per that table, except for *ceiling*-tier
-  agents (`code-reviewer`, `security-reviewer`, `critic`), which take no `model` so they
-  inherit the session model. See `CLAUDE.md` § Model Routing.
+  agents (`code-reviewer`, `security-reviewer`, `software-design-expert-review`,
+  `critic`), which take no `model` so they inherit the session model. `critic` carries a
+  **planner floor**: pass the planner alias if the session model is below planner tier.
+  See `CLAUDE.md` § Model Routing.
 - **Pi** — no per-call model params; routing resolves from `subagents.agentOverrides` (requires the `pi-subagents` extension). Use `scout` for codebase exploration.
 - The planning phase requires the strongest reasoning model for architecture decisions
 

--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -198,7 +198,7 @@ Apply Gate — but it may never report a promoted confidence.
 
 ## Claude Code Enhancements
 
-Dispatch the `software-design-expert-review` skill (invokes `software-design-expert-review` agent, model: sonnet) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
+Dispatch the `software-design-expert-review` skill (invokes the `software-design-expert-review` agent at Ceiling tier — pass no `model`, so it inherits the session model) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
 
 ---
 

--- a/.agents/skills/software-design-expert-review/SKILL.md
+++ b/.agents/skills/software-design-expert-review/SKILL.md
@@ -42,7 +42,7 @@ Run a focused structural review based on *A Philosophy of Software Design* by Jo
 
 ## Phase 2 — Dispatch APOSD Reviewer Agent
 
-For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (`model: sonnet` — Reviewer tier, not Ceiling; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass:
+For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (Ceiling tier — pass no `model` at all, so it inherits the session model; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass:
 - The git diff for the file(s)
 - Absolute paths of the files
 - The instruction: "Review ONLY these changed files. Emit every finding in the canonical four-axis format `[SEVERITY | confidence | autofix_class | owner] file:line — description`, with an `evidence:` line quoting the motivating source line for any finding at anchor `75` or `100`."

--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -432,7 +432,8 @@ Session wrapped up.
 Launch all 4 review passes as parallel agents in a SINGLE message with multiple Agent tool calls.
 
 `code-reviewer` and `critic` are **Ceiling** tier (`CLAUDE.md` § *Model Routing*):
-pass **no** `model` parameter so each inherits the session model. Pinning them
+pass **no** `model` parameter so each inherits the session model. `critic` is the one exception: it carries a **planner floor**, so pass the planner
+alias when the session model is below planner tier and omit `model` otherwise. Pinning them
 downgrades the highest-stakes review for exactly the users running a stronger
 model.
 

--- a/.claude/agents/software-design-expert-review.md
+++ b/.claude/agents/software-design-expert-review.md
@@ -1,7 +1,6 @@
 ---
 name: software-design-expert-review
 description: Read-only software design expert focused on APOSD principles. Scans changed code for structural red flags from 'A Philosophy of Software Design' by John Ousterhout, including the 10 red flags plus Error Design (R11). Outputs machine-parseable [MUST-FIX] / [SHOULD-FIX] / [NITPICK] findings. Used by /build Phase 3.5 and /software-design-expert-review.
-model: sonnet
 color: blue
 ---
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -22,7 +22,7 @@ Sub-agent model assignment for build orchestration. The Tier column is canonical
 | Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `sonnet` |
 | Highest-stakes review (correctness, security, design, adversarial) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | Ceiling | *inherit* (`critic`: planner floor) |
 | Search / recon | `scout` (extension builtin) | Scout | `haiku` |
-| Context / docs | `context-builder` (builtin), `context-document-optimizer` | Reviewer | `haiku` |
+| Context / docs | `context-builder` (builtin), `context-document-optimizer` | Scout | `haiku` |
 
 **Escalation ladder for test regressions:**
 1. 2 attempts at builder tier
@@ -374,8 +374,11 @@ On Claude Code, these resolve via built-in model name resolution (`sonnet`, `hai
 On Pi + OpenRouter, explicit model IDs from the Model Routing table are used.
 
 **Ceiling-tier agents take no `model` at all.** `code-reviewer`, `security-reviewer`,
-and `critic` inherit the session model — passing an override caps the highest-stakes
-review below the model the user chose. See `CLAUDE.md` § Model Routing.
+`software-design-expert-review`, and `critic` inherit the session model — passing an
+override caps the highest-stakes review below the model the user chose.
+`critic` is the one exception: it carries a **planner floor**, so pass the planner
+alias when the session model is below planner tier and omit `model` otherwise.
+See `CLAUDE.md` § Model Routing.
 
 ### Pi Dispatch
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -19,15 +19,17 @@ Sub-agent model assignment for build orchestration. The Tier column is canonical
 | Second opinion (advisory) | `oracle` (extension builtin) | Planner | `opus` |
 | Coding agents | `backend-developer`, `frontend-developer` | Builder | `sonnet` |
 | Debugger (attempts 1-2) | `code-debugger` | Builder | `sonnet` |
-| Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `sonnet` |
+| Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `ceiling (builder floor)` |
 | Highest-stakes review (correctness, security, design, adversarial) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | Ceiling | *inherit* (`critic`: planner floor) |
 | Search / recon | `scout` (extension builtin) | Scout | `haiku` |
 | Context / docs | `context-builder` (builtin), `context-document-optimizer` | Scout | `haiku` |
 
 **Escalation ladder for test regressions:**
 1. 2 attempts at builder tier
-2. 2 attempts at reviewer tier
+2. 2 attempts at reviewer tier — on Claude Code that resolves to `ceiling (builder floor)`, because Reviewer and Builder both map to `sonnet` there, so a plain reviewer-tier retry would re-run the model that just failed twice. The floor makes this rung strictly stronger than step 1 on every session. See `CLAUDE.md` § Model Routing → Floors.
 3. Circuit breaker — `planner` at planner tier analyzes all 4 attempts; then halt and escalate to user
+
+Steps 1 and 2 must never resolve to the same model. If they do, the ladder has no middle rung and the first genuine escalation is the circuit breaker — four failed attempts later than intended.
 
 > **For Pi + OpenRouter users:** Session-level routing goes in `~/.pi/agent/presets.json` (see `PI_SETUP.md`). **Sub-agent** routing requires the `pi-subagents` extension (`pi install npm:pi-subagents`) — set `subagents.agentOverrides` in `~/.pi/agent/settings.json` (agent name → model, plus `fallbackModels` for provider failures). Workflow agents live in `.agents/agents/` and are auto-discovered per project. See `PI_SETUP.md` § Sub-Agent Routing.
 
@@ -338,8 +340,8 @@ Read `.agents/skills/build/references/subagent-resilience.md` before dispatching
 
 When `code-debugger` fails on the same regression, escalate through two tiers before halting:
 
-**Tier 1 — Worker (2 attempts):** Standard debugging with the default coding model.
-**Tier 2 — Escalation (2 attempts):** Upgrade to the reasoning/review model for deeper analysis.
+**Tier 1 — Worker (2 attempts):** Standard debugging at builder tier.
+**Tier 2 — Escalation (2 attempts):** Upgrade to reviewer tier for deeper analysis. On Claude Code that resolves to `ceiling (builder floor)` — inherit the session model, but never at or below builder tier — so the retry genuinely escalates instead of re-running the model that just failed twice. Confirm it resolved to something stronger than Tier 1; if it did not, go straight to Tier 3 rather than burning two identical attempts.
 
 **Tier 3 — Circuit breaker (planner tier):**
 

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -11,24 +11,23 @@ Bridges the gap between `/plan` (design) and `/wrap-up-session` (close).
 
 ## Model Routing
 
-Sub-agent model assignment for build orchestration. Edit this table to match your provider setup.
+Sub-agent model assignment for build orchestration. The Tier column is canonical; concrete provider model IDs live in `PI_SETUP.md` § Sub-Agent Routing, which is their single source — do not copy them back here.
 
-| Role | Agent | Model ID (OpenRouter) | Claude Code built-in |
-|------|-------|----------------------|---------------------|
-| Planning / architecture / circuit breaker | `planner` | `moonshotai/kimi-k3` | `opus` |
-| Second opinion (advisory) | `oracle` (extension builtin) | `moonshotai/kimi-k3` | `opus` |
-| Coding agents | `backend-developer`, `frontend-developer` | `qwen/qwen3-coder-next` | `sonnet` |
-| Debugger (attempts 1-2) | `code-debugger` | `qwen/qwen3-coder-next` | `sonnet` |
-| Debugger (attempts 3-4, escalation) | `code-debugger` | `z-ai/glm-4.7` | `sonnet` |
-| Highest-stakes review (correctness, security, adversarial) | `code-reviewer`, `security-reviewer`, `critic` | *inherit* | *inherit* |
-| Design review | `software-design-expert-review` | `z-ai/glm-4.7` | `sonnet` |
-| Search / recon | `scout` (extension builtin) | `deepseek/deepseek-v4-flash` | `haiku` |
-| Context / docs | `context-builder` (builtin), `context-document-optimizer` | `deepseek/deepseek-v4-flash` | `haiku` |
+| Role | Agent | Tier | Claude Code |
+|------|-------|------|-------------|
+| Planning / architecture / circuit breaker | `planner` | Planner | `opus` |
+| Second opinion (advisory) | `oracle` (extension builtin) | Planner | `opus` |
+| Coding agents | `backend-developer`, `frontend-developer` | Builder | `sonnet` |
+| Debugger (attempts 1-2) | `code-debugger` | Builder | `sonnet` |
+| Debugger (attempts 3-4, escalation) | `code-debugger` | Reviewer | `sonnet` |
+| Highest-stakes review (correctness, security, design, adversarial) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | Ceiling | *inherit* (`critic`: planner floor) |
+| Search / recon | `scout` (extension builtin) | Scout | `haiku` |
+| Context / docs | `context-builder` (builtin), `context-document-optimizer` | Reviewer | `haiku` |
 
 **Escalation ladder for test regressions:**
-1. 2 attempts with coding/debug model (`qwen3-coder-next` / worker tier)
-2. 2 attempts with escalated model (`glm-4.7` / reasoning tier)
-3. Circuit breaker — `planner` on `kimi-k3` analyzes all 4 attempts; then halt and escalate to user
+1. 2 attempts at builder tier
+2. 2 attempts at reviewer tier
+3. Circuit breaker — `planner` at planner tier analyzes all 4 attempts; then halt and escalate to user
 
 > **For Pi + OpenRouter users:** Session-level routing goes in `~/.pi/agent/presets.json` (see `PI_SETUP.md`). **Sub-agent** routing requires the `pi-subagents` extension (`pi install npm:pi-subagents`) — set `subagents.agentOverrides` in `~/.pi/agent/settings.json` (agent name → model, plus `fallbackModels` for provider failures). Workflow agents live in `.agents/agents/` and are auto-discovered per project. See `PI_SETUP.md` § Sub-Agent Routing.
 
@@ -342,7 +341,7 @@ When `code-debugger` fails on the same regression, escalate through two tiers be
 **Tier 1 — Worker (2 attempts):** Standard debugging with the default coding model.
 **Tier 2 — Escalation (2 attempts):** Upgrade to the reasoning/review model for deeper analysis.
 
-**Tier 3 — Circuit breaker (premium model, e.g. `anthropic/claude-opus-4.8`):**
+**Tier 3 — Circuit breaker (planner tier):**
 
 1. **STOP** fixing symptoms — the design may be the problem.
 2. Spawn a `planner` with: the failing test output (all 4 attempts), the files changed across all attempts, the original spec and task description.

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -14,8 +14,10 @@ Enter plan mode to define a spec and task breakdown **before any code is written
 
 Sub-agent delegations follow the Model Routing table in `/build` (planner tier for planning/architecture, scout tier for exploration).
 - **Claude Code** — pass `model` explicitly per that table, except for *ceiling*-tier
-  agents (`code-reviewer`, `security-reviewer`, `critic`), which take no `model` so they
-  inherit the session model. See `CLAUDE.md` § Model Routing.
+  agents (`code-reviewer`, `security-reviewer`, `software-design-expert-review`,
+  `critic`), which take no `model` so they inherit the session model. `critic` carries a
+  **planner floor**: pass the planner alias if the session model is below planner tier.
+  See `CLAUDE.md` § Model Routing.
 - **Pi** — no per-call model params; routing resolves from `subagents.agentOverrides` (requires the `pi-subagents` extension). Use `scout` for codebase exploration.
 - The planning phase requires the strongest reasoning model for architecture decisions
 

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -198,7 +198,7 @@ Apply Gate — but it may never report a promoted confidence.
 
 ## Claude Code Enhancements
 
-Dispatch the `software-design-expert-review` skill (invokes `software-design-expert-review` agent, model: sonnet) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
+Dispatch the `software-design-expert-review` skill (invokes the `software-design-expert-review` agent at Ceiling tier — pass no `model`, so it inherits the session model) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
 
 ---
 

--- a/.claude/skills/software-design-expert-review/SKILL.md
+++ b/.claude/skills/software-design-expert-review/SKILL.md
@@ -42,7 +42,7 @@ Run a focused structural review based on *A Philosophy of Software Design* by Jo
 
 ## Phase 2 — Dispatch APOSD Reviewer Agent
 
-For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (`model: sonnet` — Reviewer tier, not Ceiling; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass:
+For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (Ceiling tier — pass no `model` at all, so it inherits the session model; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass:
 - The git diff for the file(s)
 - Absolute paths of the files
 - The instruction: "Review ONLY these changed files. Emit every finding in the canonical four-axis format `[SEVERITY | confidence | autofix_class | owner] file:line — description`, with an `evidence:` line quoting the motivating source line for any finding at anchor `75` or `100`."

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -432,7 +432,8 @@ Session wrapped up.
 Launch all 4 review passes as parallel agents in a SINGLE message with multiple Agent tool calls.
 
 `code-reviewer` and `critic` are **Ceiling** tier (`CLAUDE.md` § *Model Routing*):
-pass **no** `model` parameter so each inherits the session model. Pinning them
+pass **no** `model` parameter so each inherits the session model. `critic` is the one exception: it carries a **planner floor**, so pass the planner
+alias when the session model is below planner tier and omit `model` otherwise. Pinning them
 downgrades the highest-stakes review for exactly the users running a stronger
 model.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,9 +225,9 @@ Canonical persona definitions live in `.agents/agents/` (model-agnostic — neve
 | `code-reviewer` | *ceiling* | Post-implementation quality review |
 | `code-debugger` | `sonnet` | Debugging failing tests and runtime errors |
 | `security-reviewer` | *ceiling* | OWASP checks, auth flows, injection vectors |
-| `critic` | *ceiling* | Adversarial quality gate for plans, code, specs |
+| `critic` | *ceiling (planner floor)* | Adversarial quality gate for plans, code, specs |
 | `context-document-optimizer` | `sonnet` | Compress large docs for token efficiency |
-| `software-design-expert-review` | `sonnet` | Read-only APOSD design audit — depth, leakage, error design (dispatched by `/quality-gate`) |
+| `software-design-expert-review` | *ceiling* | Read-only APOSD design audit — depth, leakage, error design (dispatched by `/quality-gate`) |
 
 **Rule**: One focused task per subagent. Resolve each agent's model through the
 tier in *Model Routing* below — on Claude Code pass `model` explicitly for the
@@ -239,15 +239,15 @@ agents so they inherit the session model; on Pi, never pass per-call model param
 
 ## Model Routing
 
-Canonical tiers (concrete model IDs per provider setup live in `/build`'s Model Routing table and `PI_SETUP.md`):
+Canonical tiers. Concrete provider model IDs are deliberately **not** repeated here — `PI_SETUP.md` § Sub-Agent Routing is their single source, so a model release updates one file instead of three:
 
-| Tier | Used for | Claude Code | Pi + OpenRouter (recommended) |
-|------|----------|-------------|-------------------------------|
-| Ceiling | correctness, security, and adversarial review — the highest-stakes judgment | *inherit* | *inherit* |
-| Planner | `/plan`, architecture, oracle, circuit breaker | `opus` | `moonshotai/kimi-k3` |
-| Builder | `/build` coding, debugging (attempts 1–2) | `sonnet` | `qwen/qwen3-coder-next` |
-| Reviewer | design review, doc compression, debugging (attempts 3–4) | `sonnet` | `z-ai/glm-4.7` |
-| Scout | search, recon, context building | `haiku` | `deepseek/deepseek-v4-flash` |
+| Tier | Used for | Claude Code |
+|------|----------|-------------|
+| Ceiling | correctness, security, design, and adversarial review — the highest-stakes judgment | *inherit* |
+| Planner | `/plan`, architecture, oracle, circuit breaker | `opus` |
+| Builder | `/build` coding, debugging (attempts 1–2) | `sonnet` |
+| Reviewer | doc compression, debugging (attempts 3–4) | `sonnet` |
+| Scout | search, recon, context building | `haiku` |
 
 **`Ceiling` means: omit the model override entirely so the sub-agent inherits the
 session model.** It is not a model name and must never be written as one. If the
@@ -261,12 +261,24 @@ the correct cross-harness fallback: where a harness cannot select a model per
 agent, omit the override rather than guessing a name, because a working review on
 the parent model beats a failed dispatch on an unrecognized one.
 
+**`critic` carries a planner floor** — `*ceiling (planner floor)*`. Inheriting is
+right in every direction but down: `critic` is the adversarial gate of last
+resort, and a plain ceiling silently drops it below planner tier on a Builder- or
+Scout-tier session. So omit the override when the session model is planner tier
+or higher, and pass the planner alias when it is lower. The floor is a **dispatch
+rule, not frontmatter**: a `model: opus` pin would satisfy it on a Sonnet session
+but *cap* the agent on any session stronger than Opus — the same defect Ceiling
+exists to remove. Nothing mechanically enforces this; `tests/test-model-tiers.sh`
+pins the rule's presence and the absence of a pin, which is as far as a static
+guard reaches.
+
 Rules:
 - Never use the planner tier for code writing; never use the scout tier for coding
   or planning.
 - **Claude Code**: pass `model` explicitly for the Planner, Builder, Reviewer, and
   Scout tiers. Pass **nothing** for Ceiling — an override there is the regression
-  this tier exists to prevent.
+  this tier exists to prevent. `critic` is the one exception, and only downward,
+  per its floor above.
 - **Pi**: never pass per-call model params; `subagents.agentOverrides` resolves
   them. Leave ceiling-tier agents out of `agentOverrides` so they inherit.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ Canonical tiers. Concrete provider model IDs are deliberately **not** repeated h
 | Ceiling | correctness, security, design, and adversarial review — the highest-stakes judgment | *inherit* |
 | Planner | `/plan`, architecture, oracle, circuit breaker | `opus` |
 | Builder | `/build` coding, debugging (attempts 1–2) | `sonnet` |
-| Reviewer | doc compression, debugging (attempts 3–4) | `sonnet` |
+| Reviewer | doc compression, debugging (attempts 3–4 — see the floor below) | `sonnet` |
 | Scout | search, recon, context building | `haiku` |
 
 **`Ceiling` means: omit the model override entirely so the sub-agent inherits the
@@ -261,17 +261,31 @@ the correct cross-harness fallback: where a harness cannot select a model per
 agent, omit the override rather than guessing a name, because a working review on
 the parent model beats a failed dispatch on an unrecognized one.
 
-**`critic` carries a planner floor** — `*ceiling (planner floor)*`, meaning it
-never resolves below planner tier. Inheriting is right in every direction but
-down: `critic` is the adversarial gate of last resort, and a plain ceiling
-silently drops it beneath planner tier on a Builder- or Scout-tier session. So
-omit the override when the session model is planner tier or higher, and pass the
-planner alias when it is lower. The floor is a **dispatch
-rule, not frontmatter**: a `model: opus` pin would satisfy it on a Sonnet session
-but *cap* the agent on any session stronger than Opus — the same defect Ceiling
-exists to remove. Nothing mechanically enforces this; `tests/test-model-tiers.sh`
-pins the rule's presence and the absence of a pin, which is as far as a static
-guard reaches.
+### Floors
+
+`ceiling (<tier> floor)` means: inherit the session model, but never resolve
+*below* `<tier>`. Omit the override when the session model is at `<tier>` or
+above; pass `<tier>`'s alias when it is lower. A floor is always a **dispatch
+rule, not frontmatter** — a `model:` pin would satisfy the floor on a weaker
+session but *cap* the agent on a stronger one, the same defect Ceiling exists to
+remove. Nothing mechanically enforces a floor; `tests/test-model-tiers.sh` pins
+the rule's presence and the absence of a pin, which is as far as a static guard
+reaches. Two roles carry one:
+
+**`critic` — `*ceiling (planner floor)*`, so it never resolves below planner
+tier.** It is the adversarial gate of last resort, and a plain ceiling would
+silently drop it beneath planner tier on a Builder- or Scout-tier session — downgrading the one reviewer whose job is
+catching what the others missed.
+
+**Debugger attempts 3–4 — `ceiling (builder floor)`.** This is the escalation
+rung of the regression ladder, and on Claude Code it had nothing to escalate *to*:
+**Reviewer and Builder both resolve to `sonnet`**, because Claude Code offers no
+alias between them. So attempts 3–4 re-ran the exact model that had just failed
+twice, and "graduated escalation" was a no-op until the circuit breaker. The floor
+makes the rung strictly stronger than attempts 1–2 on every session — planner
+alias on a Builder-or-weaker session, inherited model above that — without
+capping an Opus-or-stronger session at a fixed alias. Pi is unaffected: it has a
+genuine three-model ladder already (see `PI_SETUP.md`).
 
 Rules:
 - Never use the planner tier for code writing; never use the scout tier for coding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,11 @@ Rules:
   this tier exists to prevent. `critic` is the one exception, and only downward,
   per its floor above.
 - **Pi**: never pass per-call model params; `subagents.agentOverrides` resolves
-  them. Leave ceiling-tier agents out of `agentOverrides` so they inherit.
+  them. Ceiling-tier agents stay **explicitly pinned** there. Omitting an agent
+  from `agentOverrides` falls through to `subagents.defaultModel` — a fixed
+  builder-tier model, not the session model — so omission on Pi *downgrades*
+  rather than inherits. Ceiling-by-omission is a Claude Code property; see
+  `PI_SETUP.md` § Sub-Agent Routing for the Pi equivalent.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,8 +264,9 @@ the parent model beats a failed dispatch on an unrecognized one.
 **`critic` carries a planner floor** — `*ceiling (planner floor)*`, meaning it
 never resolves below planner tier. Inheriting is right in every direction but
 down: `critic` is the adversarial gate of last resort, and a plain ceiling
-silently drops it beneath planner tier on a Builder- or Scout-tier session. So omit the override when the session model is planner tier
-or higher, and pass the planner alias when it is lower. The floor is a **dispatch
+silently drops it beneath planner tier on a Builder- or Scout-tier session. So
+omit the override when the session model is planner tier or higher, and pass the
+planner alias when it is lower. The floor is a **dispatch
 rule, not frontmatter**: a `model: opus` pin would satisfy it on a Sonnet session
 but *cap* the agent on any session stronger than Opus — the same defect Ceiling
 exists to remove. Nothing mechanically enforces this; `tests/test-model-tiers.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,10 +261,10 @@ the correct cross-harness fallback: where a harness cannot select a model per
 agent, omit the override rather than guessing a name, because a working review on
 the parent model beats a failed dispatch on an unrecognized one.
 
-**`critic` carries a planner floor** — `*ceiling (planner floor)*`. Inheriting is
-right in every direction but down: `critic` is the adversarial gate of last
-resort, and a plain ceiling silently drops it below planner tier on a Builder- or
-Scout-tier session. So omit the override when the session model is planner tier
+**`critic` carries a planner floor** — `*ceiling (planner floor)*`, meaning it
+never resolves below planner tier. Inheriting is right in every direction but
+down: `critic` is the adversarial gate of last resort, and a plain ceiling
+silently drops it beneath planner tier on a Builder- or Scout-tier session. So omit the override when the session model is planner tier
 or higher, and pass the planner alias when it is lower. The floor is a **dispatch
 rule, not frontmatter**: a `model: opus` pin would satisfy it on a Sonnet session
 but *cap* the agent on any session stronger than Opus — the same defect Ceiling

--- a/PI_SETUP.md
+++ b/PI_SETUP.md
@@ -195,10 +195,6 @@ Add a `subagents` block to `~/.pi/agent/settings.json` (agent name → model, wi
     "backend-developer":  { "model": "qwen/qwen3-coder-next", "fallbackModels": ["z-ai/glm-4.7"] },
     "frontend-developer": { "model": "qwen/qwen3-coder-next", "fallbackModels": ["z-ai/glm-4.7"] },
     "code-debugger":      { "model": "qwen/qwen3-coder-next", "fallbackModels": ["z-ai/glm-4.7"] },
-    "code-reviewer":      { "model": "z-ai/glm-4.7" },
-    "security-reviewer":  { "model": "z-ai/glm-4.7" },
-    "software-design-expert-review": { "model": "z-ai/glm-4.7" },
-    "critic":             { "model": "z-ai/glm-4.7" },
     "scout":              { "model": "deepseek/deepseek-v4-flash", "thinking": "off" },
     "context-builder":    { "model": "deepseek/deepseek-v4-flash" },
     "context-document-optimizer": { "model": "deepseek/deepseek-v4-flash" },
@@ -211,6 +207,12 @@ Add a `subagents` block to `~/.pi/agent/settings.json` (agent name → model, wi
 }
 ```
 
+**Four agents are deliberately absent from `agentOverrides`:** `code-reviewer`, `security-reviewer`,
+`software-design-expert-review`, and `critic`. Omitting them is what makes each inherit the session
+model — adding an entry re-caps the reviewer and is precisely the regression the Ceiling tier exists to
+prevent. The one exception is `critic`, which has a planner *floor*: pin it to the planner model only if
+your session model is weaker than planner tier.
+
 Dispatch is natural language ("Have backend-developer implement this task") or the `subagent` tool. Do NOT pass per-call model params — `agentOverrides` resolves each agent's model automatically, and `fallbackModels` absorbs provider errors/rate-limits.
 
 ### Tier rationale
@@ -220,13 +222,18 @@ Dispatch is natural language ("Have backend-developer implement this task") or t
 | Plan / oracle / circuit breaker | `moonshotai/kimi-k3` | $0.60 | 1M context, strong reasoning, thinking levels low/high/max |
 | Build / debug | `qwen/qwen3-coder-next` | $0.11 | Purpose-built for coding agents, cheapest of the strong coder tier |
 | Review / escalation | `z-ai/glm-4.7` | $0.40 | Flagship reasoning + programming; different model family than the builder — catches builder blind spots |
+| Ceiling (highest-stakes review) | *inherit* | session | Correctness, security, design, and adversarial review run at whatever the session pays for — pinning them caps them |
 | Scout / context / docs | `deepseek/deepseek-v4-flash` | $0.14 | 1M context, very cheap, fast |
 
 Budget alternative for the build tier: `z-ai/glm-4.7-flash` ($0.06/M in) if cost pressure beats quality headroom.
 
 ## How Build Skill Sub-Agent Routing Works
 
-The `/build` skill's Model Routing table assigns explicit model IDs to each sub-agent role:
+**This file is the single source of concrete model IDs.** `CLAUDE.md` and `/build` name tiers
+only and point here, so a model release touches one file instead of three. If you find an
+OpenRouter ID in either of those, delete it rather than updating it.
+
+Model ID per sub-agent role:
 
 | Role | Agent | OpenRouter Model ID | Cost/M in |
 |------|-------|--------------------|-----------|
@@ -235,10 +242,18 @@ The `/build` skill's Model Routing table assigns explicit model IDs to each sub-
 | Coding agents | `backend-developer`, `frontend-developer` | `qwen/qwen3-coder-next` | $0.11 |
 | Debugger (1-2) | `code-debugger` | `qwen/qwen3-coder-next` | $0.11 |
 | Debugger (3-4) | `code-debugger` | `z-ai/glm-4.7` | $0.40 |
-| Reviews | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | `z-ai/glm-4.7` | $0.40 |
+| Highest-stakes review (Ceiling) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | *inherit — no override* | session model |
 | Search / recon | `scout` | `deepseek/deepseek-v4-flash` | $0.14 |
 
-On Claude Code, these are passed to the Agent tool when dispatching sub-agents. On Pi, they are resolved from `subagents.agentOverrides` (see previous section). Each sub-agent runs independently with its own model and context.
+On Claude Code these are passed to the Agent tool when dispatching sub-agents — **except Ceiling-tier
+roles, which take no `model` at all** so they inherit the session model (see `CLAUDE.md` § *Model
+Routing*). On Pi they resolve from `subagents.agentOverrides` (see previous section), and Ceiling roles
+are simply absent from it so they inherit the session model there too. Each sub-agent runs
+independently with its own model and context.
+
+Ceiling exists because pinning the highest-stakes reviewers *caps* them: an Opus session reviewed by a
+cheaper model is a worse review than the session already paid for. `critic` is the one role with a
+**floor** as well — never below planner tier, since it is the adversarial gate of last resort.
 
 **Escalation:** If a debugger fails 2 times with the build-tier model (`qwen3-coder-next`), it escalates to the review-tier model (`glm-4.7`) for 2 more attempts. If all 4 fail, the circuit breaker trips: `planner` on `kimi-k3` analyzes every attempt before the user is asked to intervene.
 

--- a/PI_SETUP.md
+++ b/PI_SETUP.md
@@ -195,6 +195,10 @@ Add a `subagents` block to `~/.pi/agent/settings.json` (agent name → model, wi
     "backend-developer":  { "model": "qwen/qwen3-coder-next", "fallbackModels": ["z-ai/glm-4.7"] },
     "frontend-developer": { "model": "qwen/qwen3-coder-next", "fallbackModels": ["z-ai/glm-4.7"] },
     "code-debugger":      { "model": "qwen/qwen3-coder-next", "fallbackModels": ["z-ai/glm-4.7"] },
+    "code-reviewer":      { "model": "z-ai/glm-4.7" },
+    "security-reviewer":  { "model": "z-ai/glm-4.7" },
+    "software-design-expert-review": { "model": "z-ai/glm-4.7" },
+    "critic":             { "model": "moonshotai/kimi-k3" },
     "scout":              { "model": "deepseek/deepseek-v4-flash", "thinking": "off" },
     "context-builder":    { "model": "deepseek/deepseek-v4-flash" },
     "context-document-optimizer": { "model": "deepseek/deepseek-v4-flash" },
@@ -207,11 +211,17 @@ Add a `subagents` block to `~/.pi/agent/settings.json` (agent name → model, wi
 }
 ```
 
-**Four agents are deliberately absent from `agentOverrides`:** `code-reviewer`, `security-reviewer`,
-`software-design-expert-review`, and `critic`. Omitting them is what makes each inherit the session
-model — adding an entry re-caps the reviewer and is precisely the regression the Ceiling tier exists to
-prevent. The one exception is `critic`, which has a planner *floor*: pin it to the planner model only if
-your session model is weaker than planner tier.
+**Ceiling cannot be expressed by omission on Pi — the four review roles stay pinned.** On Claude Code,
+omitting `model` means the sub-agent inherits the session model; that is the whole mechanism. On Pi,
+omitting an agent from `agentOverrides` falls through to `subagents.defaultModel` above — a *fixed*
+model (`qwen/qwen3-coder-next`), not the session model. Deleting these four entries would therefore
+**downgrade** every review to the builder model rather than lifting it: strictly worse than the
+`z-ai/glm-4.7` pin, and it would destroy the different-model-family property that § *Tier rationale*
+below relies on to catch builder blind spots.
+
+`critic` is pinned to the **planner** model rather than the review model because it carries a planner
+*floor*, and a static config cannot make a floor conditional — so it is satisfied unconditionally. If you
+set `defaultModel` to your session model, you may delete all four entries and get true Ceiling behavior.
 
 Dispatch is natural language ("Have backend-developer implement this task") or the `subagent` tool. Do NOT pass per-call model params — `agentOverrides` resolves each agent's model automatically, and `fallbackModels` absorbs provider errors/rate-limits.
 
@@ -242,13 +252,15 @@ Model ID per sub-agent role:
 | Coding agents | `backend-developer`, `frontend-developer` | `qwen/qwen3-coder-next` | $0.11 |
 | Debugger (1-2) | `code-debugger` | `qwen/qwen3-coder-next` | $0.11 |
 | Debugger (3-4) | `code-debugger` | `z-ai/glm-4.7` | $0.40 |
-| Highest-stakes review (Ceiling) | `code-reviewer`, `security-reviewer`, `software-design-expert-review`, `critic` | *inherit — no override* | session model |
+| Highest-stakes review (Ceiling) | `code-reviewer`, `security-reviewer`, `software-design-expert-review` | `z-ai/glm-4.7` on Pi; *inherit* on Claude Code | $0.40 |
+| Adversarial gate (Ceiling, planner floor) | `critic` | `moonshotai/kimi-k3` on Pi; *inherit* on Claude Code | $0.60 |
 | Search / recon | `scout` | `deepseek/deepseek-v4-flash` | $0.14 |
 
 On Claude Code these are passed to the Agent tool when dispatching sub-agents — **except Ceiling-tier
 roles, which take no `model` at all** so they inherit the session model (see `CLAUDE.md` § *Model
-Routing*). On Pi they resolve from `subagents.agentOverrides` (see previous section), and Ceiling roles
-are simply absent from it so they inherit the session model there too. Each sub-agent runs
+Routing*). On Pi they resolve from `subagents.agentOverrides` (see previous section), where Ceiling roles
+stay explicitly pinned, because omission there falls through to `defaultModel` rather than to the
+session model. Each sub-agent runs
 independently with its own model and context.
 
 Ceiling exists because pinning the highest-stakes reviewers *caps* them: an Opus session reviewed by a

--- a/specs/model-tier-ceiling-gaps.md
+++ b/specs/model-tier-ceiling-gaps.md
@@ -1,0 +1,153 @@
+# Spec: Close the gaps the Ceiling tier left open
+
+> Follows PR #53, which shipped the Ceiling tier. This spec covers three things
+> #53 named but did not finish, plus a test-harness hole found while verifying
+> them. It is deliberately narrow: the Ceiling tier itself, its rationale, and its
+> `CLAUDE.md` vocabulary are #53's and are not restated here.
+
+## Behavior
+
+`Ceiling` means "omit the `model` override so the sub-agent inherits the session
+model". #53 established the tier and applied it to three review roles. Four
+things remained.
+
+### 1. `software-design-expert-review` joins Ceiling
+
+#53 left it at Reviewer tier (`sonnet`) with an explicit rationale — its own skill
+read *"`model: sonnet` — Reviewer tier, not Ceiling"* — and `tests/test-model-tiers.sh`
+asserted the pin via `PINNED_AGENTS`.
+
+**This spec overrides that decision.** An APOSD structural audit is correctness
+work: the defects it finds are the expensive kind, and a design flaw caught late
+costs far more than the token difference. It is the one change here that reverses
+a documented choice rather than completing an unfinished one, so it is the one
+most worth a reviewer's pushback.
+
+`PINNED_AGENTS` keeps a subject — `context-document-optimizer`, also Reviewer
+tier — so the mirror guard #53 added does not go vacuous. That guard protects a
+real observed regression: the `.agents/` → `.claude/` parity copy is a plain `cp`
+from a tree that is model-agnostic by contract, so it silently drops a
+Claude-only `model:` line, and parity tests cannot catch it because the `cp` is
+what made the two files identical.
+
+### 2. `critic` gains a planner floor
+
+Plain `ceiling` inherits in every direction **including down**. On a Builder- or
+Scout-tier session the adversarial gate of last resort ran below planner tier —
+a silent downgrade of the one reviewer whose whole job is catching what the others
+missed.
+
+Resolution becomes `*ceiling (planner floor)*`: omit the override at planner tier
+or above, pass the planner alias below it.
+
+The floor is a **dispatch rule, not frontmatter.** A `model: opus` pin would
+satisfy the floor on a Sonnet session but *cap* the agent on any session stronger
+than Opus — the same defect Ceiling exists to remove. Nothing mechanically
+enforces the floor; the test pins the rule's presence and the absence of a pin,
+which is as far as a static guard reaches. This limit is stated rather than
+hidden.
+
+### 3. Concrete model IDs leave the routing tables
+
+Four OpenRouter IDs lived in `CLAUDE.md`, `/build`'s table (both trees), and
+`PI_SETUP.md`. Three copies of a release-sensitive fact is three chances to go
+stale, and the two tables are the copies nobody updates.
+
+`PI_SETUP.md` § Sub-Agent Routing becomes the named single source. Both tables
+carry tiers only.
+
+This also reconciles a contradiction #53 introduced: `CLAUDE.md` gained the rule
+*"leave ceiling-tier agents out of `agentOverrides` so they inherit"* while
+`PI_SETUP.md`'s example config went on pinning all four of them.
+
+### 4. `assert_not_contains` no longer passes vacuously
+
+Absence-of-needle is trivially true of the empty string, so any `grep`/`sed`
+extraction that matched nothing reported `ok` — turning a load-bearing check into
+a silent pass. `assert_contains` needs no such guard (an empty haystack cannot
+contain a non-empty needle), which is why the hole was one-sided and easy to miss.
+
+The guard goes in the primitive rather than in each caller, because "remember to
+check your extraction first" is the discipline whose absence causes the bug.
+
+Two helpers follow from the same work: `assert_file_matches` /
+`assert_file_not_matches` for anchored patterns like `^model:` that
+`assert_file_contains` cannot express (`grep -qF` is literal-only), and
+`assert_prose_contains`, which collapses whitespace so a prose assertion depends
+on the words rather than on where the markdown hard-wrap happens to fall.
+
+## Inputs
+
+Read from disk on current `master` (`7c3dc74`), not assumed:
+
+- `CLAUDE.md` — Agents table (10 rows), Model Routing (5 tiers incl. `Ceiling`),
+  and the dispatch Rules block.
+- `.claude/agents/` — `code-reviewer`, `security-reviewer`, `critic` already
+  unpinned by #53; `software-design-expert-review` still `model: sonnet`.
+- `tests/test-model-tiers.sh` — 105 lines, `CEILING_AGENTS` (3) and
+  `PINNED_AGENTS` (1).
+- `.agents/skills/build/SKILL.md` — 8-row table with 8 concrete IDs; ladder and
+  circuit breaker naming IDs.
+- `.agents/skills/{quality-gate,software-design-expert-review}/SKILL.md` — the two
+  design-reviewer dispatch sites.
+- `PI_SETUP.md` — concrete IDs plus an `agentOverrides` example pinning all four
+  review roles; zero mentions of `ceiling`.
+- `tests/lib.sh` — 5 assertion helpers, none regex, none whitespace-normalizing.
+
+## Outputs
+
+| Path | Change |
+|------|--------|
+| `CLAUDE.md` | design reviewer → `*ceiling*`; `critic` → `*ceiling (planner floor)*`; floor rule added; Pi column dropped, pointer added; Ceiling row covers design |
+| `.claude/agents/software-design-expert-review.md` | delete the `model:` line |
+| `.agents/skills/build/SKILL.md` + `.claude/` copy | Tier column replaces Model ID column; ladder and circuit breaker name tiers |
+| `.agents/skills/{quality-gate,software-design-expert-review}/SKILL.md` + copies | dispatch at Ceiling, no `model` |
+| `PI_SETUP.md` | named single source; Ceiling row; four roles removed from `agentOverrides` with the reason |
+| `tests/lib.sh` | empty-haystack guard; `assert_file_matches`, `assert_file_not_matches`, `assert_prose_contains` |
+| `tests/test-model-tiers.sh` | `CEILING_AGENTS` gains the design reviewer; `PINNED_AGENTS` → `context-document-optimizer`; sections 6–8 added |
+
+### Unchanged, deliberately
+
+- Debugger attempts 3–4 stay at Reviewer/`sonnet`. Identical to attempts 1–2, so
+  on Claude Code the escalation ladder still escalates to the model that just
+  failed. Real, pre-existing, and out of scope — noted so it is not mistaken for
+  fixed.
+- Master's hand-rolled `^model:` loops in `tests/test-model-tiers.sh` §1–3 are not
+  collapsed onto the new helpers. The refactor is available but would make this
+  diff read as a rewrite of #53's test rather than an extension.
+- `code-reviewer`, `security-reviewer` get no floor. Only `critic` needs one.
+
+## Edge Cases
+
+- **A Haiku session.** `code-reviewer`, `security-reviewer`, and the design
+  reviewer run on Haiku. Accepted: Ceiling means the session's choice governs, and
+  a user on Haiku chose cheap. `critic` is the exception, by floor.
+- **Someone re-pins a Ceiling role.** `tests/test-model-tiers.sh` fails, in both
+  the agent file and the routing tables. Verified by probing each.
+- **The floor is unenforceable.** Stated in `CLAUDE.md` and in this spec.
+- **Pi cannot express a floor declaratively.** `agentOverrides` omits `critic`, so
+  it inherits; a user on a sub-planner Pi session pins it manually. Documented in
+  `PI_SETUP.md`.
+- **Markdown reflow.** Prose assertions use `assert_prose_contains`, so rewrapping
+  a paragraph does not break the suite.
+
+## Acceptance Criteria
+
+- [x] All four review roles resolve to a Ceiling variant in `CLAUDE.md` and `/build`
+- [x] `.claude/agents/` pins no model for any of the four
+- [x] The six non-Ceiling personas keep their pins (guards a blanket strip)
+- [x] `critic`'s floor is stated as a dispatch rule, and the test fails if the rule is deleted
+- [x] No concrete provider model ID remains in `CLAUDE.md` or either `/build` copy
+- [x] `PI_SETUP.md` claims single-source ownership and explains Ceiling
+- [x] `PI_SETUP.md`'s `agentOverrides` no longer contradicts `CLAUDE.md`
+- [x] No skill routes the design reviewer to a concrete model
+- [x] `assert_not_contains` fails on an empty haystack, with no sibling test broken
+- [x] `tests/test-skill-parity.sh` green over every edited skill
+- [x] `bash tests/run.sh` green — 15 files, 1079 assertions
+
+## Non-Goals
+
+- No change to the Ceiling tier's definition or rationale — #53 owns those.
+- No floors beyond `critic`.
+- No fix for the debugger 3–4 escalation no-op.
+- No refactor of #53's existing test loops.

--- a/specs/model-tier-ceiling-gaps.md
+++ b/specs/model-tier-ceiling-gaps.md
@@ -13,18 +13,28 @@ things remained.
 
 ### 1. `software-design-expert-review` joins Ceiling
 
-#53 left it at Reviewer tier (`sonnet`) with an explicit rationale — its own skill
-read *"`model: sonnet` — Reviewer tier, not Ceiling"* — and `tests/test-model-tiers.sh`
-asserted the pin via `PINNED_AGENTS`.
+The decision this reverses was **#55's, not #53's** (`git log -S"Reviewer tier, not
+Ceiling"` → `a798ce0`). #55 shipped two PRs after Ceiling already existed and wrote
+*"`model: sonnet` — Reviewer tier, not Ceiling"* deliberately, with the tier
+available; `tests/test-model-tiers.sh` then asserted the pin via `PINNED_AGENTS`.
+So this is a reversal of an informed choice, not the completion of an unfinished
+one — which is a higher bar.
 
 **This spec overrides that decision.** An APOSD structural audit is correctness
 work: the defects it finds are the expensive kind, and a design flaw caught late
-costs far more than the token difference. It is the one change here that reverses
-a documented choice rather than completing an unfinished one, so it is the one
-most worth a reviewer's pushback.
+costs far more than the token difference.
 
-`PINNED_AGENTS` keeps a subject — `context-document-optimizer`, also Reviewer
-tier — so the mirror guard #53 added does not go vacuous. That guard protects a
+**The cost is not a flat token difference, and that is the honest counterargument.**
+Unlike the other three Ceiling roles — each dispatched once per run — this agent is
+dispatched *per changed file* at ≥5 files, and its own skill discourages batching
+("Batching files therefore trades corroboration for tool calls"). So Ceiling
+multiplies top-tier spend by the file count, not by one. A 20-file PR on an Opus
+session means ~20 Opus dispatches for design review alone against 4 for everything
+else combined. Whether that is worth it is a spend judgment, not a correctness one,
+and it is the delta most worth dropping if the answer is no.
+
+`PINNED_AGENTS` keeps a subject — `context-document-optimizer` — so the mirror
+guard #53 added does not go vacuous. That guard protects a
 real observed regression: the `.agents/` → `.claude/` parity copy is a plain `cp`
 from a tree that is model-agnostic by contract, so it silently drops a
 Claude-only `model:` line, and parity tests cannot catch it because the `cp` is
@@ -56,9 +66,16 @@ stale, and the two tables are the copies nobody updates.
 `PI_SETUP.md` § Sub-Agent Routing becomes the named single source. Both tables
 carry tiers only.
 
-This also reconciles a contradiction #53 introduced: `CLAUDE.md` gained the rule
-*"leave ceiling-tier agents out of `agentOverrides` so they inherit"* while
-`PI_SETUP.md`'s example config went on pinning all four of them.
+It also corrects a #53 rule that was simply wrong: `CLAUDE.md` said *"leave
+ceiling-tier agents out of `agentOverrides` so they inherit"*. On Pi, omitting an
+agent falls through to `subagents.defaultModel` — a fixed builder-tier model — so
+omission there **downgrades** rather than inherits. Ceiling-by-omission is a
+Claude Code property. Pi expresses the same intent with explicit pins, and `critic`
+pins to the planner model because a static config cannot make a floor conditional.
+
+This was found only because a review challenged it; the first version of this
+branch deleted those four Pi entries and would have had every Pi user's code
+reviewed by the model family that wrote it.
 
 ### 4. `assert_not_contains` no longer passes vacuously
 
@@ -102,9 +119,9 @@ Read from disk on current `master` (`7c3dc74`), not assumed:
 | `.claude/agents/software-design-expert-review.md` | delete the `model:` line |
 | `.agents/skills/build/SKILL.md` + `.claude/` copy | Tier column replaces Model ID column; ladder and circuit breaker name tiers |
 | `.agents/skills/{quality-gate,software-design-expert-review}/SKILL.md` + copies | dispatch at Ceiling, no `model` |
-| `PI_SETUP.md` | named single source; Ceiling row; four roles removed from `agentOverrides` with the reason |
+| `PI_SETUP.md` | named single source; Ceiling rows; the four Pi pins **kept**, with why omission downgrades on Pi |
 | `tests/lib.sh` | empty-haystack guard; `assert_file_matches`, `assert_file_not_matches`, `assert_prose_contains` |
-| `tests/test-model-tiers.sh` | `CEILING_AGENTS` gains the design reviewer; `PINNED_AGENTS` → `context-document-optimizer`; sections 6–8 added |
+| `tests/test-model-tiers.sh` | `CEILING_AGENTS` gains the design reviewer; `PINNED_AGENTS` → `context-document-optimizer`; sections 6–11 added |
 
 ### Unchanged, deliberately
 
@@ -125,9 +142,9 @@ Read from disk on current `master` (`7c3dc74`), not assumed:
 - **Someone re-pins a Ceiling role.** `tests/test-model-tiers.sh` fails, in both
   the agent file and the routing tables. Verified by probing each.
 - **The floor is unenforceable.** Stated in `CLAUDE.md` and in this spec.
-- **Pi cannot express a floor declaratively.** `agentOverrides` omits `critic`, so
-  it inherits; a user on a sub-planner Pi session pins it manually. Documented in
-  `PI_SETUP.md`.
+- **Pi cannot express a floor declaratively.** So `critic` is pinned to the planner
+  model unconditionally on Pi — the floor is satisfied at all times rather than
+  conditionally. Documented in `PI_SETUP.md`.
 - **Markdown reflow.** Prose assertions use `assert_prose_contains`, so rewrapping
   a paragraph does not break the suite.
 
@@ -143,7 +160,10 @@ Read from disk on current `master` (`7c3dc74`), not assumed:
 - [x] No skill routes the design reviewer to a concrete model
 - [x] `assert_not_contains` fails on an empty haystack, with no sibling test broken
 - [x] `tests/test-skill-parity.sh` green over every edited skill
-- [x] `bash tests/run.sh` green — 15 files, 1079 assertions
+- [x] critic's floor is stated at every site that dispatches critic, not only in `CLAUDE.md`
+- [x] Pi keeps explicit review pins; the test fails if any is deleted
+- [x] Seven mutations that previously stayed green now fail (2–10 assertions each)
+- [x] `bash tests/run.sh` green
 
 ## Non-Goals
 

--- a/specs/model-tier-ceiling-gaps.md
+++ b/specs/model-tier-ceiling-gaps.md
@@ -1,14 +1,15 @@
 # Spec: Close the gaps the Ceiling tier left open
 
 > Follows PR #53, which shipped the Ceiling tier. This spec covers three things
-> #53 named but did not finish, plus a test-harness hole found while verifying
-> them. It is deliberately narrow: the Ceiling tier itself, its rationale, and its
+> #53 named but did not finish, a test-harness hole found while verifying them,
+> and a pre-existing escalation-ladder no-op the same analysis exposed. It is
+> deliberately narrow: the Ceiling tier itself, its rationale, and its
 > `CLAUDE.md` vocabulary are #53's and are not restated here.
 
 ## Behavior
 
 `Ceiling` means "omit the `model` override so the sub-agent inherits the session
-model". #53 established the tier and applied it to three review roles. Four
+model". #53 established the tier and applied it to three review roles. Five
 things remained.
 
 ### 1. `software-design-expert-review` joins Ceiling
@@ -115,23 +116,33 @@ Read from disk on current `master` (`7c3dc74`), not assumed:
 
 | Path | Change |
 |------|--------|
-| `CLAUDE.md` | design reviewer → `*ceiling*`; `critic` → `*ceiling (planner floor)*`; floor rule added; Pi column dropped, pointer added; Ceiling row covers design |
+| `CLAUDE.md` | design reviewer → `*ceiling*`; `critic` → `*ceiling (planner floor)*`; a generalized `### Floors` section covering both floor-carrying roles; Pi column dropped, pointer added; Ceiling row covers design |
 | `.claude/agents/software-design-expert-review.md` | delete the `model:` line |
-| `.agents/skills/build/SKILL.md` + `.claude/` copy | Tier column replaces Model ID column; ladder and circuit breaker name tiers |
+| `.agents/skills/build/SKILL.md` + `.claude/` copy | Tier column replaces Model ID column; ladder and circuit breaker name tiers; debugger attempts 3–4 → `ceiling (builder floor)`, plus the no-collapsed-rung invariant |
 | `.agents/skills/{quality-gate,software-design-expert-review}/SKILL.md` + copies | dispatch at Ceiling, no `model` |
 | `PI_SETUP.md` | named single source; Ceiling rows; the four Pi pins **kept**, with why omission downgrades on Pi |
 | `tests/lib.sh` | empty-haystack guard; `assert_file_matches`, `assert_file_not_matches`, `assert_prose_contains` |
-| `tests/test-model-tiers.sh` | `CEILING_AGENTS` gains the design reviewer; `PINNED_AGENTS` → `context-document-optimizer`; sections 6–11 added |
+| `tests/test-model-tiers.sh` | `CEILING_AGENTS` gains the design reviewer; `PINNED_AGENTS` → `context-document-optimizer`; sections 6–12 added; §1–3 collapsed onto the new helpers |
+
+### 5. Debugger attempts 3–4 gain a builder floor
+
+Deferred once as out of scope, then pulled in on review. `/build`'s regression
+ladder is 2 attempts at builder tier → 2 at reviewer tier → circuit breaker. On
+Claude Code **Reviewer and Builder both resolve to `sonnet`**, because there is
+no alias between them, so the middle rung re-ran the exact model that had just
+failed twice: three documented rungs, two real ones, and the first genuine
+escalation arriving four attempts later than the ladder claims.
+
+Resolution becomes `ceiling (builder floor)` — the same notation `critic`
+already uses, rather than a second mechanism. A flat `opus` would fix Claude
+Code and reintroduce the cap this whole spec removes on any stronger session.
+
+`/build` also gains the invariant behind it: steps 1 and 2 must never resolve to
+the same model. The row alone reads as an arbitrary choice and gets simplified
+back; the rule explains why it cannot be.
 
 ### Unchanged, deliberately
 
-- Debugger attempts 3–4 stay at Reviewer/`sonnet`. Identical to attempts 1–2, so
-  on Claude Code the escalation ladder still escalates to the model that just
-  failed. Real, pre-existing, and out of scope — noted so it is not mistaken for
-  fixed.
-- Master's hand-rolled `^model:` loops in `tests/test-model-tiers.sh` §1–3 are not
-  collapsed onto the new helpers. The refactor is available but would make this
-  diff read as a rewrite of #53's test rather than an extension.
 - `code-reviewer`, `security-reviewer` get no floor. Only `critic` needs one.
 
 ## Edge Cases
@@ -162,12 +173,14 @@ Read from disk on current `master` (`7c3dc74`), not assumed:
 - [x] `tests/test-skill-parity.sh` green over every edited skill
 - [x] critic's floor is stated at every site that dispatches critic, not only in `CLAUDE.md`
 - [x] Pi keeps explicit review pins; the test fails if any is deleted
+- [x] Debugger attempts 3–4 resolve to `ceiling (builder floor)` in `CLAUDE.md` and both `/build` copies, and the test fails if the rung collapses back onto builder tier
+- [x] `tests/test-model-tiers.sh` §1–3 use the shared helpers rather than hand-rolled `grep` plus raw counter arithmetic
 - [x] Seven mutations that previously stayed green now fail (2–10 assertions each)
 - [x] `bash tests/run.sh` green
 
 ## Non-Goals
 
 - No change to the Ceiling tier's definition or rationale — #53 owns those.
-- No floors beyond `critic`.
-- No fix for the debugger 3–4 escalation no-op.
-- No refactor of #53's existing test loops.
+- No floors beyond `critic` and the debugger's escalation rung.
+- No change to the ladder's *shape* — still 2 + 2 + circuit breaker. Only what
+  the second pair resolves to changes.

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -17,6 +17,18 @@ assert_contains() {
 # assert_not_contains <haystack> <needle> <message>
 assert_not_contains() {
   _TESTS=$((_TESTS + 1))
+  # An empty haystack fails rather than passing. Absence-of-needle is trivially
+  # true of the empty string, so a grep or sed extraction that matched nothing
+  # would otherwise report "ok" and turn a load-bearing check into a silent pass.
+  # Closed here because the hazard is structural: leaving it to each caller to
+  # check its own extraction is the discipline whose absence causes the bug.
+  # (assert_contains needs no such guard — an empty haystack cannot contain a
+  # non-empty needle, so it already fails.)
+  if [ -z "$1" ]; then
+    _FAILS=$((_FAILS + 1))
+    printf '  FAIL %s\n       haystack empty — the extraction found nothing to check\n' "$3"
+    return
+  fi
   case "$1" in
     *"$2"*) _FAILS=$((_FAILS + 1)); printf '  FAIL %s\n       expected NOT to contain: %s\n' "$3" "$2" ;;
     *) printf '  ok   %s\n' "$3" ;;
@@ -30,6 +42,34 @@ assert_file_contains() {
     printf '  ok   %s\n' "$3"
   else
     _FAILS=$((_FAILS + 1)); printf '  FAIL %s\n       file %s missing or lacks: %s\n' "$3" "$1" "$2"
+  fi
+}
+
+# assert_file_matches <file> <regex> <message>
+# Regex counterpart to assert_file_contains, which is literal-only (grep -qF).
+# Without it, a caller needing an anchored pattern such as '^model:' hand-rolls
+# grep plus raw _TESTS/_FAILS arithmetic — duplicating the counting logic and
+# reaching past this file's function interface.
+assert_file_matches() {
+  _TESTS=$((_TESTS + 1))
+  if [ -f "$1" ] && grep -qE -- "$2" "$1"; then
+    printf '  ok   %s\n' "$3"
+  else
+    _FAILS=$((_FAILS + 1)); printf '  FAIL %s\n       file %s missing or lacks pattern: %s\n' "$3" "$1" "$2"
+  fi
+}
+
+# assert_file_not_matches <file> <regex> <message>
+# A missing file fails: absence of the pattern is not a pass when there was
+# nothing to search, for the same reason assert_not_contains rejects empty input.
+assert_file_not_matches() {
+  _TESTS=$((_TESTS + 1))
+  if [ ! -f "$1" ]; then
+    _FAILS=$((_FAILS + 1)); printf '  FAIL %s\n       file %s is missing\n' "$3" "$1"
+  elif grep -qE -- "$2" "$1"; then
+    _FAILS=$((_FAILS + 1)); printf '  FAIL %s\n       file %s unexpectedly matches: %s\n' "$3" "$1" "$2"
+  else
+    printf '  ok   %s\n' "$3"
   fi
 }
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -45,6 +45,27 @@ assert_file_contains() {
   fi
 }
 
+# assert_prose_contains <file> <phrase> <message>
+# Matches a phrase across line wraps. Markdown prose here is hard-wrapped, so a
+# literal grep for a phrase that happens to straddle a newline fails for a reason
+# unrelated to the assertion's intent -- and picking a needle that fits on one
+# line just defers the problem to the next reflow. Collapses all whitespace in
+# both haystack and needle to single spaces before comparing.
+assert_prose_contains() {
+  _TESTS=$((_TESTS + 1))
+  if [ ! -f "$1" ]; then
+    _FAILS=$((_FAILS + 1)); printf '  FAIL %s\n       file %s is missing\n' "$3" "$1"
+    return
+  fi
+  _hay="$(tr -s '[:space:]' ' ' < "$1")"
+  _need="$(printf '%s' "$2" | tr -s '[:space:]' ' ')"
+  case "$_hay" in
+    *"$_need"*) printf '  ok   %s\n' "$3" ;;
+    *) _FAILS=$((_FAILS + 1))
+       printf '  FAIL %s\n       file %s lacks prose: %s\n' "$3" "$1" "$2" ;;
+  esac
+}
+
 # assert_file_matches <file> <regex> <message>
 # Regex counterpart to assert_file_contains, which is literal-only (grep -qF).
 # Without it, a caller needing an anchored pattern such as '^model:' hand-rolls

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -112,8 +112,8 @@ done
 # phrase also appears in the Agents table cell, so a looser needle stayed green
 # even with the whole explanation deleted. Verified by deleting it: 0 failures
 # before this was tightened.
-assert_file_contains CLAUDE.md "dispatch rule, not frontmatter"   "ModelTier: CLAUDE.md explains critic's floor as a dispatch rule"
-assert_file_contains CLAUDE.md "never resolves below planner tier"   "ModelTier: CLAUDE.md states what critic's floor bounds"
+assert_prose_contains CLAUDE.md "dispatch rule, not frontmatter"   "ModelTier: CLAUDE.md explains critic's floor as a dispatch rule"
+assert_prose_contains CLAUDE.md "never resolves below planner tier"   "ModelTier: CLAUDE.md states what critic's floor bounds"
 assert_file_matches CLAUDE.md '^\| .critic. \| .?ceiling \(planner floor\)'   "ModelTier: CLAUDE.md Agents table marks critic ceiling (planner floor)"
 
 # --- 7. No concrete provider model IDs in the routing docs -------------------

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -15,7 +15,7 @@
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
 
-CEILING_AGENTS="code-reviewer security-reviewer critic"
+CEILING_AGENTS="code-reviewer security-reviewer software-design-expert-review critic"
 
 # Reviewer-tier personas that MUST keep their Claude-side pin. This is the mirror
 # of the ceiling assertion and it guards a real, already-observed regression: the
@@ -23,7 +23,7 @@ CEILING_AGENTS="code-reviewer security-reviewer critic"
 # model-agnostic by contract, so copying over a Claude-only `model:` line drops it
 # silently. Parity tests cannot catch it -- the `cp` is what made the two files
 # identical. Pin the line itself.
-PINNED_AGENTS="software-design-expert-review:sonnet"
+PINNED_AGENTS="context-document-optimizer:sonnet"
 
 # --- 1. Ceiling agents carry no model pin in the Claude Code tree -------------
 for agent in $CEILING_AGENTS; do
@@ -99,6 +99,33 @@ for f in CLAUDE.md .agents/skills/build/SKILL.md .claude/skills/build/SKILL.md; 
     else
       assert_eq "unpinned" "unpinned" "ModelTier: $f does not pin $agent in a table"
     fi
+  done
+done
+
+# --- 6. critic never resolves below planner tier ------------------------------
+# Plain ceiling downgrades critic on a sub-planner session, and critic is the
+# adversarial gate of last resort. The floor is a dispatch rule, not frontmatter:
+# a `model: opus` pin would cap the agent at Opus rather than floor it, which is
+# the defect the ceiling tier exists to remove. So the rule text is what gets
+# pinned here, alongside the no-pin assertion above.
+assert_file_contains CLAUDE.md "planner floor"   "ModelTier: CLAUDE.md states critic's planner floor"
+assert_file_matches CLAUDE.md '^\| .critic. \| .?ceiling \(planner floor\)'   "ModelTier: CLAUDE.md Agents table marks critic ceiling (planner floor)"
+
+# --- 7. No concrete provider model IDs in the routing docs -------------------
+# PI_SETUP.md owns them. Three copies of a release-sensitive fact is three
+# chances to go stale, and the tables are the copies nobody updates.
+for f in CLAUDE.md .agents/skills/build/SKILL.md .claude/skills/build/SKILL.md; do
+  for vendor in 'moonshotai/' 'qwen/' 'z-ai/' 'deepseek/' 'anthropic/claude'; do
+    assert_file_not_matches "$f" "$vendor" "ModelTier: $f has no hardcoded $vendor ID"
+  done
+  assert_file_contains "$f" 'PI_SETUP.md` § Sub-Agent Routing'     "ModelTier: $f points at PI_SETUP.md for concrete IDs"
+done
+assert_file_contains PI_SETUP.md "single source of concrete model IDs"   "ModelTier: PI_SETUP.md claims ownership of the concrete IDs"
+
+# --- 8. No skill routes the design reviewer to a concrete model --------------
+for tree in .agents .claude; do
+  for skill in quality-gate software-design-expert-review; do
+    assert_file_not_matches "$tree/skills/$skill/SKILL.md" 'model: .?sonnet'       "ModelTier: $tree $skill no longer pins the design reviewer"
   done
 done
 

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -108,13 +108,18 @@ done
 # a `model: opus` pin would cap the agent at Opus rather than floor it, which is
 # the defect the ceiling tier exists to remove. So the rule text is what gets
 # pinned here, alongside the no-pin assertion above.
-# Assert on prose unique to the *rule*, not on the phrase "planner floor" -- that
-# phrase also appears in the Agents table cell, so a looser needle stayed green
-# even with the whole explanation deleted. Verified by deleting it: 0 failures
-# before this was tightened.
-assert_prose_contains CLAUDE.md "dispatch rule, not frontmatter"   "ModelTier: CLAUDE.md explains critic's floor as a dispatch rule"
-assert_prose_contains CLAUDE.md "never resolves below planner tier"   "ModelTier: CLAUDE.md states what critic's floor bounds"
-assert_file_matches CLAUDE.md '^\| .critic. \| .?ceiling \(planner floor\)'   "ModelTier: CLAUDE.md Agents table marks critic ceiling (planner floor)"
+#
+# The needles are prose unique to the *rule*, not the phrase "planner floor" --
+# that phrase also appears in the Agents table cell, so a looser needle stayed
+# green even with the whole explanation deleted (verified: 0 failures before this
+# was tightened). assert_prose_contains rather than assert_file_contains because
+# CLAUDE.md hard-wraps, and one of these phrases straddles a line break.
+assert_prose_contains CLAUDE.md "dispatch rule, not frontmatter" \
+  "ModelTier: CLAUDE.md explains critic's floor as a dispatch rule"
+assert_prose_contains CLAUDE.md "never resolves below planner tier" \
+  "ModelTier: CLAUDE.md states what critic's floor bounds"
+assert_file_matches CLAUDE.md '^\| .critic. \| .?ceiling \(planner floor\)' \
+  "ModelTier: CLAUDE.md Agents table marks critic ceiling (planner floor)"
 
 # --- 7. No concrete provider model IDs in the routing docs -------------------
 # PI_SETUP.md owns them. Three copies of a release-sensitive fact is three
@@ -123,14 +128,17 @@ for f in CLAUDE.md .agents/skills/build/SKILL.md .claude/skills/build/SKILL.md; 
   for vendor in 'moonshotai/' 'qwen/' 'z-ai/' 'deepseek/' 'anthropic/claude'; do
     assert_file_not_matches "$f" "$vendor" "ModelTier: $f has no hardcoded $vendor ID"
   done
-  assert_file_contains "$f" 'PI_SETUP.md` § Sub-Agent Routing'     "ModelTier: $f points at PI_SETUP.md for concrete IDs"
+  assert_file_contains "$f" 'PI_SETUP.md` § Sub-Agent Routing' \
+    "ModelTier: $f points at PI_SETUP.md for concrete IDs"
 done
-assert_file_contains PI_SETUP.md "single source of concrete model IDs"   "ModelTier: PI_SETUP.md claims ownership of the concrete IDs"
+assert_file_contains PI_SETUP.md "single source of concrete model IDs" \
+  "ModelTier: PI_SETUP.md claims ownership of the concrete IDs"
 
 # --- 8. No skill routes the design reviewer to a concrete model --------------
 for tree in .agents .claude; do
   for skill in quality-gate software-design-expert-review; do
-    assert_file_not_matches "$tree/skills/$skill/SKILL.md" 'model: .?sonnet'       "ModelTier: $tree $skill no longer pins the design reviewer"
+    assert_file_not_matches "$tree/skills/$skill/SKILL.md" 'model: .?sonnet' \
+      "ModelTier: $tree $skill no longer pins the design reviewer"
   done
 done
 

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -26,20 +26,12 @@ CEILING_AGENTS="code-reviewer security-reviewer software-design-expert-review cr
 PINNED_AGENTS="context-document-optimizer:sonnet"
 
 # --- 1. Ceiling agents carry no model pin in the Claude Code tree -------------
+# assert_file_not_matches covers both failure modes this used to hand-roll: a
+# missing file and a present pin. It also treats a missing file as a failure
+# rather than a skip, which is what the hand-rolled version did.
 for agent in $CEILING_AGENTS; do
-  f=".claude/agents/$agent.md"
-  if [ ! -f "$f" ]; then
-    _TESTS=$((_TESTS + 1)); _FAILS=$((_FAILS + 1))
-    printf '  FAIL ModelTier: %s is missing\n' "$f"
-    continue
-  fi
-  if grep -qE '^model:' "$f"; then
-    _TESTS=$((_TESTS + 1)); _FAILS=$((_FAILS + 1))
-    printf '  FAIL ModelTier: %s pins a model (%s) — ceiling agents must inherit\n' \
-      "$f" "$(grep -m1 -E '^model:' "$f")"
-  else
-    assert_eq "unpinned" "unpinned" "ModelTier: $agent inherits the session model"
-  fi
+  assert_file_not_matches ".claude/agents/$agent.md" '^model:' \
+    "ModelTier: $agent inherits the session model (no pin)"
 done
 
 # --- 1b. Reviewer-tier agents keep their Claude-side model pin ----------------
@@ -56,21 +48,20 @@ done
 for f in .agents/agents/*.md; do
   [ -f "$f" ] || continue
   case "$(basename "$f")" in README.md) continue ;; esac
-  if grep -qE '^model:' "$f"; then
-    _TESTS=$((_TESTS + 1)); _FAILS=$((_FAILS + 1))
-    printf '  FAIL ModelTier: canonical %s pins a model\n' "$f"
-  else
-    assert_eq "agnostic" "agnostic" "ModelTier: canonical $(basename "$f") is model-agnostic"
-  fi
+  assert_file_not_matches "$f" '^model:' \
+    "ModelTier: canonical $(basename "$f") is model-agnostic"
 done
 
 # --- 3. Non-ceiling agents still resolve to a tier ---------------------------
 # Guards the opposite mistake: stripping every pin, which would silently promote
 # cheap roles to the session model and inflate cost.
+# The [ -f ] guard is kept deliberately: `scout-unused` names no real file, so
+# this loop skips absent personas rather than failing on them — unlike section 1,
+# where every named agent must exist.
 for agent in backend-developer frontend-developer code-debugger scout-unused; do
   f=".claude/agents/$agent.md"
   [ -f "$f" ] || continue
-  assert_eq "pinned" "$(grep -qE '^model:' "$f" && echo pinned || echo unpinned)" \
+  assert_file_matches "$f" '^model:' \
     "ModelTier: non-ceiling $agent still pins a tier model"
 done
 
@@ -177,5 +168,30 @@ assert_prose_contains PI_SETUP.md "Ceiling cannot be expressed by omission on Pi
   "ModelTier: PI_SETUP.md explains why Pi pins rather than omits"
 assert_prose_contains CLAUDE.md "falls through to \`subagents.defaultModel\`" \
   "ModelTier: CLAUDE.md states the Pi omission hazard"
+
+# --- 12. The debugger escalation ladder has a real middle rung ----------------
+# Reviewer and Builder both resolve to `sonnet` on Claude Code, so a debugger
+# escalation written as plain reviewer tier re-runs the model that just failed
+# twice: the ladder documents three rungs and delivers two. That is invisible at
+# runtime — the retries happen, they just cannot succeed for a new reason — so it
+# needs a mechanical guard. Both the resolution and the rule forbidding a
+# collapsed rung are pinned, because the row alone reads as an arbitrary choice
+# and gets "simplified" back.
+for f in .agents/skills/build/SKILL.md .claude/skills/build/SKILL.md; do
+  assert_file_matches "$f" '^\| Debugger \(attempts 3-4.*ceiling \(builder floor\)' \
+    "ModelTier: $f routes debugger attempts 3-4 to ceiling (builder floor)"
+  assert_prose_contains "$f" "must never resolve to the same model" \
+    "ModelTier: $f forbids a ladder whose first two rungs collapse"
+  assert_prose_contains "$f" "Confirm it resolved to something stronger than Tier 1" \
+    "ModelTier: $f makes the circuit breaker's Tier 2 check its own escalation"
+done
+assert_prose_contains CLAUDE.md "Reviewer and Builder both resolve to" \
+  "ModelTier: CLAUDE.md names why the reviewer rung collapsed on Claude Code"
+# Prose rather than regex: the phrase carries an en dash and an em dash, and a
+# multibyte character does not match `.` under grep -E in the C locale.
+assert_prose_contains CLAUDE.md 'Debugger attempts 3–4 — `ceiling (builder floor)`' \
+  "ModelTier: CLAUDE.md documents the debugger's builder floor"
+assert_file_matches CLAUDE.md '^\| Reviewer \|.*see the floor below' \
+  "ModelTier: CLAUDE.md Reviewer row points at the floor rather than reading as flat sonnet"
 
 finish

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -108,7 +108,12 @@ done
 # a `model: opus` pin would cap the agent at Opus rather than floor it, which is
 # the defect the ceiling tier exists to remove. So the rule text is what gets
 # pinned here, alongside the no-pin assertion above.
-assert_file_contains CLAUDE.md "planner floor"   "ModelTier: CLAUDE.md states critic's planner floor"
+# Assert on prose unique to the *rule*, not on the phrase "planner floor" -- that
+# phrase also appears in the Agents table cell, so a looser needle stayed green
+# even with the whole explanation deleted. Verified by deleting it: 0 failures
+# before this was tightened.
+assert_file_contains CLAUDE.md "dispatch rule, not frontmatter"   "ModelTier: CLAUDE.md explains critic's floor as a dispatch rule"
+assert_file_contains CLAUDE.md "never resolves below planner tier"   "ModelTier: CLAUDE.md states what critic's floor bounds"
 assert_file_matches CLAUDE.md '^\| .critic. \| .?ceiling \(planner floor\)'   "ModelTier: CLAUDE.md Agents table marks critic ceiling (planner floor)"
 
 # --- 7. No concrete provider model IDs in the routing docs -------------------

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -134,12 +134,48 @@ done
 assert_file_contains PI_SETUP.md "single source of concrete model IDs" \
   "ModelTier: PI_SETUP.md claims ownership of the concrete IDs"
 
-# --- 8. No skill routes the design reviewer to a concrete model --------------
+# --- 8. No skill pins a Ceiling role to any alias -----------------------------
+# Any alias, not just sonnet. An alias-specific needle is trivially walked around
+# by naming a different one, which is how `model: opus` and `model: haiku`
+# mutations stayed green here.
 for tree in .agents .claude; do
-  for skill in quality-gate software-design-expert-review; do
-    assert_file_not_matches "$tree/skills/$skill/SKILL.md" 'model: .?sonnet' \
-      "ModelTier: $tree $skill no longer pins the design reviewer"
+  for skill in quality-gate software-design-expert-review wrap-up-session build plan; do
+    assert_file_not_matches "$tree/skills/$skill/SKILL.md" 'model: .?(sonnet|opus|haiku)' \
+      "ModelTier: $tree $skill pins no Ceiling role to an alias"
   done
 done
+
+# --- 9. No concrete provider ID anywhere in either skill tree ----------------
+# Section 7 names the two routing tables; this sweeps every skill, because a
+# hardcoded ID goes stale in a prose paragraph exactly as fast as in a table.
+for tree in .agents .claude; do
+  hits="$(grep -rlE 'moonshotai/|qwen/|z-ai/|deepseek/|anthropic/claude' "$tree/skills" 2>/dev/null || true)"
+  assert_eq "" "$hits" "ModelTier: no concrete provider model ID under $tree/skills"
+done
+
+# --- 10. critic's floor is stated where critic is dispatched ------------------
+# The floor lived only in CLAUDE.md while three skills instructed plain ceiling
+# unconditionally — documented and simultaneously negated. Pin it at the sites
+# that actually dispatch, or the rule is not shipped.
+for tree in .agents .claude; do
+  for skill in build plan wrap-up-session; do
+    assert_prose_contains "$tree/skills/$skill/SKILL.md" "planner floor" \
+      "ModelTier: $tree $skill states critic's planner floor at its dispatch"
+  done
+done
+
+# --- 11. Pi keeps explicit pins — omission there downgrades, not inherits -----
+# On Pi, omitting an agent from agentOverrides falls through to
+# subagents.defaultModel, a fixed builder-tier model. Deleting these entries
+# downgrades every review rather than lifting it. Both the config and the rule
+# explaining it are pinned, because the config alone reads as an oversight.
+for agent in code-reviewer security-reviewer software-design-expert-review critic; do
+  assert_file_matches PI_SETUP.md "\"$agent\":" \
+    "ModelTier: PI_SETUP.md keeps an explicit Pi pin for $agent"
+done
+assert_prose_contains PI_SETUP.md "Ceiling cannot be expressed by omission on Pi" \
+  "ModelTier: PI_SETUP.md explains why Pi pins rather than omits"
+assert_prose_contains CLAUDE.md "falls through to \`subagents.defaultModel\`" \
+  "ModelTier: CLAUDE.md states the Pi omission hazard"
 
 finish


### PR DESCRIPTION
Follows #53 (Ceiling tier) and #55. Three gaps, a test-harness hole found while verifying them, and a pre-existing escalation-ladder no-op the same analysis exposed.

Spec: `specs/model-tier-ceiling-gaps.md`.

## Read this first — the one delta worth arguing about

**`software-design-expert-review` moves to Ceiling, and that reverses a deliberate decision.** #55 wrote *"`model: sonnet` — Reviewer tier, not Ceiling"* with the Ceiling tier already available (`git log -S` → `a798ce0`). So this is not gap-closing, it is a reversal of an informed choice.

The counterargument, which adversarial review surfaced and I had missed: unlike the other three Ceiling roles — each dispatched **once** per run — this agent is dispatched **per changed file** at ≥5 files, and its own skill discourages batching. Ceiling therefore multiplies top-tier spend by the file count, not by one. A 20-file PR on an Opus session means ~20 Opus dispatches for design review alone against 4 for everything else combined.

That is a spend judgment, not a correctness one. **If the answer is "not worth it", drop this delta** — the other three stand independently. Alternative middle path: keep Ceiling but change `software-design-expert-review/SKILL.md` to batch once per run.

## The other three

**`critic` gains a planner floor.** Plain Ceiling inherits in every direction *including down*, so on a Builder- or Scout-tier session the adversarial gate of last resort ran below planner tier. The floor is a dispatch rule, not frontmatter — a `model: opus` pin would satisfy it on Sonnet but *cap* the agent on anything stronger, the exact defect Ceiling removes. Nothing mechanically enforces it; the test pins the rule text and the absence of a pin, and the spec says so rather than implying coverage.

**Concrete model IDs leave the routing tables.** They lived in three files; the two tables are the copies nobody updates. `PI_SETUP.md` § Sub-Agent Routing is now the named single source.

**`tests/lib.sh`: `assert_not_contains` no longer passes vacuously.** Absence-of-needle is trivially true of the empty string, so any grep/sed extraction that matched nothing reported `ok`. `assert_contains` needs no such guard, which is why the hole was one-sided. Verified against all 15 test files — no caller relied on it. Adds `assert_file_matches` / `assert_file_not_matches` (anchored patterns like `^model:`, which `grep -qF` cannot express) and `assert_prose_contains` (matches across markdown hard wraps).

## The debugger ladder gets a real middle rung

Both items previously listed here as deliberately-not-fixed are now fixed, at the reviewer's request.

`/build` escalates a stuck regression **2 attempts at builder tier → 2 at reviewer tier → circuit breaker**. On Claude Code **Reviewer and Builder both resolve to `sonnet`** — no alias sits between them — so the middle rung re-ran the exact model that had just failed twice. Three documented rungs, two real ones, and the first genuine escalation arriving four attempts later than the ladder claims. Invisible at runtime: the retries happen, they just cannot succeed for a new reason.

Attempts 3–4 now resolve to **`ceiling (builder floor)`** — the notation `critic` already uses, rather than a second mechanism. A flat `opus` would fix Claude Code and reintroduce on any stronger session the exact cap this branch exists to remove. `/build` also carries the invariant behind the row, because the row alone reads as an arbitrary choice and gets simplified back:

> Steps 1 and 2 must never resolve to the same model. If they do, the ladder has no middle rung and the first genuine escalation is the circuit breaker — four failed attempts later than intended.

Pi is unaffected: it already has a genuine three-model ladder.

**Test sections 1–3 are collapsed onto the new helpers.** The hand-rolled loops duplicated `_TESTS`/`_FAILS` arithmetic and reached past `lib.sh`'s function interface; they also treated a *missing* agent file as a skip, where `assert_file_not_matches` fails on it. §3 keeps its `[ -f ] || continue` deliberately — `scout-unused` names no real file, so that loop must skip absent personas.

## A regression this branch introduced and then reverted

The first version deleted the four review roles from `PI_SETUP.md`'s `agentOverrides`, reasoning that omission makes them inherit. **On Pi it does not.** `subagents.defaultModel` is `qwen/qwen3-coder-next`, three lines above that block, so omission falls through to a fixed *builder* model. That edit would have had every Pi user's code reviewed by the same model family that wrote it — a downgrade from `z-ai/glm-4.7`, destroying the different-model-family property `PI_SETUP.md`'s own Tier rationale advertises, and violating critic's new floor on every Pi session.

The root cause was upstream: #53's `CLAUDE.md` already said *"leave ceiling-tier agents out of `agentOverrides` so they inherit"*. That sentence is wrong for the same reason, so it is corrected here rather than propagated. **Ceiling-by-omission is a Claude Code property**; Pi expresses the same intent with explicit pins.

## Test rigor

Adversarial review found **seven mutations that defeated the branch's claims while the suite stayed green**. All now caught (2–10 failures each):

| Mutation | before | after |
|---|---|---|
| Re-pin design reviewer `model: opus` / `model: haiku` | green | 2 |
| Drop critic's Pi pin | green | 2 |
| Delete `CLAUDE.md`'s Pi hazard rule | green | 7 |
| Remove critic's floor from wrap-up / plan dispatch | green | 8 / 9 |
| Hardcode a vendor ID in `wrap-up-session` | green | 10 |

Root causes: the alias needle was `sonnet`-specific (walked around by naming another alias); the vendor sweep covered 3 files of ~30; nothing asserted the Pi config state or that critic's floor appeared where critic is dispatched.

Section 12 was probed the same way — collapse the ladder row back to `` `sonnet` ``, delete the no-collapsed-rung invariant, or delete `CLAUDE.md`'s floor paragraph, and the suite fails (1–2 assertions each).

## Also fixed from review

- `context-document-optimizer` was labelled `Reviewer | haiku` in the new Tier column — self-contradictory, since Reviewer is `sonnet`. It is Scout tier; my error in the column migration.
- `aefa2e3`'s message claimed 3 failures on floor deletion; the reproducible number is 2. Corrected in `1f65aae`.
- Generalizing critic's floor paragraph into a shared `### Floors` section dropped the sentence stating what critic's floor *bounds*; §6 caught it, and the bullet was restored rather than the needle loosened.

## Still deliberately unchanged

- `code-reviewer` and `security-reviewer` get no floor. Only `critic` and the debugger's escalation rung need one.
- The ladder's *shape* — 2 + 2 + circuit breaker — is untouched. Only what the second pair resolves to changes.

## Verification

- `bash tests/run.sh` → **15 files, 1108 assertions, green**
- `tests/test-model-tiers.sh` 91 assertions (82 before the ladder commit)
- `tests/test-skill-parity.sh` green over every edited skill (42 assertions)
- All `PI_SETUP.md` JSON blocks parse
- Each delta probed by reverting it and confirming the suite fails

**Not-tested:** Pi-side behavior — no Pi harness in this environment. The Pi claims are read from `PI_SETUP.md`'s own documented semantics, not executed. The builder floor is likewise a dispatch rule: nothing resolves it at runtime in a test, so the guard is static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
