### PR TITLE
feat: add Codex harness adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coding Agent Workflow
 
-A reusable, project-agnostic configuration system that enforces **spec-driven, TDD-first development** across all your projects — with persistent memory, specialized agents, and a structured session lifecycle. Works with Claude Code, Cursor, and other AI coding tools.
+A reusable, project-agnostic configuration system that enforces **spec-driven, TDD-first development** across all your projects — with persistent memory, specialized agents, and a structured session lifecycle. Works with Claude Code, Codex, Pi, Cursor, and other AI coding tools.
 
 ---
 
@@ -13,6 +13,40 @@ A reusable, project-agnostic configuration system that enforces **spec-driven, T
 | **Agents** (`.claude/agents/`) | 8 specialized subagents for planning, coding, review, debugging, security |
 | **Hooks** (`.claude/hooks/`) | Session start orientation + auto test runner on file save |
 | **Learning store** (`tasks/solutions/`) | Typed per-document learnings, grep-first retrieval, written via `/learn` |
+
+Codex uses the same canonical `.agents/` sources through the explicit adapter
+`bash scripts/install-codex.sh`; no Codex-specific project rules are required.
+
+## Codex Setup
+
+From the workflow repository, install the shared user-level configuration:
+
+```bash
+git clone <this-repo-url> ~/coding-agent-workflow
+cd ~/coding-agent-workflow
+bash scripts/install-codex.sh
+```
+
+The adapter installs skills in `~/.agents/skills/`, renders shared rules into
+`~/.codex/AGENTS.md`, converts canonical Markdown agents into
+`~/.codex/agents/*.toml`, and merges optional lifecycle hooks into
+`~/.codex/hooks.json`. Existing personal content is preserved and rerunning the
+command is idempotent. Review the hook commands with Codex's `/hooks` command
+before enabling them.
+
+For a non-default Codex directory, set `CODEX_HOME` before running the script.
+For an existing project, copy `project-template/AGENTS.md` alongside the
+existing project scaffold files. New `git init` repositories receive the
+neutral `AGENTS.md` seed automatically after the regular installer has set up
+the git template directory.
+
+Update all installed workflow artifacts with:
+
+```bash
+cd ~/coding-agent-workflow
+git pull
+bash scripts/install-codex.sh
+```
 
 ---
 
@@ -77,7 +111,8 @@ tasks/solutions/         ← typed learning store (schema in its README.md)
 tasks/history.md         ← session narrative log
 tasks/concepts.md        ← concept glossary (swept once by /memory-maintain, then accreted)
 specs/                   ← feature specification directory
-CLAUDE.md           ← project-specific overrides
+CLAUDE.md               ← Claude project-specific overrides
+AGENTS.md               ← harness-neutral project-specific overrides
 ```
 
 ### Layer 3 — `newproject` shell function
@@ -86,13 +121,13 @@ CLAUDE.md           ← project-specific overrides
 newproject() {
   local name="${1:?Usage: newproject <project-name>}"
   mkdir -p "$name" && cd "$name"
-  git init                        # triggers post-init hook → copies Claude scaffold
+  git init                        # triggers post-init hook → copies agent scaffold
   echo "# $name" > README.md
-  git add . && git commit -m "chore: init project with Claude workflow scaffold"
+  git add . && git commit -m "chore: init project with coding-agent scaffold"
 }
 ```
 
-Wraps `git init` (which triggers layer 2) and makes an initial commit. One command from zero to a fully scaffolded, Claude-ready project.
+Wraps `git init` (which triggers layer 2) and makes an initial commit. One command from zero to a scaffolded project that can be opened with Claude, Codex, Pi, or another supported harness.
 
 ### Optional — graphify code graph
 
@@ -135,6 +170,7 @@ cp -r ~/coding-agent-workflow/project-template/tasks/solutions tasks/
 cp ~/coding-agent-workflow/project-template/tasks/history.md tasks/
 cp ~/coding-agent-workflow/project-template/tasks/concepts.md tasks/
 cp ~/coding-agent-workflow/project-template/CLAUDE.md .
