### PR TITLE
fix(codex): restore SessionStart output on Windows

### DIFF
--- a/codex/hooks/session_start.py
+++ b/codex/hooks/session_start.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -11,11 +12,19 @@ from pathlib import Path
 
 def main() -> int:
     hook = Path(__file__).with_name("coding-agent-workflow-session-start.sh")
+    # The shell hook's double-invocation guard is a Claude Code workaround: that
+    # harness registers the hook twice (globally and per-project), so the second
+    # firing has to exit silently. Codex registers it exactly once, so here the
+    # guard can only ever suppress the one banner there is. It reliably does on
+    # Windows: the guard keys on $PPID, and bash spawned from a native Windows
+    # process reports PPID 1, so every invocation collides on a single sentinel
+    # and every run inside its 5-minute window emits nothing at all.
     result = subprocess.run(
         ["bash", str(hook)],
         input=sys.stdin.buffer.read(),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env={**os.environ, "CCW_SESSION_GUARD": "0"},
         check=False,
     )
     if result.stderr:
@@ -28,7 +37,13 @@ def main() -> int:
                 "additionalContext": output,
             }
         }
-        print(json.dumps(payload, ensure_ascii=False))
+        # Written as UTF-8 bytes rather than print()ed. The banner carries box
+        # rules, arrows and em-dashes, while Python encodes stdout with the
+        # platform default — cp1252 on Windows, where print() raises
+        # UnicodeEncodeError and Codex receives no JSON at all.
+        sys.stdout.buffer.write(
+            (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+        )
     return result.returncode
 
 

--- a/tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md
+++ b/tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md
@@ -1,56 +1,98 @@
 ---
 title: Codex SessionStart hook emits nothing so its JSON assertion fails
-date: 2026-08-14
+date: 2026-08-17
 problem_type: test-failure
 module: codex/hooks/session_start.py
-tags: [codex, hooks, tests, red-baseline, windows]
+tags: [codex, hooks, tests, windows, encoding]
 symptoms: "tests/test-codex-install.sh — 1/22 assertions FAILED: `hook: SessionStart output validates as Codex JSON`, with a JSONDecodeError at line 1 column 1 (char 0), i.e. the hook produced no stdout at all"
-root_cause: not established; the hook shells out to a sibling script and produced no output in this environment — reproduced on a pristine detached worktree of origin/master @ 23f0d7d, so it is not caused by any local edit
-resolution: none yet — open. Recorded here so the next session does not mistake it for its own regression.
-needs_review: true
+root_cause: "Two stacked defects in the Codex adapter, both Windows-only. (1) The shared shell hook's double-invocation guard keys on $PPID, which is 1 for any bash spawned from a native Windows process, so every adapter invocation collides on one sentinel and all but the first in a 5-minute window exit silently. (2) With the guard out of the way, `print()` encoded the banner with the platform default (cp1252), raising UnicodeEncodeError before any JSON reached stdout."
+resolution: "codex/hooks/session_start.py now passes CCW_SESSION_GUARD=0 to the shell hook (Codex registers it once, so the Claude Code de-duplication guard can only suppress) and writes the JSON as explicit UTF-8 bytes to sys.stdout.buffer instead of print()."
 ---
 
 ## Symptoms
 
-`bash tests/run.sh` on `origin/master` @ `23f0d7d` reports `RESULT: 1/16 test
-files FAILED`. The failing file is `tests/test-codex-install.sh`; every other
-assertion in it passes.
+`bash tests/run.sh` reported `RESULT: 1/16 test files FAILED`. The failing file
+was `tests/test-codex-install.sh`; every other assertion in it passed.
 
-The assertion is at `tests/test-codex-install.sh:107-119`: it pipes
-`{"source":"startup"}` into the installed
+The assertion pipes `{"source":"startup"}` into the installed
 `$CODEX_HOME/hooks/coding-agent-workflow-session-start.py` and parses the result
-as JSON. The parse fails at `char 0` — the hook wrote nothing to stdout.
+as JSON. The parse failed at `char 0` — the hook wrote nothing to stdout.
+
+Linux CI passed the full suite throughout, so the red was invisible to everyone
+except Windows contributors.
 
 ## Root cause
 
-**Not established.** What is established:
+Two independent defects, stacked so that fixing either alone leaves the test red.
+The second is *masked* by the first: the guard exits before the encode is
+reached, which is why the failure presented as silence rather than a traceback.
 
-- It reproduces on a **pristine** detached worktree of `origin/master` @ `23f0d7d`
-  with no local modifications, so it is not caused by branch work.
-- Invoking `codex/hooks/session_start.py` directly in that tree fails with
-  `coding-agent-workflow-session-start.sh: No such file or directory` (exit 127) —
-  the hook delegates to a sibling shell script by path. That path resolution is
-  the first thing to check, but the direct invocation used a `CODEX_HOME` the test
-  does not, so it is a lead rather than the diagnosis.
+**1 — the double-invocation guard collapses onto one key.**
+`.claude/hooks/session-start.sh:43-65` de-duplicates the banner for Claude Code,
+which registers the hook twice (globally by `install.sh` and per-project by
+`.claude/settings.json`). Without `jq` or a `session_id` it falls back to
+`GUARD_KEY=${GUARD_KEY:-$PPID}` (`session-start.sh:49`).
 
-The Codex adapter landed in `23f0d7d` (feat: add Codex harness adapter) with this
-test included, so the suite has been red since that commit rather than regressing
-later.
+Bash spawned from a native Windows process reports `PPID=1` — verified directly:
 
-## Why it is recorded rather than fixed
+```
+$ python3 -c "import subprocess;print(subprocess.run(['bash','-c','echo PPID=\$PPID'],capture_output=True,text=True).stdout)"
+PPID=1
+```
 
-Found during the pre-flight baseline of an unrelated branch
-(`feat/review-context-contract`, review dispatch contract). Fixing another
-subsystem inside that branch would violate the Trace test in `.claude/project.md`
-§ *Surgical Changes* — every changed line must trace to the current task.
+So every Codex invocation writes and reads the single sentinel
+`$TMPDIR/.ccw-session-start-1-startup`, and the 5-minute freshness window at
+`session-start.sh:55-63` silently `exit 0`s every run after the first. Codex
+registers the hook exactly once, so the guard has nothing legitimate to suppress
+there — it can only ever delete the one banner that exists.
 
-The cost of *not* recording it is concrete: a red baseline that nobody has written
-down gets attributed to whoever notices it next, and `/yolo`'s pre-flight halts on
-a red baseline without knowing whose red it is.
+This also explains why the failure looked non-deterministic: on a machine with no
+recent sentinel the first run got through, and every run for the next five
+minutes did not.
 
-## Prevention note
+**2 — `print()` encodes stdout with the platform default.**
+With the guard disabled, the adapter reached its output line and raised:
 
-The first baseline run of that session was itself worthless: it was launched and
-then the tree was edited while it ran, so the run picked up a test file that was
-still deliberately red. A baseline must be taken on an unmodified tree, or it
-measures a mixture. See `../process/baseline-must-precede-tree-edits.md`.
+```
+UnicodeEncodeError: 'charmap' codec can't encode characters in position 79-118
+```
+
+The banner carries box rules, arrows and em-dashes; Python 3.13 on Windows
+encodes stdout as cp1252. `ensure_ascii=False` was already set, so the JSON
+string kept its non-ASCII and `print()` could not encode it.
+
+## Resolution
+
+Both fixed in `codex/hooks/session_start.py`:
+
+- `subprocess.run(..., env={**os.environ, "CCW_SESSION_GUARD": "0"})` — the
+  shell hook already documents that escape hatch (`session-start.sh:41`).
+- `sys.stdout.buffer.write((json.dumps(...) + "\n").encode("utf-8"))` in place of
+  `print()`. Chosen over setting `PYTHONIOENCODING` because it holds regardless
+  of how Codex or a test invokes the adapter, rather than depending on the
+  caller's environment.
+
+The shell hook itself is unchanged: its guard is correct for the harness it was
+written for.
+
+## Verification
+
+Each fix was mutation-probed separately against
+`tests/test-codex-install.sh` — reverting either one alone reproduces
+`2/23 assertions FAILED`, so neither is redundant. Full suite: 17/17 files pass
+on Windows.
+
+The test now pins both. It asserts the decoded `additionalContext` contains
+non-ASCII (so a return to `print()` fails rather than passing on an
+ASCII-only banner), and it invokes the adapter twice, asserting the second run
+still emits (so a re-enabled guard fails deterministically instead of depending
+on sentinel age).
+
+## Related
+
+- A second-order effect of defect 1 is *not* fixed here and remains open: on
+  Windows the same `PPID=1` collapse means two Claude Code sessions started in
+  different repos within five minutes share the sentinel, so the second gets no
+  banner. That is a defect in the shared hook rather than the Codex adapter.
+- `../process/baseline-must-precede-tree-edits.md` — the earlier session's first
+  baseline run was taken while the tree was being edited and was worthless.

--- a/tests/test-codex-install.sh
+++ b/tests/test-codex-install.sh
@@ -106,18 +106,33 @@ assert_files_identical "$BOX/hooks.before" "$CODEX_HOME/hooks.json" \
 
 HOOK_RESULT="$(printf '%s\n' '{"source":"startup"}' | HOME="$HOME_DIR" CODEX_HOME="$CODEX_HOME" \
   python3 "$CODEX_HOME/hooks/coding-agent-workflow-session-start.py")"
+# Run it a second time before asserting anything. The shell hook's
+# double-invocation guard is a Claude Code workaround that the adapter disables,
+# because it keys on $PPID — which is 1 for every bash spawned from a native
+# Windows process, collapsing all invocations onto one sentinel. Left enabled,
+# only the very first run in a 5-minute window carries a banner, so a
+# single-shot assertion passes on a clean machine and fails on a busy one.
+HOOK_RESULT_AGAIN="$(printf '%s\n' '{"source":"startup"}' | HOME="$HOME_DIR" CODEX_HOME="$CODEX_HOME" \
+  python3 "$CODEX_HOME/hooks/coding-agent-workflow-session-start.py")"
 if python3 - "$HOOK_RESULT" <<'PY'
 import json
 import sys
 data = json.loads(sys.argv[1])
 assert data["hookSpecificOutput"]["hookEventName"] == "SessionStart"
-assert "additionalContext" in data["hookSpecificOutput"]
+context = data["hookSpecificOutput"]["additionalContext"]
+assert "SESSION START" in context, context[:200]
+# The banner is non-ASCII, which is why the adapter must not let Python encode
+# stdout with the platform default (cp1252 on Windows raises UnicodeEncodeError
+# there and emits nothing). Asserting only on shape would not catch that.
+assert any(ord(character) > 127 for character in context)
 PY
 then
   :
 else
   assert_eq "0" "1" "hook: SessionStart output validates as Codex JSON"
 fi
+assert_contains "$HOOK_RESULT_AGAIN" '"hookEventName": "SessionStart"' \
+  "hook: repeat invocation still emits context"
 
 BAD="$BOX/bad-agents"
 mkdir -p "$BAD"


### PR DESCRIPTION
## Problem

`tests/test-codex-install.sh` failed one assertion — `hook: SessionStart output validates as Codex JSON` — with a `JSONDecodeError` at char 0: the Codex SessionStart adapter wrote nothing to stdout. Linux CI has been green throughout, so the red was visible only to Windows contributors, whose suite therefore never ran fully green locally.

This is a product defect, not a test defect. Codex users on Windows get no session context at all.

## Root cause

Two stacked Windows-only defects, the second **masked** by the first — which is why the failure presented as silence rather than the traceback an encoding bug would produce.

**1 — the double-invocation guard collapses onto a single key.** `.claude/hooks/session-start.sh:43-65` de-duplicates the banner for Claude Code, which registers the hook twice (globally via `install.sh`, per-project via `.claude/settings.json`). Without `jq` it falls back to `GUARD_KEY=${GUARD_KEY:-$PPID}`, and bash spawned from a native Windows process reports `PPID=1`:

```
$ python3 -c "import subprocess;print(subprocess.run(['bash','-c','echo PPID=\$PPID'],capture_output=True,text=True).stdout)"
PPID=1
```

Every adapter invocation therefore collides on the single sentinel `$TMPDIR/.ccw-session-start-1-startup`, and the 5-minute freshness window silently `exit 0`s every run after the first. This also explains the apparent non-determinism: the assertion passed on a machine with no recent sentinel and failed on a busy one.

**2 — `print()` encodes stdout with the platform default.** With the guard cleared, the adapter reached its output line and raised `UnicodeEncodeError: 'charmap' codec can't encode characters in position 79-118`. The banner carries box rules, arrows and em-dashes; Python on Windows encodes stdout as cp1252.

## Fix

Both in `codex/hooks/session_start.py`:

- Pass `CCW_SESSION_GUARD=0` to the shell subprocess — the escape hatch the hook already documents. Codex registers the hook exactly once, so the Claude Code de-duplication guard can only ever suppress the one banner that exists.
- Write the JSON as explicit UTF-8 bytes to `sys.stdout.buffer` instead of `print()`. Chosen over `PYTHONIOENCODING=utf-8` because it holds regardless of how Codex or a test invokes the adapter, rather than depending on the caller's environment.

`.claude/hooks/session-start.sh` is deliberately **unchanged** — its guard is correct for the harness it was written for.

## Verification

- Full suite on Windows: **17/17 test files pass** (was `1/16 FAILED`).
- Each fix mutation-probed separately: reverting either one alone reproduces `2/23 assertions FAILED`, so neither is redundant.
- Nothing in the change is platform-conditional, so Linux CI is unaffected.

Note on reading the output: the count goes `1/22 FAILED` → `22 passed` rather than to 23, because the `if/else` idiom in that file registers an assertion only on failure — a passing JSON check prints nothing.

The test now pins both defects: it asserts the decoded `additionalContext` contains non-ASCII (so a return to `print()` cannot pass on an ASCII-only banner), and it invokes the adapter twice (so a re-enabled guard fails deterministically rather than depending on sentinel age).

`tasks/solutions/bugs/codex-session-start-hook-emits-nothing.md` recorded this root cause as "not established" and carried `needs_review: true`; it is now closed out with the established cause and resolution.

## Out of scope — filed separately

Two findings surfaced during the audit and are **not** addressed here:

1. **The same `PPID=1` collapse affects Claude Code on Windows.** Two sessions started in different repos within five minutes share the sentinel, so the second gets no banner. That is a defect in the shared hook, not the Codex adapter, and needs a guard key that survives without `$PPID`.
2. **`generate-presentation.py:39` reads `sys.stdin.read()`** for its documented `--markdown -` mode while the file branch beside it is explicit UTF-8 — same defect class, untested path, and mirrored across a byte-identical file pair.

No other test in `tests/` pipes hook or script output through Python; `render-codex.py`, `migrate-learning-store.py` and both skill scripts already use explicit `encoding="utf-8"` for file IO and print only ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
