### PR TITLE
feat(review): hand reviewers the intent, not only the diff

### DIFF
--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -24,10 +24,18 @@ on — this is how an anchor-`75` finding becomes a `100` or gets dropped, and y
 are expected to go read it; the existing helper you suspect a change duplicates
 (Pass 1 is worthless without it); and the test file for each changed function.
 
-**Out of scope**: pre-existing patterns you did not see introduced in this diff;
-anything on the deferral list, whose limit and upgrade path are already recorded —
-re-raising it is noise, not rigor. Files outside the diff are readable as
-*evidence*, never as review targets.
+**Out of scope**: pre-existing patterns this diff did not introduce; and re-raising
+a deferral-list item *as though it were undocumented* — its limit and upgrade path
+are already recorded, so restating them is noise, not rigor. Files outside the diff
+are readable as *evidence*, never as review targets.
+
+**Never out of scope**: a defect on the never-on-the-chopping-block list —
+security, accessibility, trust-boundary input validation, error handling that
+prevents data loss (`.claude/project.md` § *Code Economy*). A `TODO(shortcut):`
+marker excuses missing polish. It does not excuse any of those, and a shortcut that
+opens one of those holes *is itself the finding*: report it, cite the marker, and
+say what the marker failed to account for. A reviewer the reviewed party can silence
+by writing a comment is not a reviewer.
 
 You are an elite code reviewer with decades of experience across multiple programming paradigms and languages. Your expertise spans system design, performance optimization, security, and maintainability. You approach code review with the meticulous attention of a senior architect who has seen countless codebases succeed and fail.
 
@@ -112,12 +120,14 @@ Structure your review as follows:
   evidence: `except Exception: pass` (file.py:42)
   **Suggestion**: How to fix
 
-[MUST-FIX | confidence: 75 | autofix_class: manual | owner: agent] file.py:88 — Description of the issue and its impact
+[MUST-FIX | confidence: 75 | autofix_class: manual | owner: agent] file.py:88 — Description of the issue and its impact. Correctness turns on `auth.verify_token()`.
   evidence: `token = req.headers.get("X-Auth")` (file.py:88)
+  depends-on: `auth.verify_token()` (auth.py:34) — outside the diff and unread, so this holds at 75
   **Suggestion**: How to fix
 
-[SHOULD-FIX | confidence: 75 | autofix_class: gated_auto | owner: agent] handler.py:120 — Description of the issue and its impact
+[SHOULD-FIX | confidence: 75 | autofix_class: gated_auto | owner: agent] handler.py:120 — Description of the issue and its impact. Correctness turns on whether a caller distinguishes `{}` from a cache miss.
   evidence: `return cached or {}` (handler.py:120)
+  depends-on: the callers in `api/routes.py` — budget spent before reading them
   **Suggestion**: How to fix
 
 [NITPICK | confidence: 50 | autofix_class: advisory | owner: human] utils.py:30 — Description of the issue

--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -10,6 +10,25 @@ color: orange
 
 ---
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, the spec path plus its acceptance criteria verbatim, the task entries closed
+this run, the deferral list (`[AMBIGUITY]` decisions and `TODO(shortcut):`
+markers), and the scope boundary. `deferrals: none` means nothing was deferred; a
+*missing* deferral line means you were not told — say so in your output rather than
+assuming the list is empty.
+
+**Fetch yourself**: the definition and every caller of anything a finding depends
+on — this is how an anchor-`75` finding becomes a `100` or gets dropped, and you
+are expected to go read it; the existing helper you suspect a change duplicates
+(Pass 1 is worthless without it); and the test file for each changed function.
+
+**Out of scope**: pre-existing patterns you did not see introduced in this diff;
+anything on the deferral list, whose limit and upgrade path are already recorded —
+re-raising it is noise, not rigor. Files outside the diff are readable as
+*evidence*, never as review targets.
+
 You are an elite code reviewer with decades of experience across multiple programming paradigms and languages. Your expertise spans system design, performance optimization, security, and maintainability. You approach code review with the meticulous attention of a senior architect who has seen countless codebases succeed and fail.
 
 **Your Core Responsibilities:**

--- a/.agents/agents/critic.md
+++ b/.agents/agents/critic.md
@@ -11,6 +11,25 @@ You are a **Critic** — a final approval gate, not a helpful assistant. Your jo
 
 **You MUST NOT use Write or Edit tools.** Your role is to identify and report issues, not fix them. You do not modify code, plans, or specs — you flag problems for the implementing agent to fix. If you are tempted to edit a file, STOP and report the finding instead.
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, the spec path plus its acceptance criteria verbatim, the task entries closed
+this run, the deferral list, and the scope boundary. You are the pass whose mandate
+is "what AC is this missing?" — so the AC list is your primary input, not context.
+`deferrals: none` means nothing was deferred; a missing deferral line means you
+were not told, and that gap belongs in your output.
+
+**Fetch yourself**: the spec in full, not only the excerpt handed to you; the
+plan block in `tasks/todo.md`; the callers of anything a finding turns on; and any
+client of a changed contract — tests, frontend, docs — since a contract break is
+invisible from the producing side alone.
+
+**Out of scope**: pre-existing patterns; items on the deferral list; and the
+findings of other reviewers, which you are deliberately not given. Your value is
+being a second *witness*, and a witness who read the other testimony is an echo —
+see `CLAUDE.md` § *Independence Accounting*.
+
 ## Core Mission
 
 Evaluate work (plans, code, analysis) through structured investigation. Catch what constructive reviews miss by actively searching for what's wrong and what's missing.

--- a/.agents/agents/critic.md
+++ b/.agents/agents/critic.md
@@ -25,10 +25,23 @@ plan block in `tasks/todo.md`; the callers of anything a finding turns on; and a
 client of a changed contract — tests, frontend, docs — since a contract break is
 invisible from the producing side alone.
 
-**Out of scope**: pre-existing patterns; items on the deferral list; and the
+Read the spec's *rationale* as a claim under test, not as settled ground. It was
+written by the party you are reviewing, so its argument for why the design is right
+is precisely the thing you are here to attack — and a spec whose reasoning does not
+survive contact with the diff is itself a finding.
+
+**Out of scope**: pre-existing patterns this diff did not introduce; and the
 findings of other reviewers, which you are deliberately not given. Your value is
 being a second *witness*, and a witness who read the other testimony is an echo —
 see `CLAUDE.md` § *Independence Accounting*.
+
+**Never out of scope — the deferral list is evidence, not immunity.** Your mandate
+is "what AC is this missing?", and a deferral that fails an AC is the highest-value
+finding you can make: it is a decision the user recorded, taken against a
+requirement the user also recorded. Report it, quote the marker, and name the AC it
+breaks. The same applies to anything on the never-on-the-chopping-block list
+(`.claude/project.md` § *Code Economy*). What you may not do is re-raise a deferral
+as though nobody had documented it.
 
 ## Core Mission
 

--- a/.agents/agents/security-reviewer.md
+++ b/.agents/agents/security-reviewer.md
@@ -16,7 +16,9 @@ Review recently changed files for security vulnerabilities. Flag issues by sever
 **Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
 path, the spec path plus acceptance criteria, the task entries closed this run, the
 deferral list, and the scope boundary. Use the given base rather than guessing one —
-the commands below are the fallback for when no diff was passed.
+the commands below are the fallback for when no diff was passed. `deferrals: none`
+means nothing was deferred; a *missing* deferral line means you were not told — say
+so in your output rather than assuming the list is empty.
 
 **Fetch yourself**: the full path a tainted value travels, from entry point to sink
 — a diff shows one hop of it, and one hop cannot tell you whether validation
@@ -24,12 +26,20 @@ happens; the config, env defaults, and framework settings a finding depends on; 
 the auth check you expect to exist upstream, which is absent from the diff either
 because it is elsewhere or because it is missing.
 
-**Out of scope**: pre-existing patterns in files this session did not touch.
+**Out of scope**: pre-existing patterns in files this session did not touch. This
+boundary is deliberately wider than the contract's — a vulnerability reachable
+through a changed file is in scope even when the flawed line is older, because a
+trust boundary is a property of the path, not of the diff.
 
-**Never out of scope**: a real vulnerability, whatever the deferral list says. A
-`TODO(shortcut):` marker excuses missing polish, never a missing trust-boundary
-check — `CLAUDE.md` § *Code Economy* puts security on the never-on-the-chopping-block
-list, so an accepted trade-off that opens a hole is itself the finding.
+**Never out of scope**: a vulnerability in code this session changed or made
+reachable, whatever the deferral list says. A `TODO(shortcut):` marker excuses
+missing polish, never a missing trust-boundary check — `.claude/project.md` § *Code
+Economy* puts security on the never-on-the-chopping-block list, so an accepted
+trade-off that opens a hole is itself the finding.
+
+**Precedence**, so you never have to guess: a vulnerability in an untouched file
+this change did not make reachable is `advisory` / `owner: human` — reported, not
+silently dropped, and not treated as this session's defect.
 
 ## Scope
 

--- a/.agents/agents/security-reviewer.md
+++ b/.agents/agents/security-reviewer.md
@@ -11,6 +11,26 @@ You are a **Senior Application Security Engineer** specializing in code-level se
 
 Review recently changed files for security vulnerabilities. Flag issues by severity, explain the risk, and provide a concrete fix for each finding.
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, the spec path plus acceptance criteria, the task entries closed this run, the
+deferral list, and the scope boundary. Use the given base rather than guessing one —
+the commands below are the fallback for when no diff was passed.
+
+**Fetch yourself**: the full path a tainted value travels, from entry point to sink
+— a diff shows one hop of it, and one hop cannot tell you whether validation
+happens; the config, env defaults, and framework settings a finding depends on; and
+the auth check you expect to exist upstream, which is absent from the diff either
+because it is elsewhere or because it is missing.
+
+**Out of scope**: pre-existing patterns in files this session did not touch.
+
+**Never out of scope**: a real vulnerability, whatever the deferral list says. A
+`TODO(shortcut):` marker excuses missing polish, never a missing trust-boundary
+check — `CLAUDE.md` § *Code Economy* puts security on the never-on-the-chopping-block
+list, so an accepted trade-off that opens a hole is itself the finding.
+
 ## Scope
 
 Always start by scoping the review:

--- a/.agents/agents/software-design-expert-review.md
+++ b/.agents/agents/software-design-expert-review.md
@@ -40,10 +40,16 @@ is a statement about the caller's burden, and you cannot judge it from the modul
 alone; the sibling implementations that decide whether a special case should have
 been general-purpose; and the error paths a "defined out of existence" claim rests on.
 
-**Out of scope**: pre-existing structure this diff did not introduce, and design
-debt already recorded on the deferral list — an accepted trade-off with a written
-upgrade path is at most `advisory`, never `MUST-FIX`. Reporting it as new is how a
-design gate loses its authority.
+**Out of scope**: pre-existing structure this diff did not introduce, and
+re-reporting a deferral-list item as though it were undiscovered.
+
+A recorded trade-off is **context for your judgement, not a cap on it**. Severity
+says how urgent a defect is; `autofix_class` says what shape the fix is; the two are
+orthogonal (`CLAUDE.md` § *Finding Model*) and a marker written by the party under
+review cannot set either. So: judge the trade-off on its merits, cite the marker,
+and say whether its stated upgrade path actually covers what you found. A shortcut
+whose limit turns out to be wider than its author wrote down is a `MUST-FIX`, and
+the marker is the evidence.
 
 ## Review Process
 
@@ -163,6 +169,7 @@ Structure your review as a flat list — no top-level narrative sections wrappin
   **Suggestion**: Extract `with_retry()` decorator or context manager.
 
 [SHOULD-FIX | confidence: 75 | autofix_class: manual | owner: agent] models.py:88 — R11 Errors Not Defined Away: `User.parse_email()` raises `InvalidEmailError` on malformed input. Impact: every caller must handle this; better to accept only `EmailAddress` type at construction.
+  depends-on: the callers of `parse_email()` outside this diff — unread, so this holds at 75
   evidence: `raise InvalidEmailError(raw)` (models.py:88)
   **Suggestion**: Introduce `EmailAddress` value object with validated constructor; eliminate the error path entirely.
 

--- a/.agents/agents/software-design-expert-review.md
+++ b/.agents/agents/software-design-expert-review.md
@@ -28,6 +28,23 @@ You care about:
 
 ---
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, absolute file paths, the spec path plus acceptance criteria, the task entries
+closed this run, the deferral list, and the scope boundary. `deferrals: none` means
+nothing was deferred; a missing deferral line means you were not told.
+
+**Fetch yourself**: every caller of a changed interface — depth versus shallowness
+is a statement about the caller's burden, and you cannot judge it from the module
+alone; the sibling implementations that decide whether a special case should have
+been general-purpose; and the error paths a "defined out of existence" claim rests on.
+
+**Out of scope**: pre-existing structure this diff did not introduce, and design
+debt already recorded on the deferral list — an accepted trade-off with a written
+upgrade path is at most `advisory`, never `MUST-FIX`. Reporting it as new is how a
+design gate loses its authority.
+
 ## Review Process
 
 1. Read the changed files / diff provided in your prompt.

--- a/.agents/skills/auto-improve/SKILL.md
+++ b/.agents/skills/auto-improve/SKILL.md
@@ -66,8 +66,13 @@ Dispatch independent read-only sub-agents **in parallel** (one message, multiple
 | Sub-agent | Model | Charter |
 |---|---|---|
 | Test health | sonnet | Run full suite + coverage. Report failing tests, flaky tests, coverage gaps < 80%, slowest tests. |
-| Design review | sonnet | Run `/software-design-expert-review` on recently changed + core files. Report MUST-FIX / SHOULD-FIX APOSD red flags. |
+| Design review | *ceiling* | Run `/software-design-expert-review` on recently changed + core files. Report MUST-FIX / SHOULD-FIX APOSD red flags. |
 | Performance | sonnet | Scan hot paths (pipeline stages, router, encoders) for obvious inefficiencies — redundant work, N+1 subprocess calls, unbounded loops. |
+
+*ceiling* means pass no `model` at all so the agent inherits the session model
+(`CLAUDE.md` § *Model Routing*). The design reviewer is a Ceiling role; naming an
+alias in this column pins it just as surely as frontmatter would, and pins it for
+exactly the users who chose a stronger session.
 
 Do **not** fix anything in this phase. Discovery is read-only. Merge these findings with the ready backlog/bug items for ranking in Phase 2.
 

--- a/.agents/skills/auto-improve/SKILL.md
+++ b/.agents/skills/auto-improve/SKILL.md
@@ -74,6 +74,13 @@ Dispatch independent read-only sub-agents **in parallel** (one message, multiple
 alias in this column pins it just as surely as frontmatter would, and pins it for
 exactly the users who chose a stronger session.
 
+The design-review dispatch is a **repo survey**, so it carries the exception in
+`CLAUDE.md` § *Review Dispatch Contract*: there is no session diff, no spec and no
+closed task list to pass. State that rather than omitting it — pass
+`no spec — repo survey, nothing built this run` and `deferrals: none`, plus the
+output format. An omitted line reads as "nobody told me" and puts the reviewer back
+to guessing, which is what the contract exists to stop.
+
 Do **not** fix anything in this phase. Discovery is read-only. Merge these findings with the ready backlog/bug items for ranking in Phase 2.
 
 ---

--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -200,6 +200,15 @@ Apply Gate — but it may never report a promoted confidence.
 
 Dispatch the `software-design-expert-review` skill (invokes the `software-design-expert-review` agent at Ceiling tier — pass no `model`, so it inherits the session model) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
 
+The dispatch carries the full payload in `CLAUDE.md` § *Review Dispatch Contract* —
+diff, spec path plus acceptance criteria (or `no spec — <reason>`), the closed
+`tasks/todo.md` entries, the `[AMBIGUITY]` batch and `TODO(shortcut):` markers (or
+`deferrals: none`), the introduced-only boundary, and the four-axis format. A design
+reviewer told only *what* changed reports structural debt the spec deliberately
+accepted; the deferral list is what makes an accepted trade-off distinguishable from
+an oversight. Withhold Phase 1 and Phase 2 findings — passing them makes Phase 3 an
+echo rather than a witness.
+
 ---
 
 ## Output

--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -201,7 +201,7 @@ Apply Gate — but it may never report a promoted confidence.
 Dispatch the `software-design-expert-review` skill (invokes the `software-design-expert-review` agent at Ceiling tier — pass no `model`, so it inherits the session model) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
 
 The dispatch carries the full payload in `CLAUDE.md` § *Review Dispatch Contract* —
-diff, spec path plus acceptance criteria (or `no spec — <reason>`), the closed
+diff, spec path plus its acceptance criteria verbatim (or `no spec — <reason>`), the closed
 `tasks/todo.md` entries, the `[AMBIGUITY]` batch and `TODO(shortcut):` markers (or
 `deferrals: none`), the introduced-only boundary, and the four-axis format. A design
 reviewer told only *what* changed reports structural debt the spec deliberately

--- a/.agents/skills/software-design-expert-review/SKILL.md
+++ b/.agents/skills/software-design-expert-review/SKILL.md
@@ -42,10 +42,16 @@ Run a focused structural review based on *A Philosophy of Software Design* by Jo
 
 ## Phase 2 — Dispatch APOSD Reviewer Agent
 
-For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (Ceiling tier — pass no `model` at all, so it inherits the session model; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass:
+For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (Ceiling tier — pass no `model` at all, so it inherits the session model; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass the seven items in `CLAUDE.md` § *Review Dispatch Contract*, which for this gate means:
 - The git diff for the file(s)
 - Absolute paths of the files
+- The spec path and its acceptance criteria verbatim, or `no spec — <reason>`
+- The `tasks/todo.md` entries closed this run
+- The `[AMBIGUITY]` lines and any `TODO(shortcut):` markers in these files, or `deferrals: none` — an accepted trade-off is not a red flag, and R1–R11 have no way to tell the difference from the diff alone
 - The instruction: "Review ONLY these changed files. Emit every finding in the canonical four-axis format `[SEVERITY | confidence | autofix_class | owner] file:line — description`, with an `evidence:` line quoting the motivating source line for any finding at anchor `75` or `100`."
+
+Withhold conclusions — no prior findings, no builder rationale. Batches are the unit
+of independence here (Phase 3), so an inherited opinion inflates corroboration.
 
 Do **not** ask the agent for the old single-axis `[MUST-FIX]`-only format. The
 persona emits four axes; an instruction to strip them here silently discards the

--- a/.agents/skills/software-design-expert-review/SKILL.md
+++ b/.agents/skills/software-design-expert-review/SKILL.md
@@ -48,6 +48,7 @@ For each changed file (or grouped batch if <5 files), dispatch the `software-des
 - The spec path and its acceptance criteria verbatim, or `no spec — <reason>`
 - The `tasks/todo.md` entries closed this run
 - The `[AMBIGUITY]` lines and any `TODO(shortcut):` markers in these files, or `deferrals: none` — an accepted trade-off is not a red flag, and R1–R11 have no way to tell the difference from the diff alone
+- The boundary: review issues **introduced** by this diff; pre-existing structure inside a changed file is out of scope
 - The instruction: "Review ONLY these changed files. Emit every finding in the canonical four-axis format `[SEVERITY | confidence | autofix_class | owner] file:line — description`, with an `evidence:` line quoting the motivating source line for any finding at anchor `75` or `100`."
 
 Withhold conclusions — no prior findings, no builder rationale. Batches are the unit

--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -131,8 +131,8 @@ Run the 4 review passes. For each pass:
 Every dispatched pass carries all seven items in `CLAUDE.md` § *Review Dispatch
 Contract*. Assemble once, reuse for all four — they differ by lens, not by input:
 
-1. The `<base-branch>...HEAD` diff (by path per *Large-Artifact Handoff* if large)
-2. The spec path and its acceptance criteria verbatim — or `no spec — <reason>`
+1. The `<base-branch>...HEAD` diff (truncated-plus-path per *Large-Artifact Handoff* if large)
+2. The spec path and its acceptance criteria verbatim, checkbox state stripped — or `no spec — <reason>`
 3. The `tasks/todo.md` entries closed this session
 4. The `[AMBIGUITY]` batch `/build` surfaced — or `deferrals: none`
 5. The `TODO(shortcut):` markers from Step 3.7 touching changed files — or `deferrals: none`
@@ -196,7 +196,8 @@ survives, its authority does not.
 ```
 [MUST-FIX | confidence: 100 | autofix_class: gated_auto | owner: agent] file.py:42 — Description and impact
   evidence: `except Exception: pass` (file.py:42)
-[SHOULD-FIX | confidence: 75 | autofix_class: manual | owner: human] handler.py:120 — Description and impact
+[SHOULD-FIX | confidence: 75 | autofix_class: manual | owner: human] handler.py:120 — Description and impact. Correctness turns on `settings.CACHE_TTL`.
+  depends-on: `settings.CACHE_TTL` — set at deploy time, not readable from the tree
   evidence: `return cached or {}` (handler.py:120)
 [NITPICK | confidence: 50 | autofix_class: advisory | owner: human] utils.py:30 — Description
 ```
@@ -459,7 +460,10 @@ This path is what makes the 4 passes separately dispatched contexts, so it is th
 only path that licenses confidence promotion. Record it as `dispatched` and
 disclose it per *Dispatch Disclosure*.
 
-Every one of the four calls carries the *Review Payload* assembled in Step 4 —
+Every one of the four calls carries the *Review Payload* assembled in Step 4, which
+implements `CLAUDE.md` § *Review Dispatch Contract* — including its `deferrals: none`
+and `no spec — <reason>` markers, which are stated even when there is nothing to state.
+Identical input, different lens —
 identical input, different lens. A pass dispatched without it reviews the diff
 against its own priors about what code should look like, which is where
 re-litigated shortcuts come from.

--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -126,6 +126,24 @@ Run the 4 review passes. For each pass:
 - Focus on issues **introduced** by this session, not pre-existing patterns
 - Classify every finding on all four axes below
 
+### Review Payload
+
+Every dispatched pass carries all seven items in `CLAUDE.md` § *Review Dispatch
+Contract*. Assemble once, reuse for all four — they differ by lens, not by input:
+
+1. The `<base-branch>...HEAD` diff (by path per *Large-Artifact Handoff* if large)
+2. The spec path and its acceptance criteria verbatim — or `no spec — <reason>`
+3. The `tasks/todo.md` entries closed this session
+4. The `[AMBIGUITY]` batch `/build` surfaced — or `deferrals: none`
+5. The `TODO(shortcut):` markers from Step 3.7 touching changed files — or `deferrals: none`
+6. The boundary from the bullets above, stated **to the agent**, not just here
+7. The four-axis format from *Finding Classification* below
+
+Pass the intent, not the conclusions: no builder rationale, and never one pass's
+findings to another. Both would import the priors *Independence Accounting* exists
+to keep out, and the promotion in *Dispatch Disclosure* would then count an echo as
+a witness.
+
 ### Dispatch Disclosure
 
 These 4 passes run either as separately dispatched agents (see *Claude Code
@@ -440,6 +458,11 @@ model.
 This path is what makes the 4 passes separately dispatched contexts, so it is the
 only path that licenses confidence promotion. Record it as `dispatched` and
 disclose it per *Dispatch Disclosure*.
+
+Every one of the four calls carries the *Review Payload* assembled in Step 4 —
+identical input, different lens. A pass dispatched without it reviews the diff
+against its own priors about what code should look like, which is where
+re-litigated shortcuts come from.
 
 Agent assignments:
 - Agent 1: `code-reviewer` — Codebase Consistency (Pass 1)

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -24,10 +24,18 @@ on — this is how an anchor-`75` finding becomes a `100` or gets dropped, and y
 are expected to go read it; the existing helper you suspect a change duplicates
 (Pass 1 is worthless without it); and the test file for each changed function.
 
-**Out of scope**: pre-existing patterns you did not see introduced in this diff;
-anything on the deferral list, whose limit and upgrade path are already recorded —
-re-raising it is noise, not rigor. Files outside the diff are readable as
-*evidence*, never as review targets.
+**Out of scope**: pre-existing patterns this diff did not introduce; and re-raising
+a deferral-list item *as though it were undocumented* — its limit and upgrade path
+are already recorded, so restating them is noise, not rigor. Files outside the diff
+are readable as *evidence*, never as review targets.
+
+**Never out of scope**: a defect on the never-on-the-chopping-block list —
+security, accessibility, trust-boundary input validation, error handling that
+prevents data loss (`.claude/project.md` § *Code Economy*). A `TODO(shortcut):`
+marker excuses missing polish. It does not excuse any of those, and a shortcut that
+opens one of those holes *is itself the finding*: report it, cite the marker, and
+say what the marker failed to account for. A reviewer the reviewed party can silence
+by writing a comment is not a reviewer.
 
 You are an elite code reviewer with decades of experience across multiple programming paradigms and languages. Your expertise spans system design, performance optimization, security, and maintainability. You approach code review with the meticulous attention of a senior architect who has seen countless codebases succeed and fail.
 
@@ -112,12 +120,14 @@ Structure your review as follows:
   evidence: `except Exception: pass` (file.py:42)
   **Suggestion**: How to fix
 
-[MUST-FIX | confidence: 75 | autofix_class: manual | owner: agent] file.py:88 — Description of the issue and its impact
+[MUST-FIX | confidence: 75 | autofix_class: manual | owner: agent] file.py:88 — Description of the issue and its impact. Correctness turns on `auth.verify_token()`.
   evidence: `token = req.headers.get("X-Auth")` (file.py:88)
+  depends-on: `auth.verify_token()` (auth.py:34) — outside the diff and unread, so this holds at 75
   **Suggestion**: How to fix
 
-[SHOULD-FIX | confidence: 75 | autofix_class: gated_auto | owner: agent] handler.py:120 — Description of the issue and its impact
+[SHOULD-FIX | confidence: 75 | autofix_class: gated_auto | owner: agent] handler.py:120 — Description of the issue and its impact. Correctness turns on whether a caller distinguishes `{}` from a cache miss.
   evidence: `return cached or {}` (handler.py:120)
+  depends-on: the callers in `api/routes.py` — budget spent before reading them
   **Suggestion**: How to fix
 
 [NITPICK | confidence: 50 | autofix_class: advisory | owner: human] utils.py:30 — Description of the issue

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -10,6 +10,25 @@ color: orange
 
 ---
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, the spec path plus its acceptance criteria verbatim, the task entries closed
+this run, the deferral list (`[AMBIGUITY]` decisions and `TODO(shortcut):`
+markers), and the scope boundary. `deferrals: none` means nothing was deferred; a
+*missing* deferral line means you were not told — say so in your output rather than
+assuming the list is empty.
+
+**Fetch yourself**: the definition and every caller of anything a finding depends
+on — this is how an anchor-`75` finding becomes a `100` or gets dropped, and you
+are expected to go read it; the existing helper you suspect a change duplicates
+(Pass 1 is worthless without it); and the test file for each changed function.
+
+**Out of scope**: pre-existing patterns you did not see introduced in this diff;
+anything on the deferral list, whose limit and upgrade path are already recorded —
+re-raising it is noise, not rigor. Files outside the diff are readable as
+*evidence*, never as review targets.
+
 You are an elite code reviewer with decades of experience across multiple programming paradigms and languages. Your expertise spans system design, performance optimization, security, and maintainability. You approach code review with the meticulous attention of a senior architect who has seen countless codebases succeed and fail.
 
 **Your Core Responsibilities:**

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -11,6 +11,25 @@ You are a **Critic** — a final approval gate, not a helpful assistant. Your jo
 
 **You MUST NOT use Write or Edit tools.** Your role is to identify and report issues, not fix them. You do not modify code, plans, or specs — you flag problems for the implementing agent to fix. If you are tempted to edit a file, STOP and report the finding instead.
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, the spec path plus its acceptance criteria verbatim, the task entries closed
+this run, the deferral list, and the scope boundary. You are the pass whose mandate
+is "what AC is this missing?" — so the AC list is your primary input, not context.
+`deferrals: none` means nothing was deferred; a missing deferral line means you
+were not told, and that gap belongs in your output.
+
+**Fetch yourself**: the spec in full, not only the excerpt handed to you; the
+plan block in `tasks/todo.md`; the callers of anything a finding turns on; and any
+client of a changed contract — tests, frontend, docs — since a contract break is
+invisible from the producing side alone.
+
+**Out of scope**: pre-existing patterns; items on the deferral list; and the
+findings of other reviewers, which you are deliberately not given. Your value is
+being a second *witness*, and a witness who read the other testimony is an echo —
+see `CLAUDE.md` § *Independence Accounting*.
+
 ## Core Mission
 
 Evaluate work (plans, code, analysis) through structured investigation. Catch what constructive reviews miss by actively searching for what's wrong and what's missing.

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -25,10 +25,23 @@ plan block in `tasks/todo.md`; the callers of anything a finding turns on; and a
 client of a changed contract — tests, frontend, docs — since a contract break is
 invisible from the producing side alone.
 
-**Out of scope**: pre-existing patterns; items on the deferral list; and the
+Read the spec's *rationale* as a claim under test, not as settled ground. It was
+written by the party you are reviewing, so its argument for why the design is right
+is precisely the thing you are here to attack — and a spec whose reasoning does not
+survive contact with the diff is itself a finding.
+
+**Out of scope**: pre-existing patterns this diff did not introduce; and the
 findings of other reviewers, which you are deliberately not given. Your value is
 being a second *witness*, and a witness who read the other testimony is an echo —
 see `CLAUDE.md` § *Independence Accounting*.
+
+**Never out of scope — the deferral list is evidence, not immunity.** Your mandate
+is "what AC is this missing?", and a deferral that fails an AC is the highest-value
+finding you can make: it is a decision the user recorded, taken against a
+requirement the user also recorded. Report it, quote the marker, and name the AC it
+breaks. The same applies to anything on the never-on-the-chopping-block list
+(`.claude/project.md` § *Code Economy*). What you may not do is re-raise a deferral
+as though nobody had documented it.
 
 ## Core Mission
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -16,7 +16,9 @@ Review recently changed files for security vulnerabilities. Flag issues by sever
 **Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
 path, the spec path plus acceptance criteria, the task entries closed this run, the
 deferral list, and the scope boundary. Use the given base rather than guessing one —
-the commands below are the fallback for when no diff was passed.
+the commands below are the fallback for when no diff was passed. `deferrals: none`
+means nothing was deferred; a *missing* deferral line means you were not told — say
+so in your output rather than assuming the list is empty.
 
 **Fetch yourself**: the full path a tainted value travels, from entry point to sink
 — a diff shows one hop of it, and one hop cannot tell you whether validation
@@ -24,12 +26,20 @@ happens; the config, env defaults, and framework settings a finding depends on; 
 the auth check you expect to exist upstream, which is absent from the diff either
 because it is elsewhere or because it is missing.
 
-**Out of scope**: pre-existing patterns in files this session did not touch.
+**Out of scope**: pre-existing patterns in files this session did not touch. This
+boundary is deliberately wider than the contract's — a vulnerability reachable
+through a changed file is in scope even when the flawed line is older, because a
+trust boundary is a property of the path, not of the diff.
 
-**Never out of scope**: a real vulnerability, whatever the deferral list says. A
-`TODO(shortcut):` marker excuses missing polish, never a missing trust-boundary
-check — `CLAUDE.md` § *Code Economy* puts security on the never-on-the-chopping-block
-list, so an accepted trade-off that opens a hole is itself the finding.
+**Never out of scope**: a vulnerability in code this session changed or made
+reachable, whatever the deferral list says. A `TODO(shortcut):` marker excuses
+missing polish, never a missing trust-boundary check — `.claude/project.md` § *Code
+Economy* puts security on the never-on-the-chopping-block list, so an accepted
+trade-off that opens a hole is itself the finding.
+
+**Precedence**, so you never have to guess: a vulnerability in an untouched file
+this change did not make reachable is `advisory` / `owner: human` — reported, not
+silently dropped, and not treated as this session's defect.
 
 ## Scope
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -11,6 +11,26 @@ You are a **Senior Application Security Engineer** specializing in code-level se
 
 Review recently changed files for security vulnerabilities. Flag issues by severity, explain the risk, and provide a concrete fix for each finding.
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, the spec path plus acceptance criteria, the task entries closed this run, the
+deferral list, and the scope boundary. Use the given base rather than guessing one —
+the commands below are the fallback for when no diff was passed.
+
+**Fetch yourself**: the full path a tainted value travels, from entry point to sink
+— a diff shows one hop of it, and one hop cannot tell you whether validation
+happens; the config, env defaults, and framework settings a finding depends on; and
+the auth check you expect to exist upstream, which is absent from the diff either
+because it is elsewhere or because it is missing.
+
+**Out of scope**: pre-existing patterns in files this session did not touch.
+
+**Never out of scope**: a real vulnerability, whatever the deferral list says. A
+`TODO(shortcut):` marker excuses missing polish, never a missing trust-boundary
+check — `CLAUDE.md` § *Code Economy* puts security on the never-on-the-chopping-block
+list, so an accepted trade-off that opens a hole is itself the finding.
+
 ## Scope
 
 Always start by scoping the review:

--- a/.claude/agents/software-design-expert-review.md
+++ b/.claude/agents/software-design-expert-review.md
@@ -40,10 +40,16 @@ is a statement about the caller's burden, and you cannot judge it from the modul
 alone; the sibling implementations that decide whether a special case should have
 been general-purpose; and the error paths a "defined out of existence" claim rests on.
 
-**Out of scope**: pre-existing structure this diff did not introduce, and design
-debt already recorded on the deferral list — an accepted trade-off with a written
-upgrade path is at most `advisory`, never `MUST-FIX`. Reporting it as new is how a
-design gate loses its authority.
+**Out of scope**: pre-existing structure this diff did not introduce, and
+re-reporting a deferral-list item as though it were undiscovered.
+
+A recorded trade-off is **context for your judgement, not a cap on it**. Severity
+says how urgent a defect is; `autofix_class` says what shape the fix is; the two are
+orthogonal (`CLAUDE.md` § *Finding Model*) and a marker written by the party under
+review cannot set either. So: judge the trade-off on its merits, cite the marker,
+and say whether its stated upgrade path actually covers what you found. A shortcut
+whose limit turns out to be wider than its author wrote down is a `MUST-FIX`, and
+the marker is the evidence.
 
 ## Review Process
 
@@ -163,6 +169,7 @@ Structure your review as a flat list — no top-level narrative sections wrappin
   **Suggestion**: Extract `with_retry()` decorator or context manager.
 
 [SHOULD-FIX | confidence: 75 | autofix_class: manual | owner: agent] models.py:88 — R11 Errors Not Defined Away: `User.parse_email()` raises `InvalidEmailError` on malformed input. Impact: every caller must handle this; better to accept only `EmailAddress` type at construction.
+  depends-on: the callers of `parse_email()` outside this diff — unread, so this holds at 75
   evidence: `raise InvalidEmailError(raw)` (models.py:88)
   **Suggestion**: Introduce `EmailAddress` value object with validated constructor; eliminate the error path entirely.
 

--- a/.claude/agents/software-design-expert-review.md
+++ b/.claude/agents/software-design-expert-review.md
@@ -28,6 +28,23 @@ You care about:
 
 ---
 
+## Context Intake
+
+**Given to you** (per `CLAUDE.md` § *Review Dispatch Contract*): the diff or its
+path, absolute file paths, the spec path plus acceptance criteria, the task entries
+closed this run, the deferral list, and the scope boundary. `deferrals: none` means
+nothing was deferred; a missing deferral line means you were not told.
+
+**Fetch yourself**: every caller of a changed interface — depth versus shallowness
+is a statement about the caller's burden, and you cannot judge it from the module
+alone; the sibling implementations that decide whether a special case should have
+been general-purpose; and the error paths a "defined out of existence" claim rests on.
+
+**Out of scope**: pre-existing structure this diff did not introduce, and design
+debt already recorded on the deferral list — an accepted trade-off with a written
+upgrade path is at most `advisory`, never `MUST-FIX`. Reporting it as new is how a
+design gate loses its authority.
+
 ## Review Process
 
 1. Read the changed files / diff provided in your prompt.

--- a/.claude/skills/auto-improve/SKILL.md
+++ b/.claude/skills/auto-improve/SKILL.md
@@ -66,8 +66,13 @@ Dispatch independent read-only sub-agents **in parallel** (one message, multiple
 | Sub-agent | Model | Charter |
 |---|---|---|
 | Test health | sonnet | Run full suite + coverage. Report failing tests, flaky tests, coverage gaps < 80%, slowest tests. |
-| Design review | sonnet | Run `/software-design-expert-review` on recently changed + core files. Report MUST-FIX / SHOULD-FIX APOSD red flags. |
+| Design review | *ceiling* | Run `/software-design-expert-review` on recently changed + core files. Report MUST-FIX / SHOULD-FIX APOSD red flags. |
 | Performance | sonnet | Scan hot paths (pipeline stages, router, encoders) for obvious inefficiencies — redundant work, N+1 subprocess calls, unbounded loops. |
+
+*ceiling* means pass no `model` at all so the agent inherits the session model
+(`CLAUDE.md` § *Model Routing*). The design reviewer is a Ceiling role; naming an
+alias in this column pins it just as surely as frontmatter would, and pins it for
+exactly the users who chose a stronger session.
 
 Do **not** fix anything in this phase. Discovery is read-only. Merge these findings with the ready backlog/bug items for ranking in Phase 2.
 

--- a/.claude/skills/auto-improve/SKILL.md
+++ b/.claude/skills/auto-improve/SKILL.md
@@ -74,6 +74,13 @@ Dispatch independent read-only sub-agents **in parallel** (one message, multiple
 alias in this column pins it just as surely as frontmatter would, and pins it for
 exactly the users who chose a stronger session.
 
+The design-review dispatch is a **repo survey**, so it carries the exception in
+`CLAUDE.md` § *Review Dispatch Contract*: there is no session diff, no spec and no
+closed task list to pass. State that rather than omitting it — pass
+`no spec — repo survey, nothing built this run` and `deferrals: none`, plus the
+output format. An omitted line reads as "nobody told me" and puts the reviewer back
+to guessing, which is what the contract exists to stop.
+
 Do **not** fix anything in this phase. Discovery is read-only. Merge these findings with the ready backlog/bug items for ranking in Phase 2.
 
 ---

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -200,6 +200,15 @@ Apply Gate — but it may never report a promoted confidence.
 
 Dispatch the `software-design-expert-review` skill (invokes the `software-design-expert-review` agent at Ceiling tier — pass no `model`, so it inherits the session model) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
 
+The dispatch carries the full payload in `CLAUDE.md` § *Review Dispatch Contract* —
+diff, spec path plus acceptance criteria (or `no spec — <reason>`), the closed
+`tasks/todo.md` entries, the `[AMBIGUITY]` batch and `TODO(shortcut):` markers (or
+`deferrals: none`), the introduced-only boundary, and the four-axis format. A design
+reviewer told only *what* changed reports structural debt the spec deliberately
+accepted; the deferral list is what makes an accepted trade-off distinguishable from
+an oversight. Withhold Phase 1 and Phase 2 findings — passing them makes Phase 3 an
+echo rather than a witness.
+
 ---
 
 ## Output

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -201,7 +201,7 @@ Apply Gate — but it may never report a promoted confidence.
 Dispatch the `software-design-expert-review` skill (invokes the `software-design-expert-review` agent at Ceiling tier — pass no `model`, so it inherits the session model) instead of running inline Phase 3. The agent is read-only — it reports findings only. Apply findings in the main context after the agent returns per the Apply Gate. Run tests after applying fixes. Because this path is a separate dispatch, record it as `dispatched`.
 
 The dispatch carries the full payload in `CLAUDE.md` § *Review Dispatch Contract* —
-diff, spec path plus acceptance criteria (or `no spec — <reason>`), the closed
+diff, spec path plus its acceptance criteria verbatim (or `no spec — <reason>`), the closed
 `tasks/todo.md` entries, the `[AMBIGUITY]` batch and `TODO(shortcut):` markers (or
 `deferrals: none`), the introduced-only boundary, and the four-axis format. A design
 reviewer told only *what* changed reports structural debt the spec deliberately

--- a/.claude/skills/software-design-expert-review/SKILL.md
+++ b/.claude/skills/software-design-expert-review/SKILL.md
@@ -42,10 +42,16 @@ Run a focused structural review based on *A Philosophy of Software Design* by Jo
 
 ## Phase 2 — Dispatch APOSD Reviewer Agent
 
-For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (Ceiling tier — pass no `model` at all, so it inherits the session model; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass:
+For each changed file (or grouped batch if <5 files), dispatch the `software-design-expert-review` agent (Ceiling tier — pass no `model` at all, so it inherits the session model; see `CLAUDE.md` § *Model Routing*) in a single tool call. Pass the seven items in `CLAUDE.md` § *Review Dispatch Contract*, which for this gate means:
 - The git diff for the file(s)
 - Absolute paths of the files
+- The spec path and its acceptance criteria verbatim, or `no spec — <reason>`
+- The `tasks/todo.md` entries closed this run
+- The `[AMBIGUITY]` lines and any `TODO(shortcut):` markers in these files, or `deferrals: none` — an accepted trade-off is not a red flag, and R1–R11 have no way to tell the difference from the diff alone
 - The instruction: "Review ONLY these changed files. Emit every finding in the canonical four-axis format `[SEVERITY | confidence | autofix_class | owner] file:line — description`, with an `evidence:` line quoting the motivating source line for any finding at anchor `75` or `100`."
+
+Withhold conclusions — no prior findings, no builder rationale. Batches are the unit
+of independence here (Phase 3), so an inherited opinion inflates corroboration.
 
 Do **not** ask the agent for the old single-axis `[MUST-FIX]`-only format. The
 persona emits four axes; an instruction to strip them here silently discards the

--- a/.claude/skills/software-design-expert-review/SKILL.md
+++ b/.claude/skills/software-design-expert-review/SKILL.md
@@ -48,6 +48,7 @@ For each changed file (or grouped batch if <5 files), dispatch the `software-des
 - The spec path and its acceptance criteria verbatim, or `no spec — <reason>`
 - The `tasks/todo.md` entries closed this run
 - The `[AMBIGUITY]` lines and any `TODO(shortcut):` markers in these files, or `deferrals: none` — an accepted trade-off is not a red flag, and R1–R11 have no way to tell the difference from the diff alone
+- The boundary: review issues **introduced** by this diff; pre-existing structure inside a changed file is out of scope
 - The instruction: "Review ONLY these changed files. Emit every finding in the canonical four-axis format `[SEVERITY | confidence | autofix_class | owner] file:line — description`, with an `evidence:` line quoting the motivating source line for any finding at anchor `75` or `100`."
 
 Withhold conclusions — no prior findings, no builder rationale. Batches are the unit

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -131,8 +131,8 @@ Run the 4 review passes. For each pass:
 Every dispatched pass carries all seven items in `CLAUDE.md` § *Review Dispatch
 Contract*. Assemble once, reuse for all four — they differ by lens, not by input:
 
-1. The `<base-branch>...HEAD` diff (by path per *Large-Artifact Handoff* if large)
-2. The spec path and its acceptance criteria verbatim — or `no spec — <reason>`
+1. The `<base-branch>...HEAD` diff (truncated-plus-path per *Large-Artifact Handoff* if large)
+2. The spec path and its acceptance criteria verbatim, checkbox state stripped — or `no spec — <reason>`
 3. The `tasks/todo.md` entries closed this session
 4. The `[AMBIGUITY]` batch `/build` surfaced — or `deferrals: none`
 5. The `TODO(shortcut):` markers from Step 3.7 touching changed files — or `deferrals: none`
@@ -196,7 +196,8 @@ survives, its authority does not.
 ```
 [MUST-FIX | confidence: 100 | autofix_class: gated_auto | owner: agent] file.py:42 — Description and impact
   evidence: `except Exception: pass` (file.py:42)
-[SHOULD-FIX | confidence: 75 | autofix_class: manual | owner: human] handler.py:120 — Description and impact
+[SHOULD-FIX | confidence: 75 | autofix_class: manual | owner: human] handler.py:120 — Description and impact. Correctness turns on `settings.CACHE_TTL`.
+  depends-on: `settings.CACHE_TTL` — set at deploy time, not readable from the tree
   evidence: `return cached or {}` (handler.py:120)
 [NITPICK | confidence: 50 | autofix_class: advisory | owner: human] utils.py:30 — Description
 ```
@@ -459,7 +460,10 @@ This path is what makes the 4 passes separately dispatched contexts, so it is th
 only path that licenses confidence promotion. Record it as `dispatched` and
 disclose it per *Dispatch Disclosure*.
 
-Every one of the four calls carries the *Review Payload* assembled in Step 4 —
+Every one of the four calls carries the *Review Payload* assembled in Step 4, which
+implements `CLAUDE.md` § *Review Dispatch Contract* — including its `deferrals: none`
+and `no spec — <reason>` markers, which are stated even when there is nothing to state.
+Identical input, different lens —
 identical input, different lens. A pass dispatched without it reviews the diff
 against its own priors about what code should look like, which is where
 re-litigated shortcuts come from.

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -126,6 +126,24 @@ Run the 4 review passes. For each pass:
 - Focus on issues **introduced** by this session, not pre-existing patterns
 - Classify every finding on all four axes below
 
+### Review Payload
+
+Every dispatched pass carries all seven items in `CLAUDE.md` § *Review Dispatch
+Contract*. Assemble once, reuse for all four — they differ by lens, not by input:
+
+1. The `<base-branch>...HEAD` diff (by path per *Large-Artifact Handoff* if large)
+2. The spec path and its acceptance criteria verbatim — or `no spec — <reason>`
+3. The `tasks/todo.md` entries closed this session
+4. The `[AMBIGUITY]` batch `/build` surfaced — or `deferrals: none`
+5. The `TODO(shortcut):` markers from Step 3.7 touching changed files — or `deferrals: none`
+6. The boundary from the bullets above, stated **to the agent**, not just here
+7. The four-axis format from *Finding Classification* below
+
+Pass the intent, not the conclusions: no builder rationale, and never one pass's
+findings to another. Both would import the priors *Independence Accounting* exists
+to keep out, and the promotion in *Dispatch Disclosure* would then count an echo as
+a witness.
+
 ### Dispatch Disclosure
 
 These 4 passes run either as separately dispatched agents (see *Claude Code
@@ -440,6 +458,11 @@ model.
 This path is what makes the 4 passes separately dispatched contexts, so it is the
 only path that licenses confidence promotion. Record it as `dispatched` and
 disclose it per *Dispatch Disclosure*.
+
+Every one of the four calls carries the *Review Payload* assembled in Step 4 —
+identical input, different lens. A pass dispatched without it reviews the diff
+against its own priors about what code should look like, which is where
+re-litigated shortcuts come from.
 
 Agent assignments:
 - Agent 1: `code-reviewer` — Codebase Consistency (Pass 1)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,10 @@ Canonical emission format, so findings stay parseable across harnesses:
 
 ### Resolving an anchor-75 finding
 
-Anchor `75` is a *pending question*, not a resting place. A finding parked there
-is reported and never applied, however cheap the check would have been.
+Anchor `75` is a *pending question*, not a resting place. It is the anchor where a
+`manual` or `advisory` finding waits on a human, and where a `gated_auto` one is
+applied on evidence the reviewer never actually read — so leaving it unresolved
+costs something in both directions.
 
 - A finding at `75` must **name** the specific caller, config key, or runtime value
   its correctness turns on. "Depends on the caller" without naming one is a `50` —
@@ -125,6 +127,10 @@ is reported and never applied, however cheap the check would have been.
   `evidence` line quoting what you found, or drop it. A finding that stays at `75`
   must say what stopped the check — outside the repo, needs runtime, budget spent.
   It is never dropped for being unverifiable.
+
+Promotion this way does not stretch anchor `100`. `100` means reproducible from the
+cited evidence alone, and the second `evidence` line *is* cited — the reader
+reproduces it from two quoted lines instead of one, without re-deriving anything.
 
 **Verification-promotion is not agreement-promotion, and *Independence Accounting*
 does not constrain it.** Agreement promotes on *witnesses*, so it needs separately
@@ -156,23 +162,39 @@ reviewers get the same treatment here, because a reviewer without the spec is
 reviewing what the code *is* against nothing but its own priors about what code
 should be.
 
+This contract governs what crosses a **dispatch boundary**. An inline run already
+holds all of it in context; *Dispatch Disclosure* governs what its agreement is
+worth.
+
 Every dispatch of `code-reviewer`, `critic`, `security-reviewer`, or
 `software-design-expert-review` must carry all seven:
 
 | # | Item | Why the reviewer cannot supply it itself |
 |---|------|------------------------------------------|
-| 1 | The `<base>..HEAD` diff — inline when small, else by path per *Large-Artifact Handoff* | it can run `git diff`, but not know which base this session used |
-| 2 | The spec path **and** the AC list verbatim | nothing in a diff names the spec it implements |
+| 1 | The `<base>...HEAD` diff — inline when small, else truncated-plus-path per *Large-Artifact Handoff* | it can run `git diff`, but not know which base this session used |
+| 2 | The spec path **and** the AC list verbatim, with the checkbox state stripped | nothing in a diff names the spec it implements |
 | 3 | The `tasks/todo.md` entries completed this run | separates "not implemented" from "next task, deliberately" |
 | 4 | The `[AMBIGUITY]` lines emitted this run | a decision already made and recorded reads as a defect |
 | 5 | The `TODO(shortcut):` markers touching changed files | same: a documented limit with an upgrade path is not a finding |
 | 6 | The boundary — review issues **introduced** by this session; pre-existing patterns are out of scope | today this is stated to the orchestrator and never to the agent |
 | 7 | The output format — four axes, `evidence` required at `75` or above | a persona drifts from the gate that consumes it |
 
-**Lists must distinguish **empty** from **absent**.** Pass `deferrals: none` and
-`no spec — <reason>`, never a missing line. A reviewer that cannot tell "nothing
-was deferred" from "nobody told me" has to assume the latter and re-flag
-everything, which is the noise this contract exists to remove.
+**Items 2–5 must distinguish **empty** from **absent**.** Pass `deferrals: none`
+and `no spec — <reason>`, never a missing line. A reviewer that cannot tell
+"nothing was deferred" from "nobody told me" has to assume the latter and re-flag
+everything, which is the noise this contract exists to remove. Items 1, 6 and 7
+have no empty form — a dispatch without them is incomplete, not empty.
+
+Keep items 2–5 bounded the way item 1 is. A 250-line spec pasted verbatim into four
+parallel dispatches costs four times what it reads; truncate-plus-path applies to
+any of them that outgrows the diff it explains.
+
+**A repo-survey dispatch has no session to describe.** `/auto-improve`'s discovery
+scan reviews the whole tree rather than a change, so items 2, 3 and 6 have no
+subject. It passes `no spec — repo survey, nothing built this run` and
+`deferrals: none`, and carries items 1, 4, 5 and 7 unchanged. This is the one
+exception, and it is an exception to the *subject* of the items, never to stating
+them.
 
 ### Share intent, withhold conclusions
 
@@ -185,6 +207,20 @@ any other reviewer's findings. These are judgements about whether the ask was me
 and that judgement is the reviewer's own product. Passing them would import
 exactly those priors that *Independence Accounting* keeps out, and the promotion
 rule would then count a downstream echo as an independent witness.
+
+The split is imperfect in one direction worth naming. A spec written by the builder
+argues for its own design, and an AC list encodes what the builder decided "done"
+means — so intent arrives carrying some of the author's case. Strip the checkbox
+state (item 2), and treat the spec's rationale as a **claim to be tested**, not as
+evidence. A reviewer that finds the spec's argument unsound should say so; that is
+a finding, not a scope violation.
+
+**A shared payload narrows independence to the reading, not the framing.** Four
+passes handed identical intent share a frame by construction, which is exactly the
+property *Independence Accounting* discounts. Their agreement still promotes,
+because each read the diff separately — but a finding that merely restates
+something the payload told all four is not corroboration, and must not be promoted
+on that basis.
 
 The split is why this contract does not simply forward the whole build trace.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,25 @@ Canonical emission format, so findings stay parseable across harnesses:
   read as `50` / `autofix_class: manual`: reported, never auto-applied, never
   discarded.
 
+### Resolving an anchor-75 finding
+
+Anchor `75` is a *pending question*, not a resting place. A finding parked there
+is reported and never applied, however cheap the check would have been.
+
+- A finding at `75` must **name** the specific caller, config key, or runtime value
+  its correctness turns on. "Depends on the caller" without naming one is a `50` —
+  it is a pattern match wearing a higher anchor.
+- Read that dependency and resolve the finding: promote to `100` with a second
+  `evidence` line quoting what you found, or drop it. A finding that stays at `75`
+  must say what stopped the check — outside the repo, needs runtime, budget spent.
+  It is never dropped for being unverifiable.
+
+**Verification-promotion is not agreement-promotion, and *Independence Accounting*
+does not constrain it.** Agreement promotes on *witnesses*, so it needs separately
+dispatched contexts. Verification promotes on *evidence*, so one context reading
+one more line is enough. Conflating them either forbids a legitimate promotion or
+licenses an illegitimate one.
+
 ### Independence Accounting
 
 Corroboration counts **only** when the findings came from separately dispatched
@@ -126,6 +145,48 @@ of promoting on it. Naming the loss is the correct floor, not a failure.
 
 Never claim independent corroboration from a model whose identity was only
 requested rather than verified.
+
+---
+
+## Review Dispatch Contract
+
+A dispatched reviewer knows only what its prompt carries. `/build` already holds
+implementers to a contract (§ *Delegation prompt must include* in `/build`);
+reviewers get the same treatment here, because a reviewer without the spec is
+reviewing what the code *is* against nothing but its own priors about what code
+should be.
+
+Every dispatch of `code-reviewer`, `critic`, `security-reviewer`, or
+`software-design-expert-review` must carry all seven:
+
+| # | Item | Why the reviewer cannot supply it itself |
+|---|------|------------------------------------------|
+| 1 | The `<base>..HEAD` diff — inline when small, else by path per *Large-Artifact Handoff* | it can run `git diff`, but not know which base this session used |
+| 2 | The spec path **and** the AC list verbatim | nothing in a diff names the spec it implements |
+| 3 | The `tasks/todo.md` entries completed this run | separates "not implemented" from "next task, deliberately" |
+| 4 | The `[AMBIGUITY]` lines emitted this run | a decision already made and recorded reads as a defect |
+| 5 | The `TODO(shortcut):` markers touching changed files | same: a documented limit with an upgrade path is not a finding |
+| 6 | The boundary — review issues **introduced** by this session; pre-existing patterns are out of scope | today this is stated to the orchestrator and never to the agent |
+| 7 | The output format — four axes, `evidence` required at `75` or above | a persona drifts from the gate that consumes it |
+
+**Lists must distinguish **empty** from **absent**.** Pass `deferrals: none` and
+`no spec — <reason>`, never a missing line. A reviewer that cannot tell "nothing
+was deferred" from "nobody told me" has to assume the latter and re-flag
+everything, which is the noise this contract exists to remove.
+
+### Share intent, withhold conclusions
+
+**Share intent** — spec, acceptance criteria, task text, constraints, and the
+documented deferrals above. These are facts about what was asked for, and a
+reviewer denied them reviews against its own assumptions instead.
+
+**Withhold conclusions** — the builder's account of why the code is correct, and
+any other reviewer's findings. These are judgements about whether the ask was met,
+and that judgement is the reviewer's own product. Passing them would import
+exactly those priors that *Independence Accounting* keeps out, and the promotion
+rule would then count a downstream echo as an independent witness.
+
+The split is why this contract does not simply forward the whole build trace.
 
 ---
 

--- a/specs/review-context-contract.md
+++ b/specs/review-context-contract.md
@@ -24,7 +24,11 @@ source files"* (`build/SKILL.md:132`), plus role-filtered slices of
 `tasks/project-context.md`. Reviewers have no equivalent. The builder therefore
 knows what the code was *for*; the reviewer sees only what it *is*.
 
-Two consequences, both observed rather than theorised:
+Two consequences. Both are reasoned from the mechanism, not measured here — this
+repo has never carried a real `TODO(shortcut):` marker or emitted an `[AMBIGUITY]`
+line, so items 4 and 5 have had no opportunity to fire and are a bet on downstream
+projects. Item 2 is different: it is a gap in the shipped instructions, checkable
+by reading them.
 
 1. **Deliberate decisions get re-litigated.** The repo produces two explicit
    deferral records — `[AMBIGUITY]` lines (`.claude/project.md` § *Ambiguity
@@ -220,24 +224,23 @@ so there is no third tree to mirror into.
       deleted, a dispatch site's pointer is removed, a persona's intake section is
       removed, or the anchor-75 rule is deleted — each probed and recorded
 
-### Mutation probes
-
-Run after committing, so the restore step (`git checkout -- .`) could not eat the
-work under test — the failure mode recorded in the project's own lessons.
-
-| Mutation | Guard | Real failures |
-|----------|-------|---------------|
-| Delete § *Review Dispatch Contract* wholesale | `test-review-context` §1–3 | 11 |
-| Drop the contract pointer from `wrap-up-session` (both trees) | §6 | 1 |
-| Rename one persona's `## Context Intake` heading | §7 | 1 |
-| Delete the anchor-75 naming rule | §4 | 2 |
-| Re-pin `auto-improve`'s design reviewer to a bare `sonnet` cell | `test-model-tiers` §8b | 1 |
-
-The single-assertion probes are single by design: each pins one fact in one file,
-and a wider blast radius would mean the needles overlap.
 - [x] `tests/test-skill-parity.sh` green over every edited skill
-- [x] `bash tests/run.sh` green, with the assertion count recorded against the
-      baseline
+- [x] No persona caps a severity with an `autofix_class` value, and every persona
+      carries a never-out-of-scope clause covering the never-on-the-chopping-block list
+- [x] The anchor-75 text agrees with the Apply Gate about what `75` does
+- [x] Both trees of `wrap-up-session` cite the contract at **both** of their dispatch
+      sites, verified by count rather than presence
+- [x] The alias guard catches a bold, capitalised, or suffixed alias and an
+      unlisted review charter — validated against 8 evasion fixtures
+- [x] `**Given to you**`, the contract pointer, and the boundary heading are each
+      pinned per persona per tree, with the boundary needle anchored so
+      `**Never out of scope**` cannot satisfy it
+- [x] `bash tests/run.sh`: **1250 assertions, 16 of 17 files green**. The one red
+      file, `tests/test-codex-install.sh`, fails identically on pristine
+      `origin/master` @ `23f0d7d` and is recorded at
+      `tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md`. Per-file:
+      `test-review-context` 88 (new), `test-model-tiers` 95 (was 149 before §8b
+      stopped looping per file), `test-agents` 162, `test-skill-parity` 42.
 
 ## Non-Goals
 
@@ -260,3 +263,29 @@ and a wider blast radius would mean the needles overlap.
   decisions. Adopted for intent, deliberately not for conclusions.
 - Industry comparisons of diff-only versus repository-aware reviewers — diff-only
   review is the dominant false-positive source; call-chain verification is the fix.
+
+## Mutation probes
+
+Run after committing, so the restore step (`git checkout -- .`) could not eat the
+work under test — the failure mode this project already recorded once.
+
+Counts are **assertions failed**, and a mutation applied to both trees fails twice
+because every loop here iterates `.agents` and `.claude`. The first table was wrong
+about three of five rows for exactly that reason; review caught it, and the rows
+below were re-measured against the hardened guards rather than adjusted on paper.
+
+| Mutation | Guard | Assertions failed |
+|----------|-------|-------------------|
+| Delete § *Review Dispatch Contract* wholesale | `test-review-context` §1–3 | 11 |
+| Drop the contract citation from the parallel-dispatch site (both trees) | §6 count | 2 |
+| Rename `critic`'s `## Context Intake` heading (both trees) | §7 | 2 |
+| Delete the `**Given to you**` paragraph from one persona (both trees) | §7 | 6 |
+| Delete `security-reviewer`'s boundary paragraph (both trees) | §7 | 2 |
+| Delete the anchor-75 naming rule | §4 | 2 |
+| Re-pin `auto-improve`'s design reviewer as `**Sonnet**` | `test-model-tiers` §8b | 1 |
+
+The last four rows are the ones that matter: each was **green** before review, and
+each is a guard that existed and did not bite. The bold-and-capitalised alias, the
+substring collision between `Out of scope` and `Never out of scope`, the entirely
+unpinned `Given to you`, and a per-file citation needle standing in for a per-site
+AC — four different ways to report success while measuring nothing.

--- a/specs/review-context-contract.md
+++ b/specs/review-context-contract.md
@@ -200,27 +200,43 @@ so there is no third tree to mirror into.
 
 ## Acceptance Criteria
 
-- [ ] `CLAUDE.md` has a § *Review Dispatch Contract* enumerating all seven items
-- [ ] It states the intent-shared / conclusions-withheld split, and why sharing
+- [x] `CLAUDE.md` has a § *Review Dispatch Contract* enumerating all seven items
+- [x] It states the intent-shared / conclusions-withheld split, and why sharing
       conclusions would corrupt Independence Accounting
-- [ ] All four reviewer dispatch sites cite the contract by section name
-- [ ] Each site states the absent-vs-empty rule for spec and deferrals
-- [ ] `CLAUDE.md` § *Finding Model* requires a finding at `75` to name its
+- [x] All four reviewer dispatch sites cite the contract by section name
+- [x] Each site states the absent-vs-empty rule for spec and deferrals
+- [x] `CLAUDE.md` § *Finding Model* requires a finding at `75` to name its
       dependency, and an unnamed dependency reads as `50`
-- [ ] It states the verification path (read the dependency → promote to `100` with
+- [x] It states the verification path (read the dependency → promote to `100` with
       evidence, or drop, or hold and say what stopped it)
-- [ ] It states that verification-promotion is not agreement-promotion and is not
+- [x] It states that verification-promotion is not agreement-promotion and is not
       constrained by Independence Accounting
-- [ ] All four review personas carry a `## Context Intake` section in **both** trees
+- [x] All four review personas carry a `## Context Intake` section in **both** trees
       (8 files), and `tests/test-agents.sh` stays green
-- [ ] `auto-improve` no longer pins the design reviewer to an alias
-- [ ] `tests/test-model-tiers.sh` §8 fails when a Ceiling role is pinned in a table
+- [x] `auto-improve` no longer pins the design reviewer to an alias
+- [x] `tests/test-model-tiers.sh` §8 fails when a Ceiling role is pinned in a table
       cell, not only via `model:`
-- [ ] `tests/test-review-context.sh` fails when any one of: the contract section is
+- [x] `tests/test-review-context.sh` fails when any one of: the contract section is
       deleted, a dispatch site's pointer is removed, a persona's intake section is
       removed, or the anchor-75 rule is deleted — each probed and recorded
-- [ ] `tests/test-skill-parity.sh` green over every edited skill
-- [ ] `bash tests/run.sh` green, with the assertion count recorded against the
+
+### Mutation probes
+
+Run after committing, so the restore step (`git checkout -- .`) could not eat the
+work under test — the failure mode recorded in the project's own lessons.
+
+| Mutation | Guard | Real failures |
+|----------|-------|---------------|
+| Delete § *Review Dispatch Contract* wholesale | `test-review-context` §1–3 | 11 |
+| Drop the contract pointer from `wrap-up-session` (both trees) | §6 | 1 |
+| Rename one persona's `## Context Intake` heading | §7 | 1 |
+| Delete the anchor-75 naming rule | §4 | 2 |
+| Re-pin `auto-improve`'s design reviewer to a bare `sonnet` cell | `test-model-tiers` §8b | 1 |
+
+The single-assertion probes are single by design: each pins one fact in one file,
+and a wider blast radius would mean the needles overlap.
+- [x] `tests/test-skill-parity.sh` green over every edited skill
+- [x] `bash tests/run.sh` green, with the assertion count recorded against the
       baseline
 
 ## Non-Goals

--- a/specs/review-context-contract.md
+++ b/specs/review-context-contract.md
@@ -1,0 +1,246 @@
+# Spec: Review Context Contract
+
+> Reviewer sub-agents receive scope and code. They do not receive intent. This
+> spec gives them a dispatch contract as explicit as the one implementers already
+> have, and closes the two Finding-Model gaps that the missing intent was hiding.
+
+## Behavior
+
+### The defect
+
+A reviewer dispatched by `/wrap-up-session`, `/quality-gate`, or
+`/software-design-expert-review` receives context through four channels:
+
+| Channel | Carries | Specified where |
+|---------|---------|-----------------|
+| Persona file (`.claude/agents/<name>.md`) | role, red flags, finding axes, read-only constraint | the file itself |
+| Dispatch prompt | whatever the orchestrator improvises | **only** `software-design-expert-review/SKILL.md:45` |
+| Ambient project files | `CLAUDE.md`, `.claude/project.md` | harness auto-load |
+| The repo | anything the agent chooses to read | **only** `security-reviewer.md:18` |
+
+`/build` already holds implementers to a contract — *"Delegation prompt must
+include: the exact task description, the relevant spec section, paths to related
+source files"* (`build/SKILL.md:132`), plus role-filtered slices of
+`tasks/project-context.md`. Reviewers have no equivalent. The builder therefore
+knows what the code was *for*; the reviewer sees only what it *is*.
+
+Two consequences, both observed rather than theorised:
+
+1. **Deliberate decisions get re-litigated.** The repo produces two explicit
+   deferral records — `[AMBIGUITY]` lines (`.claude/project.md` § *Ambiguity
+   Protocol*) and `TODO(shortcut):` markers (§ *Code Economy*, ledgered at
+   `wrap-up-session` Step 3.7). Neither reaches a reviewer, so a shortcut whose
+   limit and upgrade path are already written down comes back as a finding.
+2. **Acceptance criteria go unchecked.** Only Pass 4 is told to read the specs and
+   every AC (`wrap-up-session/SKILL.md:203`), and that instruction sits in the
+   skill, not in the dispatch payload — so a dispatched Pass 4 receives it only if
+   the orchestrator remembers to copy it. Passes 1–3 never see a spec at all.
+
+### The fix, in four parts
+
+**1. One canonical contract, four pointers.**
+`CLAUDE.md` gains § *Review Dispatch Contract* listing what every reviewer
+dispatch must carry. Each dispatch site states its site-specific payload and
+points at that section.
+
+Canonical over per-site copies because this repo has already paid for the
+alternative: PR #61 removed four concrete model IDs that had been duplicated
+across three files precisely because *"the two tables are the copies nobody
+updates."* A seven-item list copied into four skills is the same failure with more
+surface.
+
+The contract, in full:
+
+| Item | Why the reviewer cannot supply it | Absent-vs-empty |
+|------|-----------------------------------|-----------------|
+| Diff for `<base>..HEAD` — by path when > 500 lines, per *Large-Artifact Handoff* | it can derive this, but not which base | — |
+| Spec path **and** the AC list verbatim | nothing in the diff names the spec | `no spec — <reason>` |
+| The `tasks/todo.md` entries completed this run | tells apart "not implemented" from "next task" | — |
+| `[AMBIGUITY]` lines emitted this run | a documented decision reads as a defect | `deferrals: none` |
+| `TODO(shortcut):` markers touching changed files | same | `deferrals: none` |
+| Boundary: issues **introduced** by this session; pre-existing patterns out of scope | today this is stated to the orchestrator only | — |
+| Output format: the four axes, with `evidence` at 75+ | a persona can drift from the gate that consumes it | — |
+
+Every list must distinguish **empty** from **absent**. A reviewer given no
+deferral list cannot tell "nothing was deferred" from "nobody told me", and the
+conservative reading of the ambiguous case is to re-flag everything — which is the
+noise this spec exists to remove. Same hazard class as the vacuous
+`assert_not_contains` closed in #61.
+
+**2. Intent is shared; conclusions are not.**
+
+The two authorities disagree, and the disagreement is load-bearing here. Cognition
+argues for *"share context, and share full agent traces, not just individual
+messages"*, because *"actions carry implicit decisions"* and agents that cannot see
+each other's assumptions produce conflicting ones. Anthropic's context-engineering
+guidance argues the opposite for sub-agents: keep the detailed context isolated and
+return a distilled summary.
+
+For reviewers, this repo has already picked a side and written it down:
+`CLAUDE.md` § *Independence Accounting* — *"Two lenses reasoned inside one context
+are two perspectives, not two witnesses: they share the same priors and the same
+blind spots."* Handing a reviewer the builder's reasoning imports exactly those
+priors, and the promotion rule then counts a downstream echo as corroboration.
+
+So the contract carries a **split**, stated in `CLAUDE.md`:
+
+- **Share intent** — spec, ACs, task text, constraints, documented deferrals.
+  These are facts about what was asked for.
+- **Withhold conclusions** — the builder's account of why the code is correct, and
+  any other reviewer's findings. These are judgements about whether the ask was met,
+  and that judgement is the reviewer's own product.
+
+**3. Anchor 75 gets a verification path.**
+
+The `75` anchor already says the finding's *"correctness turns on a caller, config,
+or runtime value outside the reviewed scope."* Nothing then tells the reviewer to
+go read it — so a finding parks at 75 and, under the Apply Gate, is reported but
+never applied even when a single `grep` would settle it.
+
+Two rules, both in `CLAUDE.md` § *Finding Model*:
+
+- A finding at `75` must **name** the specific caller, config key, or runtime value
+  its correctness depends on. "Depends on the caller" without naming one is a `50`.
+- The reviewer should read that dependency and resolve the finding: promote to `100`
+  with the second `evidence` line, or drop it. A finding held at `75` must say what
+  stopped the check (outside the repo, requires runtime, budget exhausted).
+
+**Verification-promotion is not agreement-promotion, and Independence Accounting
+does not constrain it.** Agreement promotes on *witnesses*, so it needs independent
+contexts; verification promotes on *evidence*, so one context reading one more line
+is sufficient. Conflating them would either ban a legitimate promotion or license
+an illegitimate one.
+
+This is also the mechanism the industry converged on: diff-only reviewers are the
+dominant false-positive source, and following the call chain before emitting is
+what separates a confirmed defect from a pattern match.
+
+**4. Every reviewer persona declares its intake.**
+
+Each of the four review personas gains a `## Context Intake` section with three
+lines: what you will be given, what to fetch yourself, what is out of scope. Today
+only `security-reviewer` says any of it (`security-reviewer.md:18`), and it says
+only the first.
+
+This is the Anthropic multi-agent requirement applied per-persona — a sub-agent
+needs *"an objective, an output format, guidance on the tools and sources to use,
+and clear task boundaries."* Objective and output format are already in every
+persona. Sources and boundaries are in none.
+
+### Adjacent defect, found while writing this spec
+
+`auto-improve/SKILL.md:69` routes the design reviewer with a `| sonnet |` column
+cell. That is a Ceiling role pinned to an alias — the exact regression #61's
+section 8 exists to prevent. It survived because that guard matches
+`model: <alias>` and this is a bare table cell, so the guard has a hole one
+formatting choice wide.
+
+Two lines to fix (the cell, and a widened assertion). Included because the guard
+shipped hours ago and leaving a known hole in it is worse than the scope cost;
+tagged separately so it can be dropped without touching the four items above.
+
+## Inputs
+
+Read from disk on `origin/master` @ `23f0d7d` (PR #61 merged; #62 and the Codex
+adapter landed after), not assumed:
+
+- `CLAUDE.md` — § *Finding Model* (L73), confidence anchors (L93), § *Independence
+  Accounting* (L116), § *Review Gate Taxonomy* (L55).
+- `.agents/skills/build/SKILL.md:132` — the implementer delegation contract this
+  mirrors.
+- `.agents/skills/wrap-up-session/SKILL.md` — Step 4 (L122), *Dispatch Disclosure*
+  (L129), *Parallel Code Review* (L431). No payload specified at any of them.
+- `.agents/skills/quality-gate/SKILL.md:201` — Phase 3 dispatch. No payload.
+- `.agents/skills/software-design-expert-review/SKILL.md:45` — the only site that
+  specifies a payload (diff, paths, format instruction).
+- `.claude/agents/{code-reviewer,critic,security-reviewer,software-design-expert-review}.md`
+  plus the `.agents/agents/` canonicals — 8 files, no intake section in any.
+- `.agents/skills/auto-improve/SKILL.md:69` — the adjacent pin.
+- `tests/test-agents.sh` §3 — pins all four axes in **both** trees per persona.
+- `tests/test-model-tiers.sh` §8 — the `model: <alias>` guard with the hole.
+- `tests/test-skill-parity.sh` — byte-identical `.agents/skills` → `.claude/skills`.
+
+The Codex adapter renders from `.agents/` at install time (`scripts/render-codex.py`),
+so there is no third tree to mirror into.
+
+## Outputs
+
+| Path | Change |
+|------|--------|
+| `CLAUDE.md` | § *Review Dispatch Contract* (the 7-item table, the intent/conclusions split); § *Finding Model* gains the anchor-75 naming rule, the verification path, and the verification-vs-agreement distinction |
+| `.agents/skills/wrap-up-session/SKILL.md` + `.claude/` copy | Step 4 and *Parallel Code Review* carry the payload and point at the contract |
+| `.agents/skills/quality-gate/SKILL.md` + `.claude/` copy | Phase 3 dispatch carries the payload and points at the contract |
+| `.agents/skills/software-design-expert-review/SKILL.md` + `.claude/` copy | Phase 2's existing `Pass:` list extended to the full contract |
+| `.agents/skills/auto-improve/SKILL.md` + `.claude/` copy | design-review charter unpinned to *ceiling* |
+| `.agents/agents/*.md` + `.claude/agents/*.md` (4 personas × 2 trees) | `## Context Intake` section |
+| `tests/test-review-context.sh` | new — pins the contract at every site, the intake sections, and the anchor-75 rules |
+| `tests/test-model-tiers.sh` | §8 widened to catch a Ceiling role pinned in a table cell |
+
+## Edge Cases
+
+- **No spec this run** (a bug fix with no `specs/` file). The payload says
+  `no spec — <reason>` rather than omitting the line, so the reviewer knows the
+  absence is deliberate.
+- **No deferrals.** `deferrals: none`, never a missing line. See the absent-vs-empty
+  column above.
+- **Diff too large to inline.** *Large-Artifact Handoff* already answers this:
+  persist to a file, pass the path plus the last N lines, and say it was truncated.
+  The contract cites the convention rather than restating a line count.
+- **Inline (undispatched) review.** The contract is about what crosses a dispatch
+  boundary. An inline run already has all of it in context; *Dispatch Disclosure*
+  continues to govern what its agreement is worth.
+- **A reviewer that cannot verify an anchor-75 dependency** (needs runtime, or the
+  caller is outside the repo). It holds at `75` and states what stopped it. The
+  finding is never dropped for being unverifiable.
+- **Persona frontmatter.** #62 fixed YAML that silently deregistered three personas;
+  edits here are body-only, and `tests/test-agents.sh` §4 still parses every block.
+- **Contract text drifting from the sites that cite it.** The new test greps each
+  site for the pointer, so deleting the section fails the suite rather than leaving
+  four dangling references.
+
+## Acceptance Criteria
+
+- [ ] `CLAUDE.md` has a § *Review Dispatch Contract* enumerating all seven items
+- [ ] It states the intent-shared / conclusions-withheld split, and why sharing
+      conclusions would corrupt Independence Accounting
+- [ ] All four reviewer dispatch sites cite the contract by section name
+- [ ] Each site states the absent-vs-empty rule for spec and deferrals
+- [ ] `CLAUDE.md` § *Finding Model* requires a finding at `75` to name its
+      dependency, and an unnamed dependency reads as `50`
+- [ ] It states the verification path (read the dependency → promote to `100` with
+      evidence, or drop, or hold and say what stopped it)
+- [ ] It states that verification-promotion is not agreement-promotion and is not
+      constrained by Independence Accounting
+- [ ] All four review personas carry a `## Context Intake` section in **both** trees
+      (8 files), and `tests/test-agents.sh` stays green
+- [ ] `auto-improve` no longer pins the design reviewer to an alias
+- [ ] `tests/test-model-tiers.sh` §8 fails when a Ceiling role is pinned in a table
+      cell, not only via `model:`
+- [ ] `tests/test-review-context.sh` fails when any one of: the contract section is
+      deleted, a dispatch site's pointer is removed, a persona's intake section is
+      removed, or the anchor-75 rule is deleted — each probed and recorded
+- [ ] `tests/test-skill-parity.sh` green over every edited skill
+- [ ] `bash tests/run.sh` green, with the assertion count recorded against the
+      baseline
+
+## Non-Goals
+
+- No change to the four axes, the anchor definitions, or the Apply Gate thresholds.
+  Anchor `75` keeps its meaning; only what a reviewer must do about it is new.
+- No change to Independence Accounting. This spec bounds it, it does not weaken it.
+- No mechanical enforcement of what a dispatch prompt actually contained at runtime.
+  The guard is static, like the tier floors: it pins the instruction, not the call.
+- No change to `/build`'s implementer contract — it is the model being copied.
+- No new reviewer, lens, or gate. Four dispatch sites in, four out.
+
+## Sources
+
+- Anthropic, *How we built our multi-agent research system* — a sub-agent needs an
+  objective, an output format, guidance on tools and sources, and clear task
+  boundaries; vague descriptions produce duplicated work and coverage gaps.
+- Anthropic, *Effective context engineering for AI agents* — just-in-time context
+  via lightweight identifiers; hybrid preload; distilled returns.
+- Cognition, *Don't build multi-agents* — share full traces; actions carry implicit
+  decisions. Adopted for intent, deliberately not for conclusions.
+- Industry comparisons of diff-only versus repository-aware reviewers — diff-only
+  review is the dominant false-positive source; call-chain verification is the fix.

--- a/tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md
+++ b/tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md
@@ -1,0 +1,56 @@
+---
+title: Codex SessionStart hook emits nothing so its JSON assertion fails
+date: 2026-08-14
+problem_type: test-failure
+module: codex/hooks/session_start.py
+tags: [codex, hooks, tests, red-baseline, windows]
+symptoms: "tests/test-codex-install.sh — 1/22 assertions FAILED: `hook: SessionStart output validates as Codex JSON`, with a JSONDecodeError at line 1 column 1 (char 0), i.e. the hook produced no stdout at all"
+root_cause: not established; the hook shells out to a sibling script and produced no output in this environment — reproduced on a pristine detached worktree of origin/master @ 23f0d7d, so it is not caused by any local edit
+resolution: none yet — open. Recorded here so the next session does not mistake it for its own regression.
+needs_review: true
+---
+
+## Symptoms
+
+`bash tests/run.sh` on `origin/master` @ `23f0d7d` reports `RESULT: 1/16 test
+files FAILED`. The failing file is `tests/test-codex-install.sh`; every other
+assertion in it passes.
+
+The assertion is at `tests/test-codex-install.sh:107-119`: it pipes
+`{"source":"startup"}` into the installed
+`$CODEX_HOME/hooks/coding-agent-workflow-session-start.py` and parses the result
+as JSON. The parse fails at `char 0` — the hook wrote nothing to stdout.
+
+## Root cause
+
+**Not established.** What is established:
+
+- It reproduces on a **pristine** detached worktree of `origin/master` @ `23f0d7d`
+  with no local modifications, so it is not caused by branch work.
+- Invoking `codex/hooks/session_start.py` directly in that tree fails with
+  `coding-agent-workflow-session-start.sh: No such file or directory` (exit 127) —
+  the hook delegates to a sibling shell script by path. That path resolution is
+  the first thing to check, but the direct invocation used a `CODEX_HOME` the test
+  does not, so it is a lead rather than the diagnosis.
+
+The Codex adapter landed in `23f0d7d` (feat: add Codex harness adapter) with this
+test included, so the suite has been red since that commit rather than regressing
+later.
+
+## Why it is recorded rather than fixed
+
+Found during the pre-flight baseline of an unrelated branch
+(`feat/review-context-contract`, review dispatch contract). Fixing another
+subsystem inside that branch would violate the Trace test in `.claude/project.md`
+§ *Surgical Changes* — every changed line must trace to the current task.
+
+The cost of *not* recording it is concrete: a red baseline that nobody has written
+down gets attributed to whoever notices it next, and `/yolo`'s pre-flight halts on
+a red baseline without knowing whose red it is.
+
+## Prevention note
+
+The first baseline run of that session was itself worthless: it was launched and
+then the tree was edited while it ran, so the run picked up a test file that was
+still deliberately red. A baseline must be taken on an unmodified tree, or it
+measures a mixture. See `../process/baseline-must-precede-tree-edits.md`.

--- a/tasks/solutions/process/baseline-must-precede-tree-edits.md
+++ b/tasks/solutions/process/baseline-must-precede-tree-edits.md
@@ -1,0 +1,48 @@
+---
+title: A baseline run overlapping tree edits measures a mixture, not a baseline
+date: 2026-08-14
+problem_type: process
+module: tests/run.sh, /yolo and /auto-improve pre-flight
+tags: [testing, baseline, background-jobs, yolo]
+applies_when: launching the full suite as a background job to establish a green baseline, then starting work before it returns
+---
+
+## The rule
+
+Take the baseline **before** the first edit, and wait for it. A suite launched in
+the background and left running while you write files does not measure the tree you
+meant — `tests/run.sh` globs `tests/test-*.sh` at the moment it reaches that loop,
+so a test file created mid-run is discovered and executed.
+
+## What happened
+
+2026-08-14, `feat/review-context-contract`. The baseline was started in a fresh
+worktree, then the session immediately began TDD work — including writing a new,
+deliberately red `tests/test-review-context.sh`. The run reported
+`RESULT: 1/16 test files FAILED` against a 15-file tree.
+
+Two distinct wrong conclusions were both available from that output:
+
+1. **"My new test is the failure."** Plausible: it was red for most of the run, and
+   16 files where master has 15 is exactly the signature of a picked-up new file.
+2. **"Master is broken."** Also plausible, and in fact true — but for a *different*
+   file (`tests/test-codex-install.sh`, see
+   `../bugs/codex-session-start-hook-emits-nothing.md`).
+
+Only `awk`-ing the per-file markers out of the captured log distinguished them. Had
+the new test still been red when the run reached it, both files would have failed
+and the pre-existing breakage would have been easy to write off as self-inflicted.
+
+## How to apply
+
+- Establish the baseline on an unmodified tree; treat the wait as part of pre-flight,
+  not as dead time to fill with edits.
+- Capture per-file results, not just the exit code:
+  `awk '/^=== tests/{f=$2} /assertions FAILED/{print f}'` over the run log names the
+  culprit in one line. An exit code cannot.
+- When a baseline is red, prove *whose* red it is before deciding anything — a
+  detached worktree at the base commit (`git worktree add --detach <path> origin/master`)
+  answers it in one run and costs nothing.
+
+Related: `../bugs/codex-session-start-hook-emits-nothing.md` — the real failure this
+nearly masked.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -97,5 +97,5 @@
 [x] TDD: test asserts each dispatch site states the absent-vs-empty rule for spec and deferrals -> add the payload lines at each site
 [x] TDD: test asserts all 8 reviewer persona files (4 personas x 2 trees) carry a `## Context Intake` section naming given / fetch-yourself / out-of-scope -> add the section; `tests/test-agents.sh` must stay green (frontmatter untouched)
 [x] TDD: `tests/test-model-tiers.sh` §8 widened to fail when a Ceiling role is pinned in a bare table cell -> widen the guard, then unpin `auto-improve`'s design-review charter to *ceiling* (both trees)
-[ ] TDD: mutation probes — delete the contract section, remove one site's pointer, remove one persona's intake, delete the anchor-75 rule; each must turn the suite red. Commit first, then probe -> record counts in the spec
-[ ] TDD: `bash tests/test-skill-parity.sh` green over every edited skill; `bash tests/run.sh` green with assertion count recorded against the 1108-assertion baseline -> run both, then `/quality-gate`
+[x] TDD: mutation probes — delete the contract section, remove one site's pointer, remove one persona's intake, delete the anchor-75 rule; each must turn the suite red. Commit first, then probe -> record counts in the spec
+[x] TDD: `bash tests/test-skill-parity.sh` green over every edited skill; `bash tests/run.sh` green with assertion count recorded against the 1108-assertion baseline -> run both, then `/quality-gate`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -84,3 +84,18 @@
 - Completed: 6 tasks (Codex harness adapter, renderer, hooks, neutral project seed, docs, and validation)
 - Pending: 0
 - Carry-forward: review and merge the draft PR
+
+## Plan: Review Context Contract
+> Spec: specs/review-context-contract.md
+> Base: origin/master @ 23f0d7d — branch feat/review-context-contract (worktree)
+
+[x] TDD: `tests/test-review-context.sh` fails on master because `CLAUDE.md` has no § Review Dispatch Contract -> add the section with the 7-item payload table and the absent-vs-empty rule
+[x] TDD: same test asserts the intent-shared / conclusions-withheld split names Independence Accounting as the reason -> add the split to the new section
+[x] TDD: test asserts a finding at `75` must name its dependency and that an unnamed one reads as `50` -> extend `CLAUDE.md` § Finding Model
+[x] TDD: test asserts the verification path (read dependency -> promote to 100 with evidence, drop, or hold and say what stopped it) and that verification-promotion is NOT agreement-promotion -> extend § Finding Model
+[x] TDD: test asserts all four dispatch sites (wrap-up Step 4 + Parallel Code Review, quality-gate Phase 3, software-design-expert-review Phase 2) cite the contract by section name, in BOTH trees -> edit 3 skills canonical-first, then byte-identical copy
+[x] TDD: test asserts each dispatch site states the absent-vs-empty rule for spec and deferrals -> add the payload lines at each site
+[x] TDD: test asserts all 8 reviewer persona files (4 personas x 2 trees) carry a `## Context Intake` section naming given / fetch-yourself / out-of-scope -> add the section; `tests/test-agents.sh` must stay green (frontmatter untouched)
+[x] TDD: `tests/test-model-tiers.sh` §8 widened to fail when a Ceiling role is pinned in a bare table cell -> widen the guard, then unpin `auto-improve`'s design-review charter to *ceiling* (both trees)
+[ ] TDD: mutation probes — delete the contract section, remove one site's pointer, remove one persona's intake, delete the anchor-75 rule; each must turn the suite red. Commit first, then probe -> record counts in the spec
+[ ] TDD: `bash tests/test-skill-parity.sh` green over every edited skill; `bash tests/run.sh` green with assertion count recorded against the 1108-assertion baseline -> run both, then `/quality-gate`

--- a/tasks/yolo-idea.md
+++ b/tasks/yolo-idea.md
@@ -1,0 +1,42 @@
+# Yolo Idea — verbatim
+
+> Captured 2026-08-14. Source-of-truth prompt; survives context resets.
+
+"right those as specs and do a /yolo cycle (on top of this branch if possible but
+I already merged to main) so plan, build and wrap up and give me the PR to review"
+
+"those" = the four recommendations from the preceding research turn, which asked:
+*"how do the reviewers receive context from what was built? And what are the best
+practices? do a research"*
+
+The four recommendations, verbatim from that turn:
+
+1. **Add a "Review dispatch prompt must include" block** mirroring
+   `build/SKILL.md`'s implementer contract, and reference it from all three
+   dispatch sites: base..HEAD diff (path, not inlined), spec path + the AC list
+   verbatim, the completed `tasks/todo.md` entries, any `[AMBIGUITY]` lines and
+   `TODO(shortcut):` markers from the session, the boundary sentence ("issues
+   introduced by this session; pre-existing patterns out of scope" — currently
+   stated to the *orchestrator*, never to the agent), and the four-axis output
+   format.
+
+2. **Pass the deferral list explicitly.** Two mechanisms already produce it — the
+   Ambiguity Protocol and the shortcut ledger in wrap-up Step 3.7. A reviewer that
+   doesn't see them re-litigates decisions the user already made.
+
+3. **Make the 75→100 promotion depend on call-chain verification, not agreement.**
+   The `75` anchor is literally "correctness turns on a caller outside the reviewed
+   scope." Instructing reviewers to go read that caller converts anchor-75 findings
+   into proven or dropped ones, without touching Independence Accounting.
+
+4. **Give each persona an intake contract.** One paragraph per file: what you will
+   be given, what to fetch yourself, what is out of scope. Only
+   `security-reviewer` says it today.
+
+Research basis (see the spec's Sources section): Anthropic's multi-agent task
+description requirements, Anthropic's just-in-time context engineering, Cognition's
+share-full-context principle, and the industry finding that diff-only review is the
+dominant false-positive source.
+
+Base: `origin/master` @ 23f0d7d (PR #61 already merged; #62 and the Codex adapter
+landed after it). Branch: `feat/review-context-contract`.

--- a/tasks/yolo-log.md
+++ b/tasks/yolo-log.md
@@ -1,0 +1,43 @@
+# Yolo Session Log
+> Append-only. One entry per iteration. State lives here, not in context.
+
+## Iteration 1 — 2026-08-14 — IN PROGRESS
+
+**Work item**: Review Context Contract (the four research recommendations)
+**Spec**: specs/review-context-contract.md
+**Plan tasks**: 10 added, 10 completed
+**Branch**: feat/review-context-contract, worktree `.claude/worktrees/review-context`,
+based on `origin/master` @ 23f0d7d (verified — PR #61 had already merged, and two
+further commits landed after it)
+
+**Pre-flight**:
+- Branch safety: OK (not master)
+- Clean tree: OK by construction (fresh worktree; the parent clone's uncommitted
+  work belongs to another branch and did not enter this one)
+- Baseline: **RED, pre-existing.** `tests/test-codex-install.sh` fails on pristine
+  `origin/master` @ 23f0d7d — verified on a detached worktree, so not caused by
+  this branch. Recorded at `tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md`.
+  Yolo's pre-flight says halt on a red baseline; continued deliberately because the
+  failure is in an unrelated subsystem (Codex adapter) that this branch does not
+  touch, and halting would have delivered nothing. Flagged in the PR rather than
+  silently absorbed.
+- The first baseline run was itself invalid — launched, then the tree was edited
+  while it ran, so it discovered a deliberately-red new test file. Lesson recorded
+  at `tasks/solutions/process/baseline-must-precede-tree-edits.md`.
+
+**Commit**: dc37b6e — feat(review): hand reviewers the intent, not only the diff
+
+**Mutation probes** (run after committing, so the restore could not eat the work):
+| Mutation | Real failures |
+|---|---|
+| Delete § Review Dispatch Contract | 11 |
+| Drop the contract pointer from wrap-up-session | 1 |
+| Rename a persona's `## Context Intake` heading | 1 |
+| Delete the anchor-75 naming rule | 2 |
+| Re-pin auto-improve's design reviewer to a bare `sonnet` cell | 1 |
+
+**Review**: 4 passes dispatched as separate agents (`dispatched` per *Dispatch
+Disclosure*), each carrying the full payload the new contract requires — dogfooding
+the change under review.
+
+**Next**: reconcile findings, final suite, push, PR.

--- a/tasks/yolo-log.md
+++ b/tasks/yolo-log.md
@@ -38,6 +38,26 @@ further commits landed after it)
 
 **Review**: 4 passes dispatched as separate agents (`dispatched` per *Dispatch
 Disclosure*), each carrying the full payload the new contract requires — dogfooding
-the change under review.
+the change under review. ~40 findings; 15 applied in `443697e`, 1 more in the
+follow-up after a probe showed the fix's own guard was blind.
 
-**Next**: reconcile findings, final suite, push, PR.
+Independent corroboration (separately dispatched, so it promotes):
+
+| Finding | Passes |
+|---|---|
+| Parallel-dispatch site cites no contract; guard is per-file | 1, 2, 3, 4 |
+| Blanket deferral immunity in `code-reviewer` / `critic` | 2, 4 |
+| `auto-improve` is a fifth dispatch site, exempted only in a test comment | 1, 4 |
+| Probe-count rows do not reconcile with per-tree assertions | 1, 3, 4 |
+| `xargs basename` label dominates suite runtime | 1, 2 |
+
+Two findings the review made that no test could have: the review agents ran with
+the **old** personas, because dispatch resolves `.claude/agents/` from the project
+root rather than this worktree — so every persona change here is inert for the
+session that wrote it. And a payload shared by four passes is a shared prior, which
+narrows what their agreement is worth. Both are now in the spec's Edge Cases; the
+second is in the contract itself.
+
+**Result**: PASS.
+
+**Next**: exit — backlog empty, one work item, one PR.

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -130,9 +130,27 @@ assert_file_contains PI_SETUP.md "single source of concrete model IDs" \
 # by naming a different one, which is how `model: opus` and `model: haiku`
 # mutations stayed green here.
 for tree in .agents .claude; do
-  for skill in quality-gate software-design-expert-review wrap-up-session build plan; do
+  for skill in quality-gate software-design-expert-review wrap-up-session build plan auto-improve; do
     assert_file_not_matches "$tree/skills/$skill/SKILL.md" 'model: .?(sonnet|opus|haiku)' \
       "ModelTier: $tree $skill pins no Ceiling role to an alias"
+  done
+done
+
+# --- 8b. A table cell pins just as hard as frontmatter -----------------------
+# `model: <alias>` was the whole needle above, so a routing table written as
+# `| Design review | sonnet | ... |` walked past it untouched. That is exactly how
+# auto-improve kept the design reviewer pinned to `sonnet` through all of #61 --
+# the guard existed, matched the wrong syntax, and reported green.
+#
+# Matched on the *role* side rather than the alias side: a row that names a review
+# charter or a Ceiling agent and then puts a bare alias in the next cell. Sweeps
+# every skill in both trees, because the hole was never specific to one file.
+for tree in .agents .claude; do
+  for f in "$tree"/skills/*/SKILL.md; do
+    [ -f "$f" ] || continue
+    assert_file_not_matches "$f" \
+      '^\|.*([Dd]esign review|[Aa]dversarial|code-reviewer|security-reviewer|software-design-expert-review|critic).*\|[[:space:]]*.?(sonnet|opus|haiku).?[[:space:]]*\|' \
+      "ModelTier: $(dirname "$f" | xargs basename) ($tree) pins no review role in a table cell"
   done
 done
 

--- a/tests/test-model-tiers.sh
+++ b/tests/test-model-tiers.sh
@@ -142,16 +142,23 @@ done
 # auto-improve kept the design reviewer pinned to `sonnet` through all of #61 --
 # the guard existed, matched the wrong syntax, and reported green.
 #
-# Matched on the *role* side rather than the alias side: a row that names a review
-# charter or a Ceiling agent and then puts a bare alias in the next cell. Sweeps
-# every skill in both trees, because the hole was never specific to one file.
+# Matches a table row whose FIRST cell names a review charter and whose later cells
+# carry an alias. Deliberately loose on both sides, because the first draft of this
+# guard was defeated three ways in review: `**sonnet**` (bold), `Sonnet` (capital),
+# and `sonnet (floor)` (trailing token) all evaded a `.?alias.?` cell pattern, and a
+# hardcoded charter list missed `Code review` and `Correctness review`. Matching any
+# first-cell "review"/"critic"/"adversarial"/"audit" against any later alias catches
+# all of those; validated against 8 evasion fixtures and the repo's 6 legitimate
+# alias rows (Coding agents, Debugger, Scout, Test health, Performance, Reviewer).
+#
+# One grep per tree, reusing section 9's shape rather than looping files: the
+# per-file loop this replaces spawned three processes per skill and cost ~35s of
+# suite time on Windows, and a glob that matched nothing would have reported zero
+# assertions as a pass.
 for tree in .agents .claude; do
-  for f in "$tree"/skills/*/SKILL.md; do
-    [ -f "$f" ] || continue
-    assert_file_not_matches "$f" \
-      '^\|.*([Dd]esign review|[Aa]dversarial|code-reviewer|security-reviewer|software-design-expert-review|critic).*\|[[:space:]]*.?(sonnet|opus|haiku).?[[:space:]]*\|' \
-      "ModelTier: $(dirname "$f" | xargs basename) ($tree) pins no review role in a table cell"
-  done
+  hits="$(grep -rlE '^\|[^|]*([Rr]eview|[Aa]dversarial|[Cc]ritic|[Aa]udit)[^|]*\|.*([Ss]onnet|[Oo]pus|[Hh]aiku)' \
+    "$tree/skills" 2>/dev/null || true)"
+  assert_eq "" "$hits" "ModelTier: no review role pinned in a table cell under $tree/skills"
 done
 
 # --- 9. No concrete provider ID anywhere in either skill tree ----------------

--- a/tests/test-review-context.sh
+++ b/tests/test-review-context.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# tests/test-review-context.sh — reviewers must be handed intent, not only a diff.
+#
+# A dispatched reviewer sees whatever the orchestrator improvised. Before this
+# guard, one site of four specified a payload at all, so a reviewer routinely
+# reviewed a diff without the spec it implements, without the acceptance criteria
+# it must satisfy, and without the list of decisions the user already made. The
+# failure is silent in the worst way: the review still runs and still reports
+# findings, so a re-litigated `TODO(shortcut):` is indistinguishable from a real
+# defect.
+#
+# What can be pinned statically is the *instruction* — that each dispatch site
+# names the contract, that the contract enumerates its items, and that each
+# persona declares its intake. Whether a given runtime call actually carried them
+# is not observable from disk, the same limit the tier floors have.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+# The four sites that dispatch a reviewer with session work to review.
+# auto-improve's discovery scan is deliberately absent: it surveys the whole repo
+# for candidates rather than reviewing what a session just built, so it has no
+# spec, no AC list, and no deferral set to pass.
+DISPATCH_SITES="skills/wrap-up-session/SKILL.md skills/quality-gate/SKILL.md skills/software-design-expert-review/SKILL.md"
+
+REVIEW_PERSONAS="code-reviewer critic security-reviewer software-design-expert-review"
+
+# --- 1. The contract exists, in one place ------------------------------------
+# Canonical rather than copied into each skill: #61 removed four model IDs that
+# had been duplicated across three files because the copies nobody updates are
+# the ones that go stale. A seven-item payload list is a bigger version of that.
+assert_file_matches CLAUDE.md '^## Review Dispatch Contract' \
+  "ReviewContext: CLAUDE.md has a Review Dispatch Contract section"
+
+# Each payload item, pinned individually. A section heading alone would stay green
+# with the table emptied.
+assert_prose_contains CLAUDE.md 'the AC list verbatim' \
+  "ReviewContext: contract requires the acceptance criteria, not just the spec path"
+assert_prose_contains CLAUDE.md '[AMBIGUITY]' \
+  "ReviewContext: contract requires the ambiguity lines from this run"
+assert_prose_contains CLAUDE.md 'TODO(shortcut):' \
+  "ReviewContext: contract requires the shortcut markers"
+assert_prose_contains CLAUDE.md 'issues **introduced** by this session' \
+  "ReviewContext: contract passes the scope boundary to the agent"
+assert_prose_contains CLAUDE.md 'Large-Artifact Handoff' \
+  "ReviewContext: contract defers to the truncate-with-pointer convention for the diff"
+
+# --- 2. Empty must be distinguishable from absent ----------------------------
+# A reviewer handed no deferral list cannot tell "nothing was deferred" from
+# "nobody told me", and the safe reading of the ambiguous case is to re-flag
+# everything -- which is the noise this contract removes. Same hazard class as the
+# vacuous `assert_not_contains` closed in #61.
+assert_prose_contains CLAUDE.md 'deferrals: none' \
+  "ReviewContext: contract requires an explicit empty marker for deferrals"
+assert_prose_contains CLAUDE.md 'distinguish **empty** from **absent**' \
+  "ReviewContext: contract states the absent-vs-empty rule as a rule"
+
+# --- 3. Intent is shared; conclusions are not --------------------------------
+# The load-bearing half. Sharing the builder's reasoning would import the priors
+# that Independence Accounting exists to keep out, and the promotion rule would
+# then count an echo as a witness. The needles name the *reason*, not the slogan:
+# a section that says "share intent" without saying why is one edit from being
+# widened to "share everything".
+assert_prose_contains CLAUDE.md 'Share intent' \
+  "ReviewContext: contract says intent is shared"
+assert_prose_contains CLAUDE.md 'Withhold conclusions' \
+  "ReviewContext: contract says conclusions are withheld"
+assert_prose_contains CLAUDE.md 'would import exactly those priors' \
+  "ReviewContext: contract explains why conclusions are withheld"
+
+# --- 4. Anchor 75 has a named dependency and a way out ------------------------
+# The anchor already says correctness "turns on a caller, config, or runtime value
+# outside the reviewed scope" -- and then nothing tells the reviewer to go read it.
+# So findings park at 75, where the Apply Gate reports and never applies them,
+# even when one grep would settle it. Two rules close that: name the dependency,
+# then resolve it.
+assert_prose_contains CLAUDE.md 'must **name** the specific caller, config key, or runtime value' \
+  "ReviewContext: a finding at 75 must name what it depends on"
+assert_prose_contains CLAUDE.md 'without naming one is a `50`' \
+  "ReviewContext: an unnamed dependency demotes to 50"
+assert_prose_contains CLAUDE.md 'promote to `100` with a second `evidence` line' \
+  "ReviewContext: the verification path resolves a 75 rather than parking it"
+assert_prose_contains CLAUDE.md 'must say what stopped the check' \
+  "ReviewContext: a finding held at 75 states why it could not be verified"
+
+# --- 5. Verification-promotion is not agreement-promotion ---------------------
+# Conflating them breaks the gate in whichever direction the reader guesses:
+# either Independence Accounting forbids a legitimate one-context verification, or
+# "I verified it" licenses promoting on agreement. Both were reachable from the
+# text before this rule existed, so the distinction is pinned, not implied.
+assert_prose_contains CLAUDE.md 'Verification-promotion is not agreement-promotion' \
+  "ReviewContext: CLAUDE.md separates the two promotion mechanisms"
+assert_prose_contains CLAUDE.md 'promotes on *evidence*' \
+  "ReviewContext: verification promotes on evidence, so one context suffices"
+assert_prose_contains CLAUDE.md 'promotes on *witnesses*' \
+  "ReviewContext: agreement promotes on witnesses, which is what needs independence"
+
+# --- 6. Every dispatch site cites the contract and its empty markers ----------
+# Pinned per tree, not once: the `.agents` -> `.claude` copy is a plain `cp`, and
+# a site updated canonically but not copied ships the old prompt to Claude Code
+# while the test reads the fixed one. Parity tests catch a diff, not a stale pair
+# that was never re-copied -- so both are named here.
+for tree in .agents .claude; do
+  for site in $DISPATCH_SITES; do
+    f="$tree/$site"
+    # Prose, not literal: the citation is a sentence and wraps. A wrap-fragile
+    # needle here would fail on reflow and teach the next author to delete it.
+    assert_prose_contains "$f" 'CLAUDE.md` § *Review Dispatch Contract*' \
+      "ReviewContext: $f cites the Review Dispatch Contract"
+    assert_file_contains "$f" 'deferrals: none' \
+      "ReviewContext: $f passes an explicit empty marker for deferrals"
+    assert_file_contains "$f" 'no spec —' \
+      "ReviewContext: $f passes an explicit marker when there is no spec"
+  done
+done
+
+# --- 7. Each reviewer persona declares its intake ----------------------------
+# Anthropic's multi-agent guidance requires four things of a sub-agent prompt:
+# objective, output format, tools/sources, boundaries. Every persona already
+# carries the first two. Before this section none carried the last two, so each
+# agent improvised its own scope -- and a reviewer that decides its own scope is
+# the one that reports pre-existing patterns as this session's defects.
+for tree in .agents/agents .claude/agents; do
+  for p in $REVIEW_PERSONAS; do
+    f="$tree/$p.md"
+    assert_file_matches "$f" '^## Context Intake' \
+      "ReviewContext: $f declares a Context Intake section"
+    assert_file_contains "$f" 'Fetch yourself' \
+      "ReviewContext: $f says what to fetch itself"
+    assert_file_contains "$f" 'Out of scope' \
+      "ReviewContext: $f states its boundary"
+  done
+done
+
+# --- 8. No Ceiling role pinned in a bare table cell --------------------------
+# test-model-tiers.sh §8 matches `model: <alias>`, which a routing table written
+# as `| Design review | sonnet | ...` walks straight past. That is how
+# auto-improve kept a Ceiling role pinned through the whole of #61. The guard
+# belongs with the tier tests; the assertion here is the regression itself, so
+# deleting it from either file leaves one witness standing.
+for tree in .agents .claude; do
+  assert_file_not_matches "$tree/skills/auto-improve/SKILL.md" '^\| Design review \| .?(sonnet|opus|haiku)' \
+    "ReviewContext: $tree auto-improve does not pin the design reviewer to an alias"
+done
+
+finish

--- a/tests/test-review-context.sh
+++ b/tests/test-review-context.sh
@@ -121,7 +121,18 @@ for tree in .agents .claude; do
   # by either. Pin the second one -- the parallel-dispatch path -- separately: it is
   # the only path the skill says "licenses confidence promotion", so a payload that
   # silently stops reaching it degrades exactly the run that promotes on it.
-  assert_prose_contains "$tree/skills/wrap-up-session/SKILL.md"     'carries the *Review Payload* assembled in Step 4'     "ReviewContext: $tree wrap-up parallel dispatch carries the payload too"
+  assert_prose_contains "$tree/skills/wrap-up-session/SKILL.md" \
+    'carries the *Review Payload* assembled in Step 4' \
+    "ReviewContext: $tree wrap-up parallel dispatch carries the payload too"
+  # Counted, not merely present. The AC is "all four sites cite the contract", and
+  # a per-file needle is satisfied by the Step 4 citation alone -- probed: dropping
+  # the citation from the parallel-dispatch site left the suite fully green. Two
+  # sites in this file, so two citations.
+  cites="$(tr -s '[:space:]' ' ' < "$tree/skills/wrap-up-session/SKILL.md" \
+    | grep -oF 'CLAUDE.md` § *Review Dispatch Contract*' | wc -l | tr -d ' ')"
+  [ "$cites" -ge 2 ] && cites_ok=yes || cites_ok="no (found $cites)"
+  assert_eq "yes" "$cites_ok" \
+    "ReviewContext: $tree wrap-up cites the contract at both of its dispatch sites"
 done
 
 # --- 7. Each reviewer persona declares its intake ----------------------------

--- a/tests/test-review-context.sh
+++ b/tests/test-review-context.sh
@@ -18,11 +18,14 @@
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
 
-# The four sites that dispatch a reviewer with session work to review.
-# auto-improve's discovery scan is deliberately absent: it surveys the whole repo
-# for candidates rather than reviewing what a session just built, so it has no
-# spec, no AC list, and no deferral set to pass.
-DISPATCH_SITES="skills/wrap-up-session/SKILL.md skills/quality-gate/SKILL.md skills/software-design-expert-review/SKILL.md"
+# The three skill FILES that dispatch a reviewer. They hold four sites between
+# them -- wrap-up-session carries two (Step 4 and Parallel Code Review), which is
+# why the second one gets its own needle below rather than riding on the file.
+# auto-improve is absent by exception, not by oversight: its discovery scan surveys
+# the whole repo rather than a session's work, so items 2/3/6 have no subject. The
+# contract names that exception explicitly and still requires the empty markers, so
+# the rule stays stated rather than silently dropped.
+DISPATCH_SITE_FILES="skills/wrap-up-session/SKILL.md skills/quality-gate/SKILL.md skills/software-design-expert-review/SKILL.md"
 
 REVIEW_PERSONAS="code-reviewer critic security-reviewer software-design-expert-review"
 
@@ -62,7 +65,7 @@ assert_prose_contains CLAUDE.md 'distinguish **empty** from **absent**' \
 # then count an echo as a witness. The needles name the *reason*, not the slogan:
 # a section that says "share intent" without saying why is one edit from being
 # widened to "share everything".
-assert_prose_contains CLAUDE.md 'Share intent' \
+assert_prose_contains CLAUDE.md '**Share intent** — spec, acceptance criteria' \
   "ReviewContext: contract says intent is shared"
 assert_prose_contains CLAUDE.md 'Withhold conclusions' \
   "ReviewContext: contract says conclusions are withheld"
@@ -89,7 +92,8 @@ assert_prose_contains CLAUDE.md 'must say what stopped the check' \
 # either Independence Accounting forbids a legitimate one-context verification, or
 # "I verified it" licenses promoting on agreement. Both were reachable from the
 # text before this rule existed, so the distinction is pinned, not implied.
-assert_prose_contains CLAUDE.md 'Verification-promotion is not agreement-promotion' \
+assert_prose_contains CLAUDE.md 'agreement-promotion, and *Independence Accounting*
+does not constrain it' \
   "ReviewContext: CLAUDE.md separates the two promotion mechanisms"
 assert_prose_contains CLAUDE.md 'promotes on *evidence*' \
   "ReviewContext: verification promotes on evidence, so one context suffices"
@@ -102,7 +106,7 @@ assert_prose_contains CLAUDE.md 'promotes on *witnesses*' \
 # while the test reads the fixed one. Parity tests catch a diff, not a stale pair
 # that was never re-copied -- so both are named here.
 for tree in .agents .claude; do
-  for site in $DISPATCH_SITES; do
+  for site in $DISPATCH_SITE_FILES; do
     f="$tree/$site"
     # Prose, not literal: the citation is a sentence and wraps. A wrap-fragile
     # needle here would fail on reflow and teach the next author to delete it.
@@ -113,6 +117,11 @@ for tree in .agents .claude; do
     assert_file_contains "$f" 'no spec —' \
       "ReviewContext: $f passes an explicit marker when there is no spec"
   done
+  # wrap-up-session holds two of the four sites, and a per-file needle is satisfied
+  # by either. Pin the second one -- the parallel-dispatch path -- separately: it is
+  # the only path the skill says "licenses confidence promotion", so a payload that
+  # silently stops reaching it degrades exactly the run that promotes on it.
+  assert_prose_contains "$tree/skills/wrap-up-session/SKILL.md"     'carries the *Review Payload* assembled in Step 4'     "ReviewContext: $tree wrap-up parallel dispatch carries the payload too"
 done
 
 # --- 7. Each reviewer persona declares its intake ----------------------------
@@ -126,22 +135,28 @@ for tree in .agents/agents .claude/agents; do
     f="$tree/$p.md"
     assert_file_matches "$f" '^## Context Intake' \
       "ReviewContext: $f declares a Context Intake section"
+    # Anchored at line start. `assert_file_contains` is a substring match and
+    # `**Never out of scope**:` contains `Out of scope`, so the unanchored needle
+    # stayed green with the entire boundary paragraph deleted from the one persona
+    # that also carries a carve-out. Found by probing, not by reading.
+    assert_file_matches "$f" '^\*\*Out of scope\*\*' \
+      "ReviewContext: $f states its boundary"
+    assert_file_matches "$f" '^\*\*Given to you\*\*' \
+      "ReviewContext: $f states what it will be handed"
     assert_file_contains "$f" 'Fetch yourself' \
       "ReviewContext: $f says what to fetch itself"
-    assert_file_contains "$f" 'Out of scope' \
-      "ReviewContext: $f states its boundary"
+    assert_prose_contains "$f" 'CLAUDE.md` § *Review Dispatch Contract*' \
+      "ReviewContext: $f points at the contract it is the receiving end of"
+    assert_file_contains "$f" 'deferrals: none' \
+      "ReviewContext: $f knows an empty deferral list from a missing one"
   done
 done
 
-# --- 8. No Ceiling role pinned in a bare table cell --------------------------
-# test-model-tiers.sh §8 matches `model: <alias>`, which a routing table written
-# as `| Design review | sonnet | ...` walks straight past. That is how
-# auto-improve kept a Ceiling role pinned through the whole of #61. The guard
-# belongs with the tier tests; the assertion here is the regression itself, so
-# deleting it from either file leaves one witness standing.
-for tree in .agents .claude; do
-  assert_file_not_matches "$tree/skills/auto-improve/SKILL.md" '^\| Design review \| .?(sonnet|opus|haiku)' \
-    "ReviewContext: $tree auto-improve does not pin the design reviewer to an alias"
-done
+# The Ceiling-in-a-table-cell rule lives in tests/test-model-tiers.sh section 8b,
+# not here. An earlier draft asserted it in both files and called that redundancy;
+# probing showed this copy was strictly weaker (it required exact single spacing,
+# so `|Design review | sonnet |` walked past it while 8b caught it). Two guards
+# where one is weaker is not two witnesses -- it is one witness and a decoy that
+# makes the pair look stronger than it is.
 
 finish


### PR DESCRIPTION
Reviewers were handed scope and code, never intent. This gives them a dispatch contract as explicit as the one `/build` has held implementers to since its first version, and closes the two Finding-Model gaps the missing intent was hiding.

Spec: `specs/review-context-contract.md`. Research basis: Anthropic's multi-agent task-description requirements and its just-in-time context-engineering guidance, Cognition's share-full-traces argument, and the industry finding that diff-only review is the dominant false-positive source.

## The defect

A dispatched reviewer receives context through four channels, and exactly **one of four dispatch sites** specified what to put in the prompt. So a reviewer read a diff without the spec it implements, without the acceptance criteria it must satisfy, and without the list of decisions the user had already made — then reported a documented `TODO(shortcut):` as a defect, indistinguishable from a real one.

The asymmetry is the tell: `build/SKILL.md:132` gives implementers the exact task text, the relevant spec section, related paths, and role-filtered project context. Reviewers had no equivalent. The builder knew what the code was *for*; the reviewer saw only what it *is*.

## What ships

**`CLAUDE.md` § Review Dispatch Contract** — seven required items (diff, spec path + AC list, closed task entries, `[AMBIGUITY]` lines, `TODO(shortcut):` markers, the introduced-only boundary, the output format), and the rule that items 2–5 distinguish **empty** from **absent**: `deferrals: none`, `no spec — <reason>`, never a missing line. A reviewer that cannot tell "nothing was deferred" from "nobody told me" assumes the latter and re-flags everything.

**Share intent, withhold conclusions.** The two authorities disagree here and the disagreement is load-bearing. Cognition argues for sharing full agent traces; Anthropic's context guidance argues for isolation plus distilled returns. For reviewers this repo already picked a side — *Independence Accounting* says same-context agreement is not corroboration — so intent is shared (spec, ACs, task text, deferrals) and conclusions are withheld (builder rationale, other reviewers' findings). Passing the latter imports the priors the promotion rule exists to exclude.

**Anchor 75 gets a resolution path.** It already said correctness "turns on a caller, config, or runtime value outside the reviewed scope" and then never told the reviewer to go read it. Now: name the dependency (unnamed reads as `50`), then promote to `100` with a second evidence line, drop it, or say what stopped the check. **Verification-promotion is not agreement-promotion** — verification promotes on *evidence*, so one context suffices; agreement promotes on *witnesses*, which is what needs independence.

**Four personas gain `## Context Intake`** — given / fetch yourself / out of scope, in both trees.

**Adjacent:** `auto-improve` pinned the design reviewer with a bare `| sonnet |` table cell. #61's guard matched `model: <alias>` only, so a Ceiling role stayed pinned through the entire PR that existed to unpin it.

## The review round is the interesting part

Four passes were dispatched **carrying the payload this PR introduces** — dogfooding it. They returned ~40 findings against the first commit; 16 were applied. Four of them are guards that existed, ran, and reported green while measuring nothing:

| What was green | Why it was green |
|---|---|
| `Out of scope` assertion on every persona | `assert_file_contains` is a substring match, and `**Never out of scope**:` contains it. The one persona with a carve-out was the one whose boundary was unguarded. |
| The alias guard, against `**Sonnet**` | `.?` admits one wrapper char; the alias list was lowercase-only. Bold, capitalised, and `sonnet (floor)` all walked past. |
| `**Given to you**` in all 8 persona files | Never pinned at all — the whole paragraph, including the contract pointer, was deletable with a green suite. |
| "All four sites cite the contract" | `assert_prose_contains` is per **file**; `wrap-up-session` holds two sites, and Step 4's citation satisfied the needle for both. |

The last one bit twice: my *fix* for it was itself probed green, because the new needle pinned the payload sentence rather than the citation. The guard now counts citations instead of testing presence.

Two findings changed the design rather than the code:

- **An AC list carries the author's conclusion.** Passed "verbatim", it ships the `[x]` checkbox state — the builder's judgement that the ask was met, which is exactly the class the contract says to withhold. The contract now says strip it, and treat the spec's rationale as a claim under test.
- **A shared payload is a shared prior.** Four passes handed identical intent agree partly because they were framed identically — the property *Independence Accounting* discounts. Promotion still stands, since each read the diff separately, but a finding that only restates a payload item is not corroboration. Stated in the contract rather than left to be discovered.

## Corroboration

Separately dispatched, so this promotes by one anchor per *Independence Accounting*:

| Finding | Passes |
|---|---|
| Parallel-dispatch site cites no contract; guard is per-file | 1, 2, 3, 4 |
| Blanket deferral immunity in `code-reviewer` / `critic` | 2, 4 |
| `auto-improve` is a fifth dispatch site, exempted only in a test comment | 1, 4 |
| Probe counts do not reconcile with per-tree assertions | 1, 3, 4 |
| `xargs basename` label dominates suite runtime | 1, 2 |

## Mutation probes

| Mutation | Guard | Assertions failed |
|---|---|---|
| Delete § *Review Dispatch Contract* | §1–3 | 11 |
| Drop the parallel-dispatch citation (both trees) | §6 count | 2 |
| Rename `critic`'s intake heading (both trees) | §7 | 2 |
| Delete `**Given to you**` from one persona (both trees) | §7 | 6 |
| Delete `security-reviewer`'s boundary paragraph (both trees) | §7 | 2 |
| Delete the anchor-75 naming rule | §4 | 2 |
| Re-pin the design reviewer as `**Sonnet**` | `test-model-tiers` §8b | 1 |

## Also

`test-model-tiers.sh` §8b now uses §9's one-grep-per-tree shape instead of a per-file loop: **149 → 95 assertions, 2m+ → 16s**. The old loop spawned three processes per skill and would have reported green on an empty glob.

## Known red, not from this branch

`tests/test-codex-install.sh` fails on `origin/master` @ `23f0d7d` — the Codex SessionStart hook emits nothing, so its JSON assertion dies at char 0. Reproduced on a pristine detached worktree, so it predates this branch and arrived with the Codex adapter commit. Recorded at `tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md`. `/yolo`'s pre-flight says halt on a red baseline; I continued because the failure is in a subsystem this branch does not touch, and flagged it rather than absorbing it.

**Not-tested:** every rule here is prose that a runtime dispatch can ignore — the tests pin the instruction, not the call, the same limit the tier floors have. Separately, sub-agent dispatch resolves `.claude/agents/` from the project root, not from a worktree, so the persona changes in this PR were **not** live for the review that produced it; they take effect for later sessions. Both limits are in the spec's Edge Cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