+cp ~/coding-agent-workflow/project-template/AGENTS.md .
 mkdir -p specs
 ```
 

--- a/codex/hooks/session_start.py
+++ b/codex/hooks/session_start.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Adapt the shared text SessionStart hook to Codex hook JSON."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    hook = Path(__file__).with_name("coding-agent-workflow-session-start.sh")
+    result = subprocess.run(
+        ["bash", str(hook)],
+        input=sys.stdin.buffer.read(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.stderr:
+        sys.stderr.buffer.write(result.stderr)
+    output = result.stdout.decode("utf-8", errors="replace").strip()
+    if output:
+        payload = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": output,
+            }
+        }
+        print(json.dumps(payload, ensure_ascii=False))
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/install.sh
+++ b/install.sh
@@ -284,6 +284,7 @@ copy_if_missing() {
 }
 
 copy_if_missing "CLAUDE.md"
+copy_if_missing "AGENTS.md"
 copy_if_missing ".ignore"
 copy_if_missing "tasks/todo.md"
 copy_if_missing "tasks/solutions/README.md"

--- a/project-template/AGENTS.md
+++ b/project-template/AGENTS.md
@@ -1,0 +1,14 @@
+# Project Instructions
+
+> Project-specific rules for this repository. Global workflow rules are
+> installed by the selected coding-agent harness.
+
+## Project Context
+
+**Name**: [project name]
+**Purpose**: [what this project does]
+**Stack**: [languages, frameworks, databases]
+
+## Project-Specific Rules
+
+<!-- Add rules that apply only to this project. -->

--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Install the harness-neutral workflow for Codex at user scope.
+#
+# This adapter is intentionally separate from install.sh: existing Claude Code,
+# Pi, and git-template installs keep their current behavior unless a user
+# explicitly runs this script.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
+RENDERER="$REPO_DIR/scripts/render-codex.py"
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/install-codex.sh
+
+Installs the workflow's harness-neutral skills, agents, shared rules, and
+optional lifecycle hooks for the current user. Set CODEX_HOME or AGENTS_HOME
+to test or use a non-default configuration directory.
+EOF
+}
+
+die() {
+  printf 'install-codex: %s\n' "$1" >&2
+  exit 1
+}
+
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; die "unknown option: $1" ;;
+  esac
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python)"
+else
+  die "Python 3 is required to render Codex agents and hooks"
+fi
+
+[ -f "$RENDERER" ] || die "missing renderer: $RENDERER"
+[ -d "$REPO_DIR/.agents/skills" ] || die "missing canonical skills: $REPO_DIR/.agents/skills"
+[ -d "$REPO_DIR/.agents/agents" ] || die "missing canonical agents: $REPO_DIR/.agents/agents"
+
+mkdir -p "$AGENTS_HOME/skills" "$CODEX_HOME/agents" "$CODEX_HOME/hooks"
+cp -r "$REPO_DIR/.agents/skills/." "$AGENTS_HOME/skills/"
+printf 'installed canonical skills in %s\n' "$AGENTS_HOME/skills"
+
+"$PYTHON_BIN" "$RENDERER" --global \
+  "$REPO_DIR/CLAUDE.md" "$CODEX_HOME/AGENTS.md"
+printf 'rendered shared workflow rules in %s\n' "$CODEX_HOME/AGENTS.md"
+
+"$PYTHON_BIN" "$RENDERER" --agents \
+  "$REPO_DIR/.agents/agents" "$CODEX_HOME/agents"
+printf 'rendered canonical agents in %s\n' "$CODEX_HOME/agents"
+
+cp "$REPO_DIR/.claude/hooks/session-start.sh" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-start.sh"
+cp "$REPO_DIR/.claude/hooks/pre-compact.sh" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-pre-compact.sh"
+cp "$REPO_DIR/.claude/hooks/session-stop.sh" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-end.sh"
+cp "$REPO_DIR/codex/hooks/session_start.py" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-start.py"
+chmod +x \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-start.sh" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-pre-compact.sh" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-end.sh" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-start.py"
+
+printf -v start_hook '%q %q' "$PYTHON_BIN" \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-start.py"
+printf -v compact_hook 'bash %q' \
+  "$CODEX_HOME/hooks/coding-agent-workflow-pre-compact.sh"
+printf -v end_hook 'bash %q' \
+  "$CODEX_HOME/hooks/coding-agent-workflow-session-end.sh"
+"$PYTHON_BIN" "$RENDERER" --merge-hooks "$CODEX_HOME/hooks.json" \
+  "$start_hook" "$compact_hook" "$end_hook"
+
+printf 'merged lifecycle hooks in %s\n' "$CODEX_HOME/hooks.json"
+printf 'Review installed hooks with /hooks before enabling them.\n'

--- a/scripts/render-codex.py
+++ b/scripts/render-codex.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Render the harness-neutral workflow into Codex user configuration."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import NoReturn, Optional
+
+BEGIN = "<!-- coding-agent-workflow:begin -->"
+END = "<!-- coding-agent-workflow:end -->"
+MANAGED = "# coding-agent-workflow:managed"
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"render-codex: {message}")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as stream:
+            temporary = Path(stream.name)
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def parse_value(raw: str) -> str:
+    value = raw.strip()
+    if value[:1] in {"'", '"'}:
+        try:
+            parsed = ast.literal_eval(value)
+        except (SyntaxError, ValueError) as exc:
+            fail(f"invalid frontmatter value: {value!r} ({exc})")
+        if not isinstance(parsed, str):
+            fail(f"frontmatter value is not text: {value!r}")
+        return parsed
+    return value
+
+
+def parse_agent(path: Path) -> tuple[str, str, str]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        fail(f"{path}: missing YAML frontmatter")
+    try:
+        end = next(index for index, line in enumerate(lines[1:], 1) if line.strip() == "---")
+    except StopIteration:
+        fail(f"{path}: unterminated YAML frontmatter")
+
+    fields: dict[str, str] = {}
+    for line in lines[1:end]:
+        if not line.strip():
+            continue
+        if ":" not in line:
+            fail(f"{path}: malformed frontmatter line: {line}")
+        key, value = line.split(":", 1)
+        fields[key.strip()] = parse_value(value)
+    for required in ("name", "description"):
+        if not fields.get(required):
+            fail(f"{path}: frontmatter requires {required}")
+
+    body_lines = lines[end + 1 :]
+    if body_lines and body_lines[0].strip() == "---":
+        try:
+            second_end = next(
+                index for index, line in enumerate(body_lines[1:], 1) if line.strip() == "---"
+            )
+        except StopIteration:
+            fail(f"{path}: unterminated secondary frontmatter")
+        body_lines = body_lines[second_end + 1 :]
+    body = "\n".join(body_lines).strip()
+    if not body:
+        fail(f"{path}: agent instructions are empty")
+    return fields["name"], fields["description"], body
+
+
+def render_global(source: Path, destination: Path) -> None:
+    source_text = source.read_text(encoding="utf-8")
+    marker = "## Session Start Checklist"
+    if marker not in source_text:
+        fail(f"{source}: shared rules marker not found")
+    body = source_text[source_text.index(marker) :]
+    body = "\n".join(line for line in body.splitlines() if not line.startswith("@"))
+    managed = (
+        f"{BEGIN}\n"
+        "# Shared Coding Agent Workflow\n"
+        "> Project-specific instructions belong in the project's AGENTS.md.\n\n"
+        f"{body.rstrip()}\n"
+        f"{END}\n"
+    )
+    existing = destination.read_text(encoding="utf-8") if destination.exists() else ""
+    if BEGIN in existing and END in existing:
+        before = existing.split(BEGIN, 1)[0]
+        after = existing.split(END, 1)[1].lstrip("\n")
+        result = before + managed + after
+    else:
+        result = existing.rstrip() + ("\n\n" if existing.strip() else "") + managed
+    write_text(destination, result)
+
+
+def render_agents(source_dir: Path, destination_dir: Path) -> None:
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    for source in sorted(source_dir.glob("*.md")):
+        if source.name == "README.md":
+            continue
+        name, description, instructions = parse_agent(source)
+        destination = destination_dir / f"{source.stem}.toml"
+        if destination.exists() and MANAGED not in destination.read_text(encoding="utf-8"):
+            print(f"kept personal agent: {destination}")
+            continue
+        content = (
+            f"{MANAGED}\n"
+            f"name = {json.dumps(name, ensure_ascii=False)}\n"
+            f"description = {json.dumps(description, ensure_ascii=False)}\n"
+            f"developer_instructions = {json.dumps(instructions, ensure_ascii=False)}\n"
+        )
+        write_text(destination, content)
+
+
+def merge_hooks(destination: Path, commands: list[str]) -> None:
+    if destination.exists():
+        try:
+            data = json.loads(destination.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            fail(f"{destination}: invalid JSON ({exc})")
+    else:
+        data = {}
+    if not isinstance(data, dict):
+        fail(f"{destination}: top-level JSON value must be an object")
+    hooks = data.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        fail(f"{destination}: hooks must be an object")
+    events = ("SessionStart", "PreCompact", "SessionEnd")
+    for event, command in zip(events, commands):
+        groups = hooks.setdefault(event, [])
+        if not isinstance(groups, list):
+            fail(f"{destination}: {event} must be an array")
+        registered = any(
+            isinstance(group, dict)
+            and any(
+                isinstance(hook, dict) and hook.get("command") == command
+                for hook in group.get("hooks", [])
+            )
+            for group in groups
+        )
+        if not registered:
+            groups.append({"hooks": [{"type": "command", "command": command}]})
+    write_text(destination, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--global", dest="global_args", nargs=2, metavar=("SOURCE", "DEST"))
+    parser.add_argument("--agents", dest="agents_args", nargs=2, metavar=("SOURCE", "DEST"))
+    parser.add_argument(
+        "--merge-hooks",
+        dest="hooks_args",
+        nargs=4,
+        metavar=("DEST", "SESSION_START", "PRE_COMPACT", "SESSION_END"),
+    )
+    args = parser.parse_args()
+    selected = [args.global_args, args.agents_args, args.hooks_args]
+    if sum(value is not None for value in selected) != 1:
+        parser.error("choose exactly one rendering operation")
+    if args.global_args:
+        render_global(Path(args.global_args[0]), Path(args.global_args[1]))
+    elif args.agents_args:
+        render_agents(Path(args.agents_args[0]), Path(args.agents_args[1]))
+    else:
+        merge_hooks(Path(args.hooks_args[0]), args.hooks_args[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/codex-harness-adapter.md
+++ b/specs/codex-harness-adapter.md
@@ -1,0 +1,53 @@
+# Codex Harness Adapter
+
+## Problem
+
+The workflow repository keeps skills and agent personas in a harness-neutral
+`.agents/` tree, but its installer currently provisions Claude Code and Pi
+directly. Codex users need an explicit, repeatable installation path that
+adapts those same sources to Codex's user-level configuration without copying
+Claude-only imports or overwriting personal configuration.
+
+## Design
+
+Add a standalone Bash entry point, `scripts/install-codex.sh`, plus a small
+stdlib Python renderer/merger used by it:
+
+- install `.agents/skills/` additively into `~/.agents/skills/`;
+- render the shared workflow rules into a managed block in
+  `${CODEX_HOME:-$HOME/.codex}/AGENTS.md`, omitting Claude import directives;
+- convert canonical Markdown agent definitions into Codex TOML files under
+  `${CODEX_HOME:-$HOME/.codex}/agents/`;
+- install optional lifecycle hook adapters and merge their registrations into
+  `${CODEX_HOME:-$HOME/.codex}/hooks.json` without removing existing hooks;
+- make reruns idempotent and preserve unrelated user content;
+- print the Codex hooks review step instead of silently trusting hooks.
+
+Add a neutral `project-template/AGENTS.md` seed and include it in the existing
+git-init scaffold. Update the README with the Codex install, project setup,
+and update paths. Do not change the default Claude/Pi installation flow or add
+project-specific rules, paths, services, or dependencies.
+
+## Acceptance Criteria
+
+1. A fresh isolated HOME can run `bash scripts/install-codex.sh` successfully
+   from outside the repository and receives skills, global AGENTS instructions,
+   agent TOMLs, hook scripts, and a valid hooks JSON file.
+2. The generated global AGENTS file contains the shared workflow rules, has no
+   Claude `@` imports, preserves pre-existing user text, and is idempotent.
+3. Every canonical Markdown agent with valid frontmatter produces a TOML file
+   with `name`, `description`, and `developer_instructions`; reruns update
+   workflow-managed files without deleting unrelated user agents.
+4. Hook registration preserves existing JSON keys and commands, adds each
+   adapter exactly once, and remains stable after a second installation.
+5. The project template seeds `AGENTS.md` alongside the existing Claude
+   project rules, and the scaffold installer copies it only when absent.
+6. Existing tests remain green and new tests cover isolation, preservation,
+   idempotence, rendering, and malformed-input failure behavior.
+
+## Non-goals
+
+- Replacing or redesigning the existing Claude/Pi adapters.
+- Automatically modifying project repositories during user-level Codex setup.
+- Installing or trusting hooks without the user's Codex review step.
+- Adding project-specific instructions to the upstream template.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -67,3 +67,20 @@
 - Completed: 8 tasks (M4 Tier 3.3 — glossary, bootstrap sweep, capture/prune hooks, guards, dogfood evidence)
 - Pending: 0 tasks
 - Carry-forward: stacked on unmerged `worktree-m3-typed-learning-store` — M3 PR merges first, then this branch's PR retargets/merges
+
+
+## Plan: Codex Harness Adapter
+> Spec: specs/codex-harness-adapter.md
+> Branch: agent/codex-harness-adapter-pr
+
+[x] TDD: `tests/test-codex-install.sh` covers isolated installation, personal-content preservation, valid rendered agents/hooks, and idempotence -> add the failing integration/static test
+[x] TDD: renderer tests cover shared AGENTS block, Markdown-agent-to-TOML conversion, and hooks JSON merge -> add the stdlib renderer/merger
+[x] TDD: Codex adapter installs canonical skills, agents, hooks, and managed global rules from any working directory -> add `scripts/install-codex.sh` and hook adapters
+[x] TDD: project scaffold test requires neutral `AGENTS.md` -> add template seed and copy it from the git `post-init` hook
+[x] TDD: documentation test requires Codex setup/update instructions and harness-neutral language -> update README and installer help text
+[x] Full validation: `bash tests/run.sh`, shell syntax checks, Python compile/parse checks, and security review of changed scripts
+
+## Session Summary — 2026-08-14
+- Completed: 6 tasks (Codex harness adapter, renderer, hooks, neutral project seed, docs, and validation)
+- Pending: 0
+- Carry-forward: review and merge the draft PR

--- a/tests/test-codex-install.sh
+++ b/tests/test-codex-install.sh
@@ -1,0 +1,133 @@
+# tests/test-codex-install.sh — isolated Codex adapter contract.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL="$REPO/scripts/install-codex.sh"
+RENDERER="$REPO/scripts/render-codex.py"
+
+assert_file_contains "$RENDERER" "coding-agent-workflow:begin" \
+  "renderer: managed global block marker exists"
+assert_file_contains "$INSTALL" "CODEX_HOME" \
+  "installer: supports CODEX_HOME override"
+assert_file_contains "$INSTALL" ".agents/skills/." \
+  "installer: installs canonical skills additively"
+assert_file_contains "$INSTALL" "Review installed hooks with /hooks" \
+  "installer: tells users to review hook registrations"
+assert_file_contains "$REPO/install.sh" 'copy_if_missing "AGENTS.md"' \
+  "git scaffold: copies neutral AGENTS.md"
+assert_file_contains "$REPO/project-template/AGENTS.md" "Project-Specific Rules" \
+  "project template: carries a neutral rules section"
+assert_file_contains "$REPO/README.md" "bash scripts/install-codex.sh" \
+  "README: documents the Codex adapter command"
+assert_file_contains "$REPO/README.md" "project-template/AGENTS.md" \
+  "README: documents the neutral project seed"
+
+BOX="$(mktemp -d)"
+HOME_DIR="$BOX/home"
+CODEX_HOME="$HOME_DIR/.codex"
+PROJECT="$BOX/project"
+mkdir -p "$HOME_DIR/.agents/skills/personal" "$CODEX_HOME/agents" "$PROJECT"
+printf 'personal skill\n' > "$HOME_DIR/.agents/skills/personal/SKILL.md"
+printf '# Personal Codex instructions\n' > "$CODEX_HOME/AGENTS.md"
+printf 'name = "personal-agent"\ndescription = "Keep me"\ndeveloper_instructions = "Do not remove me"\n' \
+  > "$CODEX_HOME/agents/personal-agent.toml"
+cat > "$CODEX_HOME/hooks.json" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      {"hooks": [{"type": "command", "command": "echo existing"}]}
+    ]
+  },
+  "userSetting": true
+}
+JSON
+
+( cd "$PROJECT" && HOME="$HOME_DIR" CODEX_HOME="$CODEX_HOME" bash "$INSTALL" ) \
+  > "$BOX/install.log" 2>&1
+
+assert_eq "present" "$([ -f "$HOME_DIR/.agents/skills/build/SKILL.md" ] && echo present || echo missing)" \
+  "install: canonical skills are available to Codex"
+assert_eq "present" "$([ -f "$CODEX_HOME/AGENTS.md" ] && echo present || echo missing)" \
+  "install: global AGENTS.md is created"
+assert_file_contains "$CODEX_HOME/AGENTS.md" "# Personal Codex instructions" \
+  "install: existing AGENTS content is preserved"
+assert_file_contains "$CODEX_HOME/AGENTS.md" "Session Start Checklist" \
+  "install: shared workflow rules are rendered"
+assert_not_contains "$(cat "$CODEX_HOME/AGENTS.md")" "@.claude/project.md" \
+  "install: Claude project import is not copied into Codex"
+assert_not_contains "$(cat "$CODEX_HOME/AGENTS.md")" "@CLAUDE.local.md" \
+  "install: Claude local import is not copied into Codex"
+assert_eq "present" "$([ -f "$CODEX_HOME/agents/planner.toml" ] && echo present || echo missing)" \
+  "install: canonical agents become Codex TOML"
+assert_eq "present" "$([ -f "$CODEX_HOME/agents/personal-agent.toml" ] && echo present || echo missing)" \
+  "install: unrelated personal agent is preserved"
+assert_eq "present" "$([ -f "$CODEX_HOME/hooks/coding-agent-workflow-session-start.py" ] && echo present || echo missing)" \
+  "install: SessionStart adapter is installed"
+assert_contains "$(cat "$BOX/install.log")" "Review installed hooks with /hooks" \
+  "install: hook trust remains an explicit user action"
+
+if python3 - "$CODEX_HOME" "$REPO" <<'PY'
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+codex_home = Path(sys.argv[1])
+repo = Path(sys.argv[2])
+agents = sorted((codex_home / "agents").glob("*.toml"))
+expected = sorted(p.stem for p in (repo / ".agents" / "agents").glob("*.md") if p.name != "README.md")
+assert [p.stem for p in agents if p.stem != "personal-agent"] == expected
+for path in agents:
+    data = tomllib.loads(path.read_text())
+    if path.stem != "personal-agent":
+        assert {"name", "description", "developer_instructions"} <= data.keys(), path
+hooks = json.loads((codex_home / "hooks.json").read_text())
+assert hooks["userSetting"] is True
+assert any("echo existing" in h.get("command", "") for g in hooks["hooks"]["SessionStart"] for h in g["hooks"])
+for event in ("SessionStart", "PreCompact", "SessionEnd"):
+    commands = [h["command"] for g in hooks["hooks"][event] for h in g["hooks"]]
+    adapter_commands = [command for command in commands if "coding-agent-workflow" in command]
+    assert len(adapter_commands) == 1, (event, commands)
+PY
+then
+  :
+else
+  assert_eq "0" "1" "install: generated Codex configuration validates"
+fi
+
+cp "$CODEX_HOME/AGENTS.md" "$BOX/agents.before"
+cp "$CODEX_HOME/hooks.json" "$BOX/hooks.before"
+( cd "$PROJECT" && HOME="$HOME_DIR" CODEX_HOME="$CODEX_HOME" bash "$INSTALL" ) \
+  > "$BOX/install-again.log" 2>&1
+assert_files_identical "$BOX/agents.before" "$CODEX_HOME/AGENTS.md" \
+  "install: global AGENTS rendering is idempotent"
+assert_files_identical "$BOX/hooks.before" "$CODEX_HOME/hooks.json" \
+  "install: hook registration is idempotent"
+
+HOOK_RESULT="$(printf '%s\n' '{"source":"startup"}' | HOME="$HOME_DIR" CODEX_HOME="$CODEX_HOME" \
+  python3 "$CODEX_HOME/hooks/coding-agent-workflow-session-start.py")"
+if python3 - "$HOOK_RESULT" <<'PY'
+import json
+import sys
+data = json.loads(sys.argv[1])
+assert data["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+assert "additionalContext" in data["hookSpecificOutput"]
+PY
+then
+  :
+else
+  assert_eq "0" "1" "hook: SessionStart output validates as Codex JSON"
+fi
+
+BAD="$BOX/bad-agents"
+mkdir -p "$BAD"
+printf '# malformed\n' > "$BAD/broken.md"
+if python3 "$RENDERER" --agents "$BAD" "$BOX/bad-output" > "$BOX/bad.log" 2>&1; then
+  assert_eq "failure" "success" "renderer: malformed agent input is rejected"
+else
+  assert_contains "$(cat "$BOX/bad.log")" "broken.md" \
+    "renderer: malformed input identifies the source file"
+fi
+
+rm -rf "$BOX"
+finish


### PR DESCRIPTION
## Summary

Adds an explicit, idempotent Codex adapter while keeping the canonical workflow harness-neutral.

- Installs .agents/skills into the user skill directory.
- Renders shared rules into a managed ~/.codex/AGENTS.md block without Claude imports.
- Converts canonical Markdown agents into Codex TOML.
- Merges SessionStart, PreCompact, and SessionEnd hooks without removing existing hooks.
- Adds a neutral AGENTS.md project seed to the git-init scaffold.
- Documents setup and update flows and adds isolated integration coverage.

## Verification

- bash tests/run.sh — all 16 test files passed
- Focused Codex adapter test — 21 assertions passed
- bash syntax, Python compilation, and git diff checks passed
- ShellCheck unavailable in the environment

Please review the adapter boundaries, config-preservation behavior, and hook trust flow.