### PR TITLE
feat(verify): optional lightpanda e2e browser tier behind a fail-closed AC classifier

### DIFF
--- a/.agents/skills/brainstorm/SKILL.md
+++ b/.agents/skills/brainstorm/SKILL.md
@@ -25,6 +25,13 @@ DO NOT invoke /plan, /build, /tdd, write any code, scaffold any project, or take
 - Grep tasks/solutions/ frontmatter (architecture-decision, pattern docs) for architectural context and past decisions
 - Understand what already exists before proposing anything new
 
+**Reading prior art on a JS-rendered page.** `WebFetch` returns the empty shell
+for an SPA and gives no signal that it did, so a page can read as "nothing there"
+when the content simply had not run yet. If `lightpanda fetch <url>` is available
+it executes the scripts first and dumps HTML or markdown. It is optional — when
+it is absent, use `WebFetch` and say what you could not read. **A missing
+lightpanda is not an error and never blocks the exploration.**
+
 ### Step 2 — Offer Visual Aids
 If the topic benefits from diagrams, mockups, or flowcharts:
 - Offer to create ASCII diagrams, Mermaid charts, or component trees

--- a/.agents/skills/prd/SKILL.md
+++ b/.agents/skills/prd/SKILL.md
@@ -43,6 +43,13 @@ and the backlog is generated.
   - If PRD exists: ask "Update the existing PRD or create a new one?"
   - If backlog exists with completed items: warn that regenerating will need to preserve `[x]` items
 
+**Researching an external product or competitor.** `WebFetch` returns the empty
+shell for a JS-rendered page without signalling that it did, which reads as an
+absence of information rather than a failure to read. Where `lightpanda fetch
+<url>` is installed it runs the page's scripts first and dumps HTML or markdown.
+It is optional — fall back to `WebFetch` and record what you could not read.
+**A missing lightpanda is not an error and never blocks the interview.**
+
 ### Step 2 — Hybrid Draft + Interview
 
 From the user's initial prompt and any existing context:

--- a/.agents/skills/sync/SKILL.md
+++ b/.agents/skills/sync/SKILL.md
@@ -94,6 +94,7 @@ CLAUDE.md             → Shared rules: workflow, principles, skills index (both
 .claude/skills/       → Claude Code backwards-compat copy of .agents/skills/
 .claude/agents/       → Subagent definitions (Claude Code only)
 .claude/hooks/        → Lifecycle hooks (Claude Code only)
+.claude/browsers/     → Browser adapter runbooks read by /verify --scope e2e
 .claude/settings.json → Hook configuration + env (Claude Code only — no SessionStart, see above)
 ```
 
@@ -245,12 +246,12 @@ Compare the syncable paths between the current project and the template source.
 # Show changed files in syncable paths only
 # Note: use two-dot diff (not three-dot) — template and project have unrelated histories,
 # so HEAD...workflow/$WORKFLOW_BRANCH fails with "no merge base"
-git diff workflow/$WORKFLOW_BRANCH --stat -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md
+git diff workflow/$WORKFLOW_BRANCH --stat -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/browsers/ .claude/settings.json CLAUDE.md
 ```
 
 Then show the full diff:
 ```bash
-git diff workflow/$WORKFLOW_BRANCH -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md
+git diff workflow/$WORKFLOW_BRANCH -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/browsers/ .claude/settings.json CLAUDE.md
 ```
 
 **If manual diff mode:**

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -188,6 +188,7 @@ Commit: <full-sha>
 Browser: <backend> <version> (full-fidelity | DOM-tier)
 
 ### AC-1: <criterion text>
+Tier: DOM-FUNCTIONAL (asserts element text)
 Journey: <plain-language steps>
 Steps executed:
   ✓ Navigate /path → 200, element visible

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -112,8 +112,60 @@ Unit tests prove functions work. E2E walkthroughs prove features work.
 
 1. Read the active spec from `specs/` and extract **user-facing ACs**
 2. Verify the app is running locally (check dev server, start via `/start-qa` if not)
-3. Verify the browser MCP is available (Playwright or Chrome)
+3. Resolve a browser backend and classify every AC (below)
 4. Load authentication state as a real user would — cookie-based session, not injected tokens
+
+### Backend resolution
+
+Ordered; first available wins. A backend is available when its MCP tools are
+exposed in the session.
+
+| Order | Backend | Fidelity | Eligible ACs |
+|-------|---------|----------|--------------|
+| 1 | Chrome MCP | full | all |
+| 2 | Playwright MCP | full | all |
+| 3 | Lightpanda MCP | DOM only | DOM-FUNCTIONAL only |
+| 4 | none | — | STOP |
+
+Lightpanda's absence is never an error — fall through. Its runbook, including the
+capability ceiling, is `.claude/browsers/lightpanda.md`.
+
+### AC classification
+
+Classify each user-facing AC **before** walking it. The tier decides which
+backends may run it.
+
+**VISUAL** — needs a full-fidelity backend. The AC references appearance, layout,
+alignment, spacing, colour, theme, dark mode, responsiveness or breakpoints;
+"looks like" or "renders correctly"; screenshots or visual regression; canvas,
+charts, maps or drawn output; hover, animation, transition or drag-and-drop;
+print/PDF output; or realtime behaviour depending on WebSockets, Web Workers,
+Service Workers or WebRTC.
+
+**DOM-FUNCTIONAL** — lightpanda-eligible. The AC is satisfied by asserting
+navigation and URL state, redirects and HTTP status, form fill/submit and
+validation messages as text, authentication through the real login flow,
+presence/absence/text of elements, or absence of console errors.
+
+> **Fail closed: when classification is uncertain, the AC is VISUAL.**
+> Uncertainty resolves toward the stricter tier, never the permissive one. A page
+> with broken layout still exposes a correct DOM, so guessing DOM-FUNCTIONAL
+> converts a missing check into a green one — the single failure this tier
+> system exists to prevent.
+
+### Outcome matrix
+
+| Backend available | AC tier | Result |
+|---|---|---|
+| full-fidelity | any | walk through normally |
+| lightpanda only | DOM-FUNCTIONAL | walk through, log as DOM-tier |
+| lightpanda only | VISUAL | `BLOCKED` — **never** `PASS` |
+| none | any | STOP |
+
+A `BLOCKED` AC has not failed — it was never attempted — so it does not halt the
+walkthrough, and the remaining DOM-functional ACs still execute. But any run
+containing a `BLOCKED` AC reports **non-success** to its caller (`/build` Phase 4,
+`/wrap-up-session` Step 6.3). Partial coverage is reported as partial coverage.
 
 ### Walkthrough Protocol
 
@@ -133,6 +185,7 @@ Append to `tasks/e2e-log.md`:
 
 Spec: specs/<feature>.md
 Commit: <full-sha>
+Browser: <backend> <version> (full-fidelity | DOM-tier)
 
 ### AC-1: <criterion text>
 Journey: <plain-language steps>
@@ -142,6 +195,10 @@ Steps executed:
   ✓ Assert session state
 Negative: invalid input rejected with inline error ✓
 Result: PASS
+
+### AC-2: <criterion text>
+Tier: VISUAL (references layout)
+Result: BLOCKED — requires a full-fidelity browser; only lightpanda (DOM-tier) available
 ```
 
 The log is **append-only**. Never overwrite prior walkthroughs — they form the audit trail.
@@ -150,12 +207,20 @@ The log is **append-only**. Never overwrite prior walkthroughs — they form the
 
 - **Step fails**: STOP, report exact step + evidence, hand back to `/build` or `/debug`
 - **MCP browser unavailable**: STOP. Do not fall back to curl or unit tests.
+- **VISUAL AC, only a DOM-tier backend**: record `BLOCKED`, continue with the
+  remaining DOM-functional ACs, report the run as non-success
+- **DOM-tier backend errors on an unimplemented Web API**: treat as a step
+  failure and name the API in evidence. Never re-classify the AC as passing —
+  the gap is real and the feature was not verified
 - **Auth fails twice**: STOP, report to user — this is usually a session misconfiguration
 - **Dev server unreachable**: STOP, invoke `/start-qa`, then resume
 
 ### Iron Laws
 
-1. A real browser must load the real app — no jsdom, no headless emulation bypassing the network
+1. A real browser must load the real app — no jsdom, no headless emulation bypassing the network.
+   A DOM-tier backend satisfies this: lightpanda loads over **libcurl** and makes real HTTP
+   requests, unlike jsdom. "Bypassing the network" is what the law forbids, and it does not.
+   What it cannot do is *see* the result — which the classifier handles, not this law.
 2. Authentication must go through the real login flow — no token injection
 3. Every user-facing AC gets its own walkthrough entry — no batching
 4. A failed step halts the walkthrough — do not cascade to the next AC

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -128,7 +128,8 @@ exposed in the session.
 | 4 | none | — | STOP |
 
 Lightpanda's absence is never an error — fall through. Its runbook, including the
-capability ceiling, is `.claude/browsers/lightpanda.md`.
+capability ceiling, is `.claude/browsers/lightpanda.md` (Claude Code only —
+other harnesses read the same runbook from the template repo).
 
 ### AC classification
 

--- a/.claude/browsers/lightpanda.md
+++ b/.claude/browsers/lightpanda.md
@@ -1,0 +1,160 @@
+---
+name: lightpanda
+display_name: Lightpanda
+fidelity: dom
+detect_command: "command -v lightpanda"
+mcp_command: "lightpanda mcp"
+platforms: [linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64]
+license: AGPL-3.0
+pinned_release: "0.3.6"
+---
+
+# Lightpanda — DOM-tier e2e browser
+
+> Adapter runbook for `/verify --scope e2e`. The frontmatter above is the
+> machine-readable contract; this body is the human-readable operating notes.
+> Optional: if lightpanda is absent, `/verify` falls through to the next tier and
+> that is **not** an error.
+
+[Lightpanda](https://github.com/lightpanda-io/browser) is a headless browser
+written from scratch in Zig — libcurl for transport, html5ever for parsing, V8
+for JavaScript, plus a CDP server and an MCP server. It exists to be driven by
+agents rather than watched by people: roughly 9x faster and 16x lighter than
+headless Chrome on the same pages.
+
+This workflow uses it for exactly one job: **executing DOM-functional acceptance
+criteria in unattended runs where no desktop Chrome exists** — `/auto-improve`,
+`/yolo`, cloud containers, CI. It is the third tier in `/verify --scope e2e`'s
+resolution order, behind Chrome MCP and Playwright MCP.
+
+---
+
+## The capability ceiling — read this before trusting a PASS
+
+Lightpanda has **no rendering path**. It builds a DOM and runs scripts against
+it; it never lays the result out or paints it. Concretely, it does not support:
+
+| Missing | Consequence |
+|---|---|
+| **screenshot** / PDF export | No visual artefact can be captured, so no visual regression check is possible |
+| **Canvas** / WebGL | Charts, maps, drawn output, and anything on a canvas are invisible to it |
+| Complete CSS layout — **Flexbox**/Grid are partial | An element can be reported present while being positioned wrongly or overlapping |
+| **Service Worker**, Web Worker, WebRTC | Offline behaviour, background sync, and peer connections cannot be exercised |
+| Full **WebSocket** support | Realtime and streaming features may behave differently or not connect |
+
+The failure mode this creates is specific and worth naming: **a page with
+completely broken layout can still expose a correct DOM.** An assertion that
+"the submit button exists and has the right text" passes on a page where that
+button is rendered off-screen, behind a modal, or invisible. Lightpanda cannot
+tell those apart, and neither can a reviewer reading a bare PASS.
+
+That is why `/verify --scope e2e` classifies every AC before choosing a tier and
+**fails closed** — an AC whose wording is ambiguous is treated as VISUAL and
+refuses to run here. See `.agents/skills/verify/SKILL.md` § `--scope e2e`.
+
+It is also why every `tasks/e2e-log.md` entry records the backend and its
+fidelity. A PASS produced here is a narrower claim than a PASS from Chrome, and
+the log has to say which one it was.
+
+---
+
+## Install
+
+Upstream publishes binaries for Linux and macOS only. Pinned release: **0.3.6**.
+
+```bash
+brew install lightpanda-io/browser/lightpanda     # macOS / Linuxbrew
+```
+
+```bash
+yay -S lightpanda-nightly-bin                     # Arch (AUR)
+```
+
+```bash
+docker run --rm -p 9222:9222 lightpanda/browser:0.3.6
+```
+
+Direct download — substitute your architecture:
+
+```bash
+curl -L -o lightpanda https://github.com/lightpanda-io/browser/releases/download/0.3.6/lightpanda-x86_64-linux && chmod +x lightpanda
+```
+
+**Pin the release; do not track `nightly`.** Lightpanda is beta and moves fast.
+An unattended run that silently changes browser behaviour between one night and
+the next produces failures nobody can attribute. Bumping `pinned_release` in the
+frontmatter above is a deliberate edit with a deliberate re-verification.
+
+### Windows
+
+**There is no Windows build.** Release 0.3.6 ships
+`{aarch64,x86_64}-{linux,macos}` and two `.deb` packages — nothing else. On
+Windows, run it under **WSL2** or **Docker** Desktop, or accept that
+`/verify --scope e2e` will resolve to a different tier on that machine.
+
+This is a real portability seam, not a rough edge: a repository whose sessions
+alternate between a Windows box and a Linux box will take different verification
+paths on each. The fidelity line in `tasks/e2e-log.md` is what makes that visible
+after the fact.
+
+---
+
+## Registration
+
+`install.sh` deliberately does **not** wire this up — it has never mutated MCP
+configuration, and the right scope (user vs project) is the operator's call, not
+the installer's. Register it yourself:
+
+```bash
+claude mcp add lightpanda -- lightpanda mcp
+```
+
+The server speaks MCP JSON-RPC 2.0 over stdio. For several agents against one
+browser, run it over HTTP instead — each connection gets its own page, cookies,
+and memory:
+
+```bash
+lightpanda mcp --port 9223
+```
+
+A CDP endpoint is also available (`lightpanda serve --host 127.0.0.1 --port
+9222`) for Puppeteer/Playwright scripts, but this workflow does not use it. One
+integration path is enough; two would mean two ways for the tier to be
+misconfigured.
+
+---
+
+## Licensing
+
+Lightpanda is **AGPL-3.0**. Use the **unmodified upstream** binary or Docker
+image. Do not vendor it into this template, patch it, or redistribute a modified
+build — the AGPL's network-use clause makes that a question for whoever ships the
+result, and nothing here needs a fork to work.
+
+---
+
+## Troubleshooting
+
+**`/verify` never selects lightpanda.** Resolution is ordered: Chrome MCP, then
+Playwright MCP, then lightpanda. If a full-fidelity backend is present it wins,
+by design — lightpanda is a fallback for environments without one, not a
+preference.
+
+**Every AC comes back BLOCKED.** The classifier decided they are all VISUAL. Read
+the AC wording: layout, appearance, colour, responsiveness, screenshots, hover,
+animation, and drag-and-drop all route to a full-fidelity browser. This is
+working correctly; it is telling you these criteria need a real browser.
+
+**A walkthrough fails on an unimplemented Web API.** Treat it as a step failure
+and record which API in the evidence. Do not re-classify the AC as passing — the
+gap is real, it is listed in the ceiling table above, and the feature genuinely
+was not verified.
+
+**The page loads but is empty.** Lightpanda respects `robots.txt` by default. Use
+`--no-obey-robots` for a local dev server if the app serves a restrictive one.
+
+**Upstream capability status.** Coverage improves steadily; the ceiling table
+above reflects release 0.3.6. Track
+[issue #1799](https://github.com/lightpanda-io/browser/issues/1799) for the
+current missing-features list, and update this runbook in the same commit as any
+`pinned_release` bump.

--- a/.claude/browsers/lightpanda.md
+++ b/.claude/browsers/lightpanda.md
@@ -48,6 +48,34 @@ completely broken layout can still expose a correct DOM.** An assertion that
 button is rendered off-screen, behind a modal, or invisible. Lightpanda cannot
 tell those apart, and neither can a reviewer reading a bare PASS.
 
+### Geometry is stubbed, not absent — this is the dangerous part
+
+`getBoundingClientRect()` and `offsetWidth`/`offsetHeight` **exist and return
+confident, plausible-looking numbers that are fiction.** Measured against 0.3.6
+on a fixture whose button is styled `position:absolute; left:-9999px`:
+
+```
+submit-btn=[110,110,5,5]  total=[130,130,5,5]  checkout=[80,80,5,5]  h1=[65,65,5,5]
+```
+
+Every element reports `5x5`, and `x` always equals `y`. An `<h1>` and a
+`<button>` are not both 5x5 pixels; the CSS offset is ignored entirely. The
+values are synthetic.
+
+A missing API throws, and a caller notices. A **stubbed** API silently returns
+the wrong answer, so the defensive visual assertion a careful engineer would
+write —
+
+```js
+const r = el.getBoundingClientRect();
+if (r.width > 0 && r.x >= 0) { /* "it's visible" */ }
+```
+
+— **passes here for an element 9999px off the left edge.** That is why VISUAL
+criteria are refused rather than attempted-and-checked: there is no runtime
+signal to check against. The classifier has to decide before it runs, which is
+why it fails closed.
+
 That is why `/verify --scope e2e` classifies every AC before choosing a tier and
 **fails closed** — an AC whose wording is ambiguous is treated as VISUAL and
 refuses to run here. See `.agents/skills/verify/SKILL.md` § `--scope e2e`.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -251,7 +251,8 @@ fi
 
 # ── Workflow Template Drift Check ────────────────────────────────────────────
 # Notifies if the coding-agent-workflow template has new commits affecting
-# syncable paths (.claude/skills, .claude/agents, .claude/hooks, settings.json).
+# syncable paths (.claude/skills, .claude/agents, .claude/hooks, .claude/browsers,
+# settings.json).
 # Silent when in sync (observability discipline: loud only on actionable state).
 #
 # Preconditions:
@@ -288,7 +289,7 @@ if [ ! -f ".claude/sync-check-dismissed" ] \
 
     if timeout 5 git fetch workflow "$WORKFLOW_BRANCH" &>/dev/null; then
       DRIFT_COUNT=$(git diff --name-only "workflow/$WORKFLOW_BRANCH" -- \
-        .agents/skills .agents/agents .claude/skills .claude/agents .claude/hooks .claude/settings.json CLAUDE.md 2>/dev/null \
+        .agents/skills .agents/agents .claude/skills .claude/agents .claude/hooks .claude/browsers .claude/settings.json CLAUDE.md 2>/dev/null \
         | wc -l | tr -d ' ')
       printf '%s\n%s\n' "$DRIFT_COUNT" "$WORKFLOW_BRANCH" > "$WORKFLOW_CHECK_CACHE"
     fi

--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -25,6 +25,13 @@ DO NOT invoke /plan, /build, /tdd, write any code, scaffold any project, or take
 - Grep tasks/solutions/ frontmatter (architecture-decision, pattern docs) for architectural context and past decisions
 - Understand what already exists before proposing anything new
 
+**Reading prior art on a JS-rendered page.** `WebFetch` returns the empty shell
+for an SPA and gives no signal that it did, so a page can read as "nothing there"
+when the content simply had not run yet. If `lightpanda fetch <url>` is available
+it executes the scripts first and dumps HTML or markdown. It is optional — when
+it is absent, use `WebFetch` and say what you could not read. **A missing
+lightpanda is not an error and never blocks the exploration.**
+
 ### Step 2 — Offer Visual Aids
 If the topic benefits from diagrams, mockups, or flowcharts:
 - Offer to create ASCII diagrams, Mermaid charts, or component trees

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -43,6 +43,13 @@ and the backlog is generated.
   - If PRD exists: ask "Update the existing PRD or create a new one?"
   - If backlog exists with completed items: warn that regenerating will need to preserve `[x]` items
 
+**Researching an external product or competitor.** `WebFetch` returns the empty
+shell for a JS-rendered page without signalling that it did, which reads as an
+absence of information rather than a failure to read. Where `lightpanda fetch
+<url>` is installed it runs the page's scripts first and dumps HTML or markdown.
+It is optional — fall back to `WebFetch` and record what you could not read.
+**A missing lightpanda is not an error and never blocks the interview.**
+
 ### Step 2 — Hybrid Draft + Interview
 
 From the user's initial prompt and any existing context:

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -94,6 +94,7 @@ CLAUDE.md             → Shared rules: workflow, principles, skills index (both
 .claude/skills/       → Claude Code backwards-compat copy of .agents/skills/
 .claude/agents/       → Subagent definitions (Claude Code only)
 .claude/hooks/        → Lifecycle hooks (Claude Code only)
+.claude/browsers/     → Browser adapter runbooks read by /verify --scope e2e
 .claude/settings.json → Hook configuration + env (Claude Code only — no SessionStart, see above)
 ```
 
@@ -245,12 +246,12 @@ Compare the syncable paths between the current project and the template source.
 # Show changed files in syncable paths only
 # Note: use two-dot diff (not three-dot) — template and project have unrelated histories,
 # so HEAD...workflow/$WORKFLOW_BRANCH fails with "no merge base"
-git diff workflow/$WORKFLOW_BRANCH --stat -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md
+git diff workflow/$WORKFLOW_BRANCH --stat -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/browsers/ .claude/settings.json CLAUDE.md
 ```
 
 Then show the full diff:
 ```bash
-git diff workflow/$WORKFLOW_BRANCH -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md
+git diff workflow/$WORKFLOW_BRANCH -- .agents/skills/ .agents/agents/ .claude/skills/ .claude/agents/ .claude/hooks/ .claude/browsers/ .claude/settings.json CLAUDE.md
 ```
 
 **If manual diff mode:**

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -188,6 +188,7 @@ Commit: <full-sha>
 Browser: <backend> <version> (full-fidelity | DOM-tier)
 
 ### AC-1: <criterion text>
+Tier: DOM-FUNCTIONAL (asserts element text)
 Journey: <plain-language steps>
 Steps executed:
   ✓ Navigate /path → 200, element visible

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -112,8 +112,60 @@ Unit tests prove functions work. E2E walkthroughs prove features work.
 
 1. Read the active spec from `specs/` and extract **user-facing ACs**
 2. Verify the app is running locally (check dev server, start via `/start-qa` if not)
-3. Verify the browser MCP is available (Playwright or Chrome)
+3. Resolve a browser backend and classify every AC (below)
 4. Load authentication state as a real user would — cookie-based session, not injected tokens
+
+### Backend resolution
+
+Ordered; first available wins. A backend is available when its MCP tools are
+exposed in the session.
+
+| Order | Backend | Fidelity | Eligible ACs |
+|-------|---------|----------|--------------|
+| 1 | Chrome MCP | full | all |
+| 2 | Playwright MCP | full | all |
+| 3 | Lightpanda MCP | DOM only | DOM-FUNCTIONAL only |
+| 4 | none | — | STOP |
+
+Lightpanda's absence is never an error — fall through. Its runbook, including the
+capability ceiling, is `.claude/browsers/lightpanda.md`.
+
+### AC classification
+
+Classify each user-facing AC **before** walking it. The tier decides which
+backends may run it.
+
+**VISUAL** — needs a full-fidelity backend. The AC references appearance, layout,
+alignment, spacing, colour, theme, dark mode, responsiveness or breakpoints;
+"looks like" or "renders correctly"; screenshots or visual regression; canvas,
+charts, maps or drawn output; hover, animation, transition or drag-and-drop;
+print/PDF output; or realtime behaviour depending on WebSockets, Web Workers,
+Service Workers or WebRTC.
+
+**DOM-FUNCTIONAL** — lightpanda-eligible. The AC is satisfied by asserting
+navigation and URL state, redirects and HTTP status, form fill/submit and
+validation messages as text, authentication through the real login flow,
+presence/absence/text of elements, or absence of console errors.
+
+> **Fail closed: when classification is uncertain, the AC is VISUAL.**
+> Uncertainty resolves toward the stricter tier, never the permissive one. A page
+> with broken layout still exposes a correct DOM, so guessing DOM-FUNCTIONAL
+> converts a missing check into a green one — the single failure this tier
+> system exists to prevent.
+
+### Outcome matrix
+
+| Backend available | AC tier | Result |
+|---|---|---|
+| full-fidelity | any | walk through normally |
+| lightpanda only | DOM-FUNCTIONAL | walk through, log as DOM-tier |
+| lightpanda only | VISUAL | `BLOCKED` — **never** `PASS` |
+| none | any | STOP |
+
+A `BLOCKED` AC has not failed — it was never attempted — so it does not halt the
+walkthrough, and the remaining DOM-functional ACs still execute. But any run
+containing a `BLOCKED` AC reports **non-success** to its caller (`/build` Phase 4,
+`/wrap-up-session` Step 6.3). Partial coverage is reported as partial coverage.
 
 ### Walkthrough Protocol
 
@@ -133,6 +185,7 @@ Append to `tasks/e2e-log.md`:
 
 Spec: specs/<feature>.md
 Commit: <full-sha>
+Browser: <backend> <version> (full-fidelity | DOM-tier)
 
 ### AC-1: <criterion text>
 Journey: <plain-language steps>
@@ -142,6 +195,10 @@ Steps executed:
   ✓ Assert session state
 Negative: invalid input rejected with inline error ✓
 Result: PASS
+
+### AC-2: <criterion text>
+Tier: VISUAL (references layout)
+Result: BLOCKED — requires a full-fidelity browser; only lightpanda (DOM-tier) available
 ```
 
 The log is **append-only**. Never overwrite prior walkthroughs — they form the audit trail.
@@ -150,12 +207,20 @@ The log is **append-only**. Never overwrite prior walkthroughs — they form the
 
 - **Step fails**: STOP, report exact step + evidence, hand back to `/build` or `/debug`
 - **MCP browser unavailable**: STOP. Do not fall back to curl or unit tests.
+- **VISUAL AC, only a DOM-tier backend**: record `BLOCKED`, continue with the
+  remaining DOM-functional ACs, report the run as non-success
+- **DOM-tier backend errors on an unimplemented Web API**: treat as a step
+  failure and name the API in evidence. Never re-classify the AC as passing —
+  the gap is real and the feature was not verified
 - **Auth fails twice**: STOP, report to user — this is usually a session misconfiguration
 - **Dev server unreachable**: STOP, invoke `/start-qa`, then resume
 
 ### Iron Laws
 
-1. A real browser must load the real app — no jsdom, no headless emulation bypassing the network
+1. A real browser must load the real app — no jsdom, no headless emulation bypassing the network.
+   A DOM-tier backend satisfies this: lightpanda loads over **libcurl** and makes real HTTP
+   requests, unlike jsdom. "Bypassing the network" is what the law forbids, and it does not.
+   What it cannot do is *see* the result — which the classifier handles, not this law.
 2. Authentication must go through the real login flow — no token injection
 3. Every user-facing AC gets its own walkthrough entry — no batching
 4. A failed step halts the walkthrough — do not cascade to the next AC

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -128,7 +128,8 @@ exposed in the session.
 | 4 | none | — | STOP |
 
 Lightpanda's absence is never an error — fall through. Its runbook, including the
-capability ceiling, is `.claude/browsers/lightpanda.md`.
+capability ceiling, is `.claude/browsers/lightpanda.md` (Claude Code only —
+other harnesses read the same runbook from the template repo).
 
 ### AC classification
 

--- a/specs/lightpanda-browser-adoption.md
+++ b/specs/lightpanda-browser-adoption.md
@@ -1,0 +1,332 @@
+# Lightpanda Browser Adoption
+
+> Status: awaiting approval → `/plan`
+> Brainstorm date: 2026-08-13
+> Supersedes nothing. Related: `specs/deployment-verification.md` (adapter-file precedent).
+
+---
+
+## 1. Context
+
+The workflow touches a browser in exactly two places today:
+
+- `.agents/skills/start-qa/SKILL.md:90` — launches `/chrome` for **human** manual QA.
+- `.agents/skills/verify/SKILL.md:105` — `--scope e2e`, which requires a real browser MCP
+  (Chrome or Playwright) and hard-STOPs rather than falling back.
+
+Unattended runs (`/auto-improve`, `/yolo`, worktree runs) execute in environments with no
+desktop Chrome — a Linux personal machine, local Docker, and cloud containers, alongside a
+Windows work machine. In those contexts `--scope e2e` cannot run at all, so user-facing
+acceptance criteria go unverified precisely where nobody is watching.
+
+[Lightpanda](https://github.com/lightpanda-io/browser) (Zig, AGPL-3.0, beta) is a headless
+browser built for agents: libcurl + html5ever + V8 + a CDP server, ~9x faster and ~16x
+lighter than headless Chrome. It ships four modes — `serve` (CDP), `fetch` (URL → HTML or
+markdown), `agent`, and **`mcp`** (JSON-RPC over stdio, or `--port` for HTTP with one
+browsing session per connection).
+
+The `mcp` mode is what makes this cheap: integration is an MCP registration, not CDP
+plumbing.
+
+### 1.1 The capability ceiling (the thing that shapes the whole design)
+
+Per [issue #1799](https://github.com/lightpanda-io/browser/issues/1799), lightpanda has:
+
+- **No screenshots, no PDF export**
+- **No Canvas / WebGL** — no visual rendering of any kind
+- **Partial CSS layout** — incomplete Flexbox/Grid
+- **No Web Workers, Service Workers, WebRTC**
+- **Limited WebSockets**
+
+A page with broken layout can still expose a correct DOM. Therefore a naive "use lightpanda
+when Chrome is absent" fallback would let `--scope e2e` report PASS on a visually broken
+feature — turning the strongest gate in the workflow into a false-confidence machine. That
+is the single highest likelihood × impact failure identified in the brainstorm, and every
+decision below exists to defuse it.
+
+---
+
+## 2. Decision
+
+Adopt lightpanda as an **optional, capability-scoped e2e browser tier**, documented by a
+runbook file, gated by a fail-closed AC classifier, and detected at runtime with a silent
+no-op when absent.
+
+**Decline agent-reach.** Its zero-config slice (Jina Reader, `gh`, RSS, V2EX, yt-dlp)
+overlaps almost entirely with tools already present — built-in `WebFetch`/`WebSearch`, the
+`gh` CLI, and now `lightpanda fetch` for JS-heavy pages. The unique residue is YouTube
+transcripts, which is `yt-dlp` directly (Code Economy rung 3) rather than a Python CLI with
+20+ transitive backends (rung 5). Declining now is reversible at zero cost.
+
+---
+
+## 3. Scope
+
+### In scope
+
+1. `.claude/browsers/lightpanda.md` — runbook: install per platform, capability ceiling,
+   when not to use it.
+2. `--scope e2e` gains a **browser tier resolution order** and an **AC fidelity classifier**.
+3. `tasks/e2e-log.md` entries record which tier executed the walkthrough.
+4. `.claude/browsers/` declared as a **syncable path** across all seven hand-maintained
+   enumerations, so downstream projects actually receive the runbook and INVARIANT 2 of
+   `tests/test-syncable-paths.sh` holds (see §4.9).
+5. MCP registration documented in the runbook as a copy-pasteable one-liner. `install.sh` is
+   **not** modified.
+6. A one-paragraph note in `/prd` and `/brainstorm` research steps: when `WebFetch` returns
+   an empty SPA shell, `lightpanda fetch` is an available fallback if installed.
+7. Tests covering the runbook contract, the classifier's fail-closed rule, and the extended
+   syncable-path set.
+
+### Out of scope (explicit non-goals)
+
+| Non-goal | Reason |
+|---|---|
+| Changing `/start-qa` | Manual QA means a human looks at the app. Lightpanda cannot render. |
+| Changing the AC format in `/plan` | Classification happens at verify time; zero ripple into specs or downstream projects. |
+| A general optional-capability registry | N=3 optional tools. YAGNI (Code Economy rung 1). |
+| Formalizing Chrome/Playwright as `.claude/browsers/*.md` adapters | Deferred — see §9. |
+| Lightpanda `serve`/CDP mode | One interface (`mcp`) is enough; CDP adds a second integration path for no gain. |
+| Lightpanda `agent` mode | The workflow already has an agent driving the browser. |
+| Modifying `install.sh` | It has never touched MCP config. Registration is per-harness and per-scope; documenting the command keeps the installer's blast radius unchanged. |
+| Fixing `.claude/deployments/`'s identical syncable-path gap | Pre-existing. Noted in §8, out of scope per the orphan rule. |
+| Adopting agent-reach | See §2. |
+
+---
+
+## 4. Architecture
+
+### 4.1 Browser tier resolution (in `--scope e2e` Pre-Flight)
+
+Resolution is ordered, first match wins:
+
+| Order | Backend | Fidelity | Eligible ACs |
+|---|---|---|---|
+| 1 | Chrome MCP (`/chrome`) | Full | All |
+| 2 | Playwright MCP | Full | All |
+| 3 | Lightpanda MCP | DOM-tier | DOM-functional only |
+| 4 | none | — | STOP |
+
+Detection: a backend is available if its MCP tools are exposed in the session. Lightpanda is
+additionally considered available if `command -v lightpanda` succeeds and the MCP server can
+be started. Absence of lightpanda is **never an error** — it is the graphify convention
+already stated in `CLAUDE.md`.
+
+### 4.2 The AC fidelity classifier
+
+For each user-facing AC extracted from the spec, `--scope e2e` assigns one of two tiers.
+
+**VISUAL** — requires a full-fidelity backend. Triggered when the AC references:
+
+- appearance, layout, alignment, spacing, colour, theme, dark mode, responsiveness,
+  breakpoints, "looks like", "renders correctly", "above the fold"
+- screenshots or visual regression
+- canvas, charts, graphs, maps, or any drawn output
+- hover states, animations, transitions, drag-and-drop
+- print or PDF output
+- realtime behaviour depending on WebSockets, Web Workers, Service Workers, or WebRTC
+
+**DOM-FUNCTIONAL** — lightpanda-eligible. The AC is satisfiable by asserting:
+
+- navigation and URL state, redirects, HTTP status
+- form fill, submit, and validation messages as text
+- authentication through the real cookie-based login flow
+- presence, absence, or text content of elements
+- absence of console errors
+
+**Fail-closed rule (non-negotiable): when classification is uncertain, the AC is VISUAL.**
+Uncertainty resolves toward the stricter tier, never the permissive one. This is the property
+that makes the whole design safe; it must be stated verbatim in the skill.
+
+### 4.3 Outcome matrix
+
+| Available backend | AC tier | Result |
+|---|---|---|
+| Full-fidelity | any | Walk through normally |
+| Lightpanda only | DOM-FUNCTIONAL | Walk through, log as DOM-tier |
+| Lightpanda only | VISUAL | `Result: BLOCKED — requires full-fidelity browser` |
+| None | any | STOP (existing behaviour, unchanged) |
+
+A BLOCKED AC is **not** a PASS and **not** a step failure. It does not halt the walkthrough
+(existing Iron Law 4 governs failed steps, not unrunnable ones) — remaining DOM-functional
+ACs still execute, so unattended runs extract the coverage they can. But `--scope e2e`
+returns non-success whenever any AC is BLOCKED, and the caller (`/build` Phase 4,
+`/wrap-up-session` Step 6.3) surfaces it. Partial coverage is reported as partial coverage.
+
+### 4.4 Relationship to the existing Iron Laws
+
+Iron Law 1 currently reads: *"A real browser must load the real app — no jsdom, no headless
+emulation bypassing the network."* Lightpanda satisfies it — it loads over libcurl and makes
+real HTTP requests, unlike jsdom. The qualifier "bypassing the network" is what scopes the
+rule, and lightpanda does not bypass it. This spec adds no exemption to Iron Law 1; a reader
+hitting that line should find this paragraph rather than infer a contradiction, so the skill
+gains a one-sentence cross-reference at that point.
+
+Iron Law 4 (*"a failed step halts the walkthrough"*) governs **failed** steps. A BLOCKED AC
+has not failed — it was never attempted. §4.3 defines that case explicitly so the two do not
+get conflated.
+
+### 4.5 Evidence
+
+The `tasks/e2e-log.md` entry header gains one line so the audit trail records fidelity:
+
+```markdown
+## E2E Walkthrough — <Feature> — <YYYY-MM-DD> <short-sha>
+
+Spec: specs/<feature>.md
+Commit: <full-sha>
+Browser: lightpanda 0.3.6 (DOM-tier)
+```
+
+Without this, a reader six months later cannot tell whether a PASS was seen or inferred.
+
+### 4.6 Runbook contract
+
+`.claude/browsers/lightpanda.md`, mirroring `.claude/deployments/`'s frontmatter-contract
+shape:
+
+```yaml
+---
+name: lightpanda
+display_name: Lightpanda
+fidelity: dom            # dom | full
+detect_command: "command -v lightpanda"
+mcp_command: "lightpanda mcp"
+platforms: [linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64]
+license: AGPL-3.0
+---
+```
+
+Body: per-platform install (Homebrew, AUR, `.deb`, pinned release binary, Docker), the
+registration one-liner, the Windows situation, the capability ceiling from §1.1, and
+troubleshooting notes.
+
+Pin an explicit release tag rather than `nightly` — `0.3.6` at time of writing — so an
+upstream change to a beta project cannot silently alter unattended-run behaviour. Bumping the
+pin is a deliberate edit to this file.
+
+### 4.7 Platform reality
+
+Lightpanda release 0.3.6 publishes only `{aarch64,x86_64}-{linux,macos}` binaries and two
+`.deb` packages. **There is no Windows build.** On the Windows work machine the runbook
+directs the user to WSL2 or Docker, and if neither is set up, detection simply fails and
+`--scope e2e` behaves exactly as it does today. The runbook must state this plainly rather
+than implying parity across machines.
+
+### 4.9 Distribution — the syncable-path invariant
+
+`tests/test-syncable-paths.sh` holds INVARIANT 2: *every asset path a skill names, once
+resolved, must be a descendant of a declared syncable path.* Because `verify/SKILL.md` names
+`.claude/browsers/lightpanda.md`, that directory must join the syncable set — otherwise the
+skill instructs downstream agents to read a runbook their project never received, which is
+precisely the failure the invariant was written to catch.
+
+The syncable-path set is retyped by hand in **seven** regions across three files:
+
+| # | Location |
+|---|---|
+| 1–3 | `.agents/skills/sync/SKILL.md` — § Syncable Paths block, the `git diff --stat` command, the full `git diff` command |
+| 4–6 | `.claude/skills/sync/SKILL.md` — byte-identical parity copy of 1–3 |
+| 7 | `.claude/hooks/session-start.sh` — the template-drift check |
+
+All seven must gain `.claude/browsers/` in the same task; the test pins them equal, so a
+partial edit fails loudly rather than drifting.
+
+**Pre-existing gap, not fixed here**: `.claude/deployments/` has the same hole — the
+`verify-deployment` skill names `.claude/deployments/<service>.md` while that directory sits
+outside the syncable set, so downstream projects never receive the deployment runbooks. Noted
+per the orphan rule in `.claude/project.md` § Surgical Changes; fixing it is separate work.
+
+### 4.10 Licensing
+
+Lightpanda is AGPL-3.0. Use the **unmodified upstream binary or Docker image**. Do not vendor,
+patch, or redistribute it with this template. The runbook carries this note so the constraint
+travels with the tool rather than living only in this spec.
+
+---
+
+## 5. Error handling
+
+| Condition | Behaviour |
+|---|---|
+| Lightpanda not installed | Silent. Fall through the resolution order. Not an error. |
+| Lightpanda installed, MCP server fails to start | Log the failure, fall through to "none" → STOP. Do not retry silently. |
+| Lightpanda errors mid-walkthrough on an unimplemented Web API | Treat as a step failure: STOP that AC, record the API in evidence, do **not** re-classify the AC as passing. |
+| Backend resolves to lightpanda but every AC is VISUAL | Report BLOCKED for all, return non-success, name the missing capability. |
+
+No silent failures, per `CLAUDE.md`. Every degradation is either invisible-by-design
+(tool absent) or explicitly reported (tool present but insufficient).
+
+---
+
+## 6. Testing
+
+Bash suite, consistent with `tests/run.sh`:
+
+1. `tests/test-browser-runbook.sh` — `.claude/browsers/lightpanda.md` exists; frontmatter
+   carries every required field; `name` matches the filename; `fidelity` is `dom` or `full`.
+2. `tests/test-e2e-classifier.sh` — the `verify` SKILL.md in **both** trees contains the
+   resolution-order table, both tier definitions, and the fail-closed sentence verbatim.
+3. `tests/test-skill-parity.sh` — unchanged, but must still pass: `verify/SKILL.md` edits
+   land in `.agents/skills/` first and are copied byte-identically to `.claude/skills/`.
+4. `tests/test-doc-conventions.sh` — extend token greps to cover the new runbook directory.
+
+There is no code to unit-test here; the artifacts are prose contracts, so the tests assert
+the contracts are present and internally consistent. That is the same bar the existing
+`test-doc-conventions.sh` and `test-skill-parity.sh` hold.
+
+**Known limit of this approach**: AC-4 is behavioural — "a VISUAL AC yields BLOCKED, never
+PASS" — and bash tests can only assert that the rule is *written*, not that a future agent
+*obeys* it. Static verification is therefore necessary but not sufficient. AC-4 additionally
+requires one recorded manual walkthrough in `tasks/e2e-log.md`: a spec with one VISUAL and
+one DOM-functional AC, run with lightpanda as the only backend, showing one BLOCKED and one
+PASS. That walkthrough is the acceptance evidence; the bash test is the regression guard.
+
+---
+
+## 7. Acceptance criteria
+
+- **AC-1** `.claude/browsers/lightpanda.md` exists with valid frontmatter per §4.5, and its
+  body documents install paths, the §1.1 capability ceiling, the Windows gap, and the AGPL
+  note.
+- **AC-2** `--scope e2e` Pre-Flight resolves a backend using the §4.1 ordered table and treats
+  a missing lightpanda as a silent no-op.
+- **AC-3** `--scope e2e` classifies every user-facing AC as VISUAL or DOM-FUNCTIONAL, and the
+  skill states the fail-closed rule verbatim.
+- **AC-4** With only lightpanda available, a VISUAL AC yields `BLOCKED`, never `PASS`, and
+  `--scope e2e` returns non-success.
+- **AC-5** With only lightpanda available, DOM-functional ACs still execute and log normally.
+- **AC-6** Every `tasks/e2e-log.md` entry records the backend and fidelity tier.
+- **AC-7** `verify/SKILL.md` is byte-identical across `.agents/skills/` and `.claude/skills/`;
+  `tests/run.sh` passes.
+- **AC-8** The runbook documents the MCP registration one-liner; `install.sh` is unmodified.
+- **AC-9** `.claude/browsers/` appears in all seven syncable-path enumerations, and
+  `tests/test-syncable-paths.sh` passes with INVARIANT 2 satisfied for the runbook.
+- **AC-10** `/start-qa` is unmodified.
+- **AC-11** No file in the repo references agent-reach as a dependency.
+
+AC-4 is the one that matters. If it regresses, the feature is a liability rather than a gap
+closed.
+
+---
+
+## 8. Open risks carried forward
+
+| Risk | Mitigation | Residual |
+|---|---|---|
+| Lightpanda is beta; nightly changes break unattended runs at 3am | Pin to a release tag in the runbook, not `nightly` | Medium — upgrades need a deliberate bump |
+| Machine-dependent code paths (Windows vs Linux) cause bugs that reproduce on one box only | The e2e-log records the backend, so divergence is visible in the audit trail | Medium |
+| Classifier drifts toward permissive over time as BLOCKED results get annoying | Fail-closed rule stated verbatim and asserted by a test | Low |
+
+---
+
+## 9. Deferred
+
+- **Browser adapters as a directory.** If a fourth backend appears, promote `.claude/browsers/`
+  to a full adapter contract with `chrome.md` and `playwright.md`, and let `--scope e2e` read
+  the directory instead of hardcoding the order — exactly what `.claude/deployments/` does for
+  services. Not now: three backends do not justify the indirection.
+- **agent-reach.** Revisit if research needs shift toward video or social content. Adopt
+  `yt-dlp` alone first if only transcripts are needed.
+- **Lightpanda `fetch` as a first-class research tool.** Starts as a documented option in
+  `/prd` and `/brainstorm`; promote to a defined step only if it proves load-bearing.

--- a/specs/lightpanda-browser-adoption.md
+++ b/specs/lightpanda-browser-adoption.md
@@ -321,15 +321,21 @@ Branch `feat/lightpanda-e2e-tier`, off master @ `25999b1`.
 | AC-5 | same entry — DOM-functional AC `PASS`, JS-rendered content resolved |
 | AC-6 | `Browser:` line asserted in both trees' evidence template |
 | AC-7 | `tests/test-skill-parity.sh` green; both `verify/SKILL.md` byte-identical |
-| AC-8 | runbook documents the one-liner; `git diff 25999b1 -- install.sh` empty |
+| AC-8 | runbook documents the one-liner; `git diff origin/master...HEAD -- install.sh` empty |
 | AC-9 | `tests/test-syncable-paths.sh` green; 3 enumerations probed red then reverted |
-| AC-10 | `git diff 25999b1 -- .../start-qa` empty; guard pins no lightpanda reference |
+| AC-10 | `git diff origin/master...HEAD -- .../start-qa` empty; guard pins no lightpanda reference |
 | AC-11 | doc-conventions asserts no `agent-reach` token outside `specs/` |
 
-**Suite**: 20 test files, 19 pass, 1347 assertions (baseline at branch point: 18 files).
-The single failure is `tests/test-codex-install.sh` — pre-existing on master, Windows-only
-(Python 3.13 defaults to cp1252 and dies on the hook banner's non-ASCII before parsing).
-Reproduced at `0064efe` without this branch's commits; CI on Linux is green.
+**Suite**: 21 test files, all pass, 1395 assertions, exit 0 — run on master `8828ba0`
+after rebase (baseline at branch point: 18 files).
+
+Earlier runs of this branch reported 20 files / 19 pass / 1347 assertions, with
+`tests/test-codex-install.sh` failing. That failure was pre-existing on master and
+Windows-only, reproduced at `0064efe` without this branch's commits, and is now **resolved
+upstream** by #66 (a `$PPID`-keyed guard collapsing to PID 1 on Windows, then `print()`
+encoding the non-ASCII banner as cp1252) and #67 (explicit UTF-8 at the remaining Python
+IO boundaries). Recorded rather than deleted: this branch was verified against a red
+baseline for most of its life, and that is a fact about the evidence above.
 
 ### What the AC-4 run changed
 

--- a/specs/lightpanda-browser-adoption.md
+++ b/specs/lightpanda-browser-adoption.md
@@ -308,6 +308,42 @@ PASS. That walkthrough is the acceptance evidence; the bash test is the regressi
 AC-4 is the one that matters. If it regresses, the feature is a liability rather than a gap
 closed.
 
+### Verification record
+
+Branch `feat/lightpanda-e2e-tier`, off master @ `25999b1`.
+
+| AC | Evidence |
+|----|----------|
+| AC-1 | `tests/test-browser-runbook.sh` — 26 assertions |
+| AC-2 | `tests/test-e2e-classifier.sh` — resolution table pinned in both trees |
+| AC-3 | same — fail-closed sentence pinned **verbatim**, both trees |
+| AC-4 | `tasks/e2e-log.md` — lightpanda 0.3.6 sole backend, VISUAL AC `BLOCKED` |
+| AC-5 | same entry — DOM-functional AC `PASS`, JS-rendered content resolved |
+| AC-6 | `Browser:` line asserted in both trees' evidence template |
+| AC-7 | `tests/test-skill-parity.sh` green; both `verify/SKILL.md` byte-identical |
+| AC-8 | runbook documents the one-liner; `git diff 25999b1 -- install.sh` empty |
+| AC-9 | `tests/test-syncable-paths.sh` green; 3 enumerations probed red then reverted |
+| AC-10 | `git diff 25999b1 -- .../start-qa` empty; guard pins no lightpanda reference |
+| AC-11 | doc-conventions asserts no `agent-reach` token outside `specs/` |
+
+**Suite**: 20 test files, 19 pass, 1347 assertions (baseline at branch point: 18 files).
+The single failure is `tests/test-codex-install.sh` — pre-existing on master, Windows-only
+(Python 3.13 defaults to cp1252 and dies on the hook banner's non-ASCII before parsing).
+Reproduced at `0064efe` without this branch's commits; CI on Linux is green.
+
+### What the AC-4 run changed
+
+The evidence run did not merely confirm the design — it sharpened it. Geometry APIs are
+**stubbed rather than absent**: `getBoundingClientRect()` returns every element as `5x5`
+with `x == y`, ignoring CSS entirely. So a defensively written visibility check
+(`r.width > 0 && r.x >= 0`) returns *true* for an element positioned 9999px off-screen.
+
+This is materially worse than §1.1's original "no rendering path" framing. A missing API
+throws where its caller notices; a stubbed one answers wrong in silence, leaving no runtime
+signal to fail on. That is the concrete reason the classifier must decide **before**
+execution rather than attempting a visual check and letting it fail. The runbook and
+`tests/test-browser-runbook.sh` both carry this finding.
+
 ---
 
 ## 8. Open risks carried forward

--- a/tasks/e2e-log.md
+++ b/tasks/e2e-log.md
@@ -68,3 +68,77 @@ Result: PASS
 this commit. Cause: Python 3.13 on Windows defaults to cp1252, so `json.loads` raises
 `UnicodeEncodeError` on the hook banner's non-ASCII characters before parsing. CI (Linux)
 reports the full suite green for this commit.
+
+---
+
+## E2E Walkthrough — Lightpanda DOM tier — 2026-08-17 ad475ec
+
+Spec: specs/lightpanda-browser-adoption.md (AC-4, AC-5)
+Commit: ad475ec82e926db24ee98217bf654ed6db0432d7
+Browser: lightpanda 0.3.6 (DOM-tier) — Docker `lightpanda/browser:0.3.6`, sole backend
+
+**AC-4/AC-5** — with only a DOM-tier backend available, a VISUAL AC yields BLOCKED
+and never PASS, while DOM-functional ACs still execute.
+
+### Fixture
+
+A checkout page served by nginx over a private Docker network (real HTTP, no host
+port). Two deliberate properties:
+
+- `#total` is filled in by JavaScript after load.
+- `#submit-btn` is present and correctly labelled, but styled
+  `position:absolute; left:-9999px; top:-9999px` — **DOM-correct, visually absent.**
+
+### AC-1: "the order total is displayed on the checkout page"
+Tier: DOM-FUNCTIONAL (element text content)
+Journey: load the page, assert the total resolves after scripts run.
+
+Raw HTTP, i.e. what `WebFetch` sees:
+```
+<p id="total">loading…</p>
+```
+
+Lightpanda `fetch --dump html`:
+```
+<p id="total">Order total: $42.00</p>
+```
+
+The scripts ran against a real network fetch — the distinction Iron Law 1 turns
+on. Result: **PASS**
+
+### AC-2: "the submit button is visible on the checkout form"
+Tier: VISUAL (visibility is a rendering property)
+Result: **BLOCKED** — requires a full-fidelity browser; only lightpanda (DOM-tier) available
+
+Not attempted. Recorded as BLOCKED, so the run reports non-success while AC-1's
+coverage is kept.
+
+### Why BLOCKED rather than attempted-and-checked
+
+The reflex is to attempt it defensively and let the check fail. Probing the
+backend shows why that does not work — geometry is **stubbed, not missing**:
+
+```
+submit-btn=[110,110,5,5]  total=[130,130,5,5]  checkout=[80,80,5,5]  h1=[65,65,5,5]
+```
+
+Every element reports 5x5 with x == y; an `<h1>` and a `<button>` are not the same
+size, and the `left:-9999px` offset is ignored entirely. So the careful assertion
+
+```js
+const r = el.getBoundingClientRect();
+if (r.width > 0 && r.x >= 0) { /* "visible" */ }
+```
+
+**returns true for an element 9999px off the left edge.** A missing API throws and
+its caller notices; a stubbed one answers wrong in silence. There is no runtime
+signal to fail on, so the tier must be decided before execution — which is what
+fail-closed classification does.
+
+Method note: the first geometry probe returned nothing and could have been read
+as "API absent". A control run showed `console.log` output does not reach stdout
+in `fetch` mode — the probe was faulty, not the API. The values above were
+re-obtained by writing results into the DOM, which the dump captures. An empty
+result is not evidence of absence.
+
+Result: PASS (AC-4 and AC-5 both satisfied)

--- a/tasks/e2e-log.md
+++ b/tasks/e2e-log.md
@@ -142,3 +142,16 @@ re-obtained by writing results into the DOM, which the dump captures. An empty
 result is not evidence of absence.
 
 Result: PASS (AC-4 and AC-5 both satisfied)
+
+### Addendum — 2026-08-18: commit reference rebased
+
+The `Commit:` line above records `ad475ec82e926db24ee98217bf654ed6db0432d7`, the SHA
+this branch carried when the walkthrough ran. The branch was later rebased onto master
+`8828ba0` to pick up #66/#67/#68, so that SHA is unreachable and `git show` on it fails.
+The same content is now `c91ae4a` ("feat(research): offer lightpanda fetch for
+JS-rendered pages; guard the decisions").
+
+Corrected by addendum rather than by editing the line above: the log is the audit trail,
+and an entry silently rewritten to look as though it always pointed at the right commit
+is worth less than one that shows what moved. Nothing about the run itself changed — same
+fixture, same `lightpanda/browser:0.3.6` image, same observed values.

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -156,3 +156,47 @@
   first full suite run overlapped tree edits, so it was discarded and re-run on a settled
   tree with before/after `git status` snapshots as proof.
 - Learnings captured: `tasks/solutions/patterns/explicit-encoding-at-every-python-io-boundary.md`
+
+### [2026-08-18] — Lightpanda optional e2e browser tier
+
+- Key changes: Evaluated two candidate repos and adopted one. Lightpanda enters as an
+  optional, capability-scoped e2e backend behind a **fail-closed AC classifier**;
+  `agent-reach` was declined outright (spec §2) rather than adopted partially. New
+  `.claude/browsers/lightpanda.md` adapter runbook mirroring the `.claude/deployments/`
+  frontmatter-plus-troubleshooting precedent; `.claude/browsers/` declared syncable across
+  all 7 enumerations in 3 files; `/verify --scope e2e` gained backend resolution, the
+  VISUAL / DOM-FUNCTIONAL tiers, and the `BLOCKED` outcome; `/prd` and `/brainstorm` gained
+  `lightpanda fetch` as an optional research fallback that never blocks when absent.
+  `/start-qa` and `install.sh` deliberately untouched (AC-10, AC-11).
+- Design decision worth keeping: the load-bearing element is a single sentence —
+  "when classification is uncertain, the AC is VISUAL". Reverse it and the gate inverts
+  from *refuse to guess* to *guess and pass*, silently, with every test still green,
+  because nothing else in the suite reads it. `tests/test-e2e-classifier.sh` therefore
+  pins that sentence **verbatim in both skill trees** rather than paraphrasing it.
+- Why a routing gate and not a runtime check: lightpanda's `getBoundingClientRect()` is
+  *stubbed*, not absent — it returns plausible constants, so the standard visibility guard
+  passes for an element 9999px off-screen. A capability gap that lies cannot be caught by
+  the caller's feature detection, so it has to be refused before dispatch. Captured as
+  `tasks/solutions/patterns/a-stubbed-web-api-is-more-dangerous-than-an-absent-one.md`.
+- Investigation error worth recording: the first geometry probe returned nothing, which
+  supported the tidy and wrong conclusion "the API is absent". A control run showed
+  `console.log` never reaches stdout in `fetch` mode. Re-probing through the DOM inverted
+  the finding. The method note stayed in `tasks/e2e-log.md` rather than being tidied away.
+  Captured as `tasks/solutions/patterns/a-null-probe-result-needs-a-control-run.md`.
+- Review: 4 passes run **inline**, not dispatched — the session operated under a standing
+  no-subagent constraint. Per `CLAUDE.md` § *Independence Accounting* that forfeits
+  corroboration-based promotion, so no finding here was promoted on agreement; naming the
+  loss is the floor. Two real defects found and fixed: passing walkthroughs were not
+  recording their tier (only blocked ones were), and a `harness: universal` skill pointed
+  at a Claude-only `.claude/browsers/` path that `scripts/install-codex.sh:50` never copies.
+- Process failure, self-caught: I argued the >6-task worktree trigger did not apply and
+  worked in the shared clone. A `git add tasks/todo.md` then swept a parallel session's
+  plans into my commit, which had to be rebuilt with `--amend`. The trigger was right and
+  my exception was wrong; the shared register is exactly what the worktree isolates.
+- AC-4 could not be satisfied by static assertions, and was not claimed on them. It needed
+  a real lightpanda run, no Windows binary exists, and Docker Desktop was down — repaired
+  first (stale AF_UNIX socket at `%LOCALAPPDATA%\Docker\run\dockerInference`, unremovable
+  by `Remove-Item`, `del`, or `fsutil reparsepoint delete`; fixed by rotating the directory)
+  and the walkthrough then ran container-to-container.
+- Learnings captured: `tasks/solutions/patterns/a-stubbed-web-api-is-more-dangerous-than-an-absent-one.md`,
+  `tasks/solutions/patterns/a-null-probe-result-needs-a-control-run.md`

--- a/tasks/solutions/patterns/a-null-probe-result-needs-a-control-run.md
+++ b/tasks/solutions/patterns/a-null-probe-result-needs-a-control-run.md
@@ -1,0 +1,41 @@
+---
+title: A null probe result needs a control run before it becomes a conclusion
+date: 2026-08-18
+problem_type: pattern
+module: general — investigation method
+tags: [investigation, evidence, probe, false-negative]
+applies_when: A diagnostic probe returns nothing, and the emptiness itself is about to be read as the finding.
+---
+
+## A null probe result needs a control run before it becomes a conclusion
+
+**Pattern**: When a probe returns nothing, there are two explanations — the
+subject produced nothing, or the *channel* carried nothing — and they are
+indistinguishable from the empty output alone. Before reporting emptiness as a
+property of the subject, run a control that would definitely produce output if
+the channel worked.
+
+While probing whether lightpanda implements element geometry, the first probe
+emitted `console.log` and returned nothing. Read at face value that supports
+"the API is absent" — a clean, quotable, **wrong** conclusion. A control run
+showed `console.log` output does not reach stdout in `fetch` mode at all
+(`tasks/e2e-log.md:138-139`). Re-probing by writing results into the DOM instead
+returned real numbers, and those numbers reversed the finding: the API is not
+absent, it is stubbed — the opposite conclusion, with the opposite design
+consequence
+([a-stubbed-web-api-is-more-dangerous-than-an-absent-one.md](a-stubbed-web-api-is-more-dangerous-than-an-absent-one.md)).
+
+**Why this is worth a rule**: a false negative from a broken channel is
+*self-confirming*. It arrives looking exactly like a successful measurement, it
+agrees with the prior that motivated the probe ("the cheap browser probably lacks
+this"), and nothing downstream contradicts it. Cost asymmetry favours the
+control: one extra run, versus a spec written around an inverted premise.
+
+**Prevention rule**: an absence claim needs two runs — the probe, and a positive
+control on the same channel. Record both. If only the probe exists, the finding
+is at confidence `50` regardless of how clean the output looked, because no line
+proves the channel worked.
+
+**Evidence**: the method note appended to the walkthrough that produced the
+finding (`tasks/e2e-log.md:138-139`) records that the first probe was faulty
+rather than quietly publishing the corrected result.

--- a/tasks/solutions/patterns/a-stubbed-web-api-is-more-dangerous-than-an-absent-one.md
+++ b/tasks/solutions/patterns/a-stubbed-web-api-is-more-dangerous-than-an-absent-one.md
@@ -1,0 +1,56 @@
+---
+title: A stubbed Web API is more dangerous than an absent one
+date: 2026-08-18
+problem_type: pattern
+module: .agents/skills/verify — e2e browser tiering
+tags: [browser, e2e, feature-detection, fail-closed, lightpanda]
+applies_when: Adding a reduced-capability backend (headless browser, shim, emulator, mock) behind an interface that callers feature-detect.
+---
+
+## A stubbed Web API is more dangerous than an absent one
+
+**Pattern**: When you scope a capability out of a backend, check whether the
+removed API *throws* or *returns a plausible value*. An absent API throws, and
+the caller notices. A stubbed one returns fiction that satisfies every guard
+written to detect absence — so the check that was supposed to protect the caller
+becomes the thing that green-lights it.
+
+Lightpanda implements `getBoundingClientRect()` and `offsetWidth`/`offsetHeight`
+as constants rather than layout results
+(`.claude/browsers/lightpanda.md:51-74`). On a fixture whose button is styled
+`position:absolute; left:-9999px`, the geometry came back as
+`submit-btn=[110,110,5,5]` — positive width, non-negative x
+(`.claude/browsers/lightpanda.md:58`). So the canonical visibility guard
+
+```js
+const r = el.getBoundingClientRect();
+if (r.width > 0 && r.x >= 0) { /* "it's visible" */ }
+```
+
+**passes for an element 9999px off the left edge**
+(`.claude/browsers/lightpanda.md:74`).
+
+**Consequence for design**: a capability ceiling cannot be enforced by the
+caller's feature detection when the gap is stubbed. It has to be enforced
+*above* the backend, by refusing to route the work at all. That is why the tier
+system classifies each acceptance criterion before choosing a backend and fails
+closed toward the stricter tier
+(`.agents/skills/verify/SKILL.md:150`), instead of letting the walkthrough try
+and see what happens.
+
+**Corollary — asymmetric treatment of the two failure shapes**: an API that
+*errors* is a step failure and names the API in evidence; it must never be
+re-classified as passing
+(`.agents/skills/verify/SKILL.md:214`). An API that *lies* cannot be caught at
+that layer at all, which is what makes pre-classification load-bearing rather
+than belt-and-braces.
+
+**Prevention rule**: before trusting a reduced backend, probe one case whose
+correct answer you already know from outside the backend, and confirm the
+backend gets it *wrong* in a way you can see. If it gets it plausibly wrong and
+silently, the gap needs a routing gate, not a runtime check.
+
+See also: [a-null-probe-result-needs-a-control-run.md](a-null-probe-result-needs-a-control-run.md).
+
+**Evidence**: PR for the lightpanda e2e tier; behavioural walkthrough recorded
+in `tasks/e2e-log.md` under `Browser: lightpanda 0.3.6 (DOM-tier)`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -170,4 +170,4 @@
 
 ## Task 8 — Full suite + quality gate
 
-[ ] TDD: `bash tests/run.sh` green with a 600s timeout; new test-file count recorded against the Setup baseline -> run, fix fallout, then `/quality-gate`; verify every AC in `specs/lightpanda-browser-adoption.md` including the AC-4 evidence from Task 7
+[x] TDD: `bash tests/run.sh` green with a 600s timeout; new test-file count recorded against the Setup baseline -> run, fix fallout, then `/quality-gate`; verify every AC in `specs/lightpanda-browser-adoption.md` including the AC-4 evidence from Task 7

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -127,3 +127,47 @@
 - Carry-forward: none. This branch also fixed the Codex adapter and diagnosed the
   session guard; both were superseded by #66 and #68, which landed on master first.
   Taken from upstream at merge — see the history entry for what my diagnosis got wrong.
+## Plan: Lightpanda Optional E2E Browser Tier
+> Spec: specs/lightpanda-browser-adoption.md
+> Branch: `feat/lightpanda-e2e-tier` off master @ 25999b1 (PR #65 merged, so
+> `tests/test-syncable-paths.sh` is now on master — Task 2's dependency is satisfied
+> and its red-then-green runs normally).
+> Status: In progress
+>
+> **Decision:** lightpanda enters as an optional, capability-scoped e2e tier gated by a
+> fail-closed AC classifier. agent-reach declined (spec §2). `/start-qa` and `install.sh`
+> unmodified.
+
+[x] Setup: branch `feat/lightpanda-e2e-tier` created off master @ 25999b1
+
+## Task 1 — Runbook: `.claude/browsers/lightpanda.md` (AC-1)
+
+[ ] TDD: new `tests/test-browser-runbook.sh` asserts `.claude/browsers/lightpanda.md` exists; frontmatter carries `name`, `display_name`, `fidelity`, `detect_command`, `mcp_command`, `platforms`, `license`; `name` equals the filename stem; `fidelity` is `dom` or `full`; body contains the capability-ceiling tokens (`screenshot`, `Canvas`, `Flexbox`, `Service Worker`), the Windows gap, `AGPL-3.0`, the pinned release tag, and the MCP registration one-liner -> write the runbook per spec §4.6: per-platform install (Homebrew, AUR, `.deb`, pinned `0.3.6` binary, Docker), registration command, ceiling from §1.1, Windows→WSL2/Docker note, AGPL unmodified-binary constraint, troubleshooting
+
+## Task 2 — Declare `.claude/browsers/` syncable (AC-9)
+
+[ ] TDD: `tests/test-syncable-paths.sh` green with `.claude/browsers/` present in all seven enumerations, and red when any single one is perturbed (demonstrate by temporary edit + revert, capture output); INVARIANT 2 resolves the runbook to a declared syncable path -> add `.claude/browsers/` to the § Syncable Paths doc block, the `git diff --stat` arg list, and the full `git diff` arg list in `.agents/skills/sync/SKILL.md`; copy byte-identical into `.claude/skills/sync/SKILL.md`; add it to the drift-check arg list in `.claude/hooks/session-start.sh`
+
+## Task 3 — Tier resolution + fail-closed classifier in `/verify --scope e2e` (AC-2, AC-3, AC-4 static)
+
+[ ] TDD: new `tests/test-e2e-classifier.sh` asserts BOTH tree copies of `verify/SKILL.md` contain the four-row resolution-order table (Chrome MCP, Playwright MCP, Lightpanda, none→STOP), both tier definitions (VISUAL, DOM-FUNCTIONAL), the fail-closed sentence **verbatim** (`when classification is uncertain, the AC is VISUAL`), the `BLOCKED` outcome row, and the Iron Law 1 cross-reference; `tests/test-skill-parity.sh` green -> edit `.agents/skills/verify/SKILL.md` Pre-Flight + Failure Handling per spec §4.1–§4.4, then copy byte-identical to `.claude/skills/verify/SKILL.md`
+
+## Task 4 — Evidence records the backend and fidelity (AC-6)
+
+[ ] TDD: `tests/test-e2e-classifier.sh` asserts both tree copies' Evidence Format block includes a `Browser:` line carrying backend and fidelity tier -> add the line to the `tasks/e2e-log.md` template in § Evidence Format, both trees byte-identical
+
+## Task 5 — `lightpanda fetch` as an optional research fallback (spec §3.6)
+
+[ ] TDD: `tests/test-doc-conventions.sh` asserts both tree copies of `prd/SKILL.md` and `brainstorm/SKILL.md` name `lightpanda fetch` as an optional fallback for JS-heavy pages AND state that its absence is not an error -> add one paragraph to each skill's research step; four files, parity-copied
+
+## Task 6 — Guards: agent-reach absent, `/start-qa` untouched (AC-10, AC-11)
+
+[ ] TDD: `tests/test-doc-conventions.sh` asserts no `agent-reach` token outside `specs/`, and that `.agents/skills/start-qa/SKILL.md` is byte-identical to its `.claude/` copy and unchanged from the base commit -> assertions only; no implementation
+
+## Task 7 — Behavioural evidence for AC-4 (the one static tests cannot cover)
+
+[ ] TDD: `tasks/e2e-log.md` gains an entry with `Browser: lightpanda 0.3.6 (DOM-tier)` showing one VISUAL AC as `BLOCKED` and one DOM-functional AC as `PASS`, run with lightpanda as the only available backend -> run against a throwaway two-AC spec via the pinned Docker image (no Windows binary exists). **If lightpanda cannot be run in this environment, mark this task BLOCKED and report it — do not mark AC-4 satisfied on static assertions alone**
+
+## Task 8 — Full suite + quality gate
+
+[ ] TDD: `bash tests/run.sh` green with a 600s timeout; new test-file count recorded against the Setup baseline -> run, fix fallout, then `/quality-gate`; verify every AC in `specs/lightpanda-browser-adoption.md` including the AC-4 evidence from Task 7

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -132,7 +132,8 @@
 > Branch: `feat/lightpanda-e2e-tier` off master @ 25999b1 (PR #65 merged, so
 > `tests/test-syncable-paths.sh` is now on master — Task 2's dependency is satisfied
 > and its red-then-green runs normally).
-> Status: In progress
+> Status: Complete — rebased onto master @ 8828ba0 (#66/#67/#68 landed mid-session,
+> which cleared the pre-existing Windows red baseline this plan's Task 8 was blocked on)
 >
 > **Decision:** lightpanda enters as an optional, capability-scoped e2e tier gated by a
 > fail-closed AC classifier. agent-reach declined (spec §2). `/start-qa` and `install.sh`
@@ -171,3 +172,12 @@
 ## Task 8 — Full suite + quality gate
 
 [x] TDD: `bash tests/run.sh` green with a 600s timeout; new test-file count recorded against the Setup baseline -> run, fix fallout, then `/quality-gate`; verify every AC in `specs/lightpanda-browser-adoption.md` including the AC-4 evidence from Task 7
+
+## Session Summary — [2026-08-18] [8828ba0..HEAD]
+- Completed: 8 planned tasks (all of the Lightpanda plan above) + 1 review-driven fix
+- Pending: 0
+- Carry-forward: `.claude/deployments/` has the same syncable-path gap `.claude/browsers/`
+  just closed, and `/verify --scope deployment` names `tasks/deployments/<service>.md`
+  while the directory in this repo is `.claude/deployments/` — a pre-existing mismatch,
+  left alone under the orphan rule rather than folded into this change. Lightpanda `0.3.7`
+  is published upstream; the pin stays at `0.3.6`, the version AC-4 evidence was taken on.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -142,31 +142,31 @@
 
 ## Task 1 — Runbook: `.claude/browsers/lightpanda.md` (AC-1)
 
-[ ] TDD: new `tests/test-browser-runbook.sh` asserts `.claude/browsers/lightpanda.md` exists; frontmatter carries `name`, `display_name`, `fidelity`, `detect_command`, `mcp_command`, `platforms`, `license`; `name` equals the filename stem; `fidelity` is `dom` or `full`; body contains the capability-ceiling tokens (`screenshot`, `Canvas`, `Flexbox`, `Service Worker`), the Windows gap, `AGPL-3.0`, the pinned release tag, and the MCP registration one-liner -> write the runbook per spec §4.6: per-platform install (Homebrew, AUR, `.deb`, pinned `0.3.6` binary, Docker), registration command, ceiling from §1.1, Windows→WSL2/Docker note, AGPL unmodified-binary constraint, troubleshooting
+[x] TDD: new `tests/test-browser-runbook.sh` asserts `.claude/browsers/lightpanda.md` exists; frontmatter carries `name`, `display_name`, `fidelity`, `detect_command`, `mcp_command`, `platforms`, `license`; `name` equals the filename stem; `fidelity` is `dom` or `full`; body contains the capability-ceiling tokens (`screenshot`, `Canvas`, `Flexbox`, `Service Worker`), the Windows gap, `AGPL-3.0`, the pinned release tag, and the MCP registration one-liner -> write the runbook per spec §4.6: per-platform install (Homebrew, AUR, `.deb`, pinned `0.3.6` binary, Docker), registration command, ceiling from §1.1, Windows→WSL2/Docker note, AGPL unmodified-binary constraint, troubleshooting
 
 ## Task 2 — Declare `.claude/browsers/` syncable (AC-9)
 
-[ ] TDD: `tests/test-syncable-paths.sh` green with `.claude/browsers/` present in all seven enumerations, and red when any single one is perturbed (demonstrate by temporary edit + revert, capture output); INVARIANT 2 resolves the runbook to a declared syncable path -> add `.claude/browsers/` to the § Syncable Paths doc block, the `git diff --stat` arg list, and the full `git diff` arg list in `.agents/skills/sync/SKILL.md`; copy byte-identical into `.claude/skills/sync/SKILL.md`; add it to the drift-check arg list in `.claude/hooks/session-start.sh`
+[x] TDD: `tests/test-syncable-paths.sh` green with `.claude/browsers/` present in all seven enumerations, and red when any single one is perturbed (demonstrate by temporary edit + revert, capture output); INVARIANT 2 resolves the runbook to a declared syncable path -> add `.claude/browsers/` to the § Syncable Paths doc block, the `git diff --stat` arg list, and the full `git diff` arg list in `.agents/skills/sync/SKILL.md`; copy byte-identical into `.claude/skills/sync/SKILL.md`; add it to the drift-check arg list in `.claude/hooks/session-start.sh`
 
 ## Task 3 — Tier resolution + fail-closed classifier in `/verify --scope e2e` (AC-2, AC-3, AC-4 static)
 
-[ ] TDD: new `tests/test-e2e-classifier.sh` asserts BOTH tree copies of `verify/SKILL.md` contain the four-row resolution-order table (Chrome MCP, Playwright MCP, Lightpanda, none→STOP), both tier definitions (VISUAL, DOM-FUNCTIONAL), the fail-closed sentence **verbatim** (`when classification is uncertain, the AC is VISUAL`), the `BLOCKED` outcome row, and the Iron Law 1 cross-reference; `tests/test-skill-parity.sh` green -> edit `.agents/skills/verify/SKILL.md` Pre-Flight + Failure Handling per spec §4.1–§4.4, then copy byte-identical to `.claude/skills/verify/SKILL.md`
+[x] TDD: new `tests/test-e2e-classifier.sh` asserts BOTH tree copies of `verify/SKILL.md` contain the four-row resolution-order table (Chrome MCP, Playwright MCP, Lightpanda, none→STOP), both tier definitions (VISUAL, DOM-FUNCTIONAL), the fail-closed sentence **verbatim** (`when classification is uncertain, the AC is VISUAL`), the `BLOCKED` outcome row, and the Iron Law 1 cross-reference; `tests/test-skill-parity.sh` green -> edit `.agents/skills/verify/SKILL.md` Pre-Flight + Failure Handling per spec §4.1–§4.4, then copy byte-identical to `.claude/skills/verify/SKILL.md`
 
 ## Task 4 — Evidence records the backend and fidelity (AC-6)
 
-[ ] TDD: `tests/test-e2e-classifier.sh` asserts both tree copies' Evidence Format block includes a `Browser:` line carrying backend and fidelity tier -> add the line to the `tasks/e2e-log.md` template in § Evidence Format, both trees byte-identical
+[x] TDD: `tests/test-e2e-classifier.sh` asserts both tree copies' Evidence Format block includes a `Browser:` line carrying backend and fidelity tier -> add the line to the `tasks/e2e-log.md` template in § Evidence Format, both trees byte-identical
 
 ## Task 5 — `lightpanda fetch` as an optional research fallback (spec §3.6)
 
-[ ] TDD: `tests/test-doc-conventions.sh` asserts both tree copies of `prd/SKILL.md` and `brainstorm/SKILL.md` name `lightpanda fetch` as an optional fallback for JS-heavy pages AND state that its absence is not an error -> add one paragraph to each skill's research step; four files, parity-copied
+[x] TDD: `tests/test-doc-conventions.sh` asserts both tree copies of `prd/SKILL.md` and `brainstorm/SKILL.md` name `lightpanda fetch` as an optional fallback for JS-heavy pages AND state that its absence is not an error -> add one paragraph to each skill's research step; four files, parity-copied
 
 ## Task 6 — Guards: agent-reach absent, `/start-qa` untouched (AC-10, AC-11)
 
-[ ] TDD: `tests/test-doc-conventions.sh` asserts no `agent-reach` token outside `specs/`, and that `.agents/skills/start-qa/SKILL.md` is byte-identical to its `.claude/` copy and unchanged from the base commit -> assertions only; no implementation
+[x] TDD: `tests/test-doc-conventions.sh` asserts no `agent-reach` token outside `specs/`, and that `.agents/skills/start-qa/SKILL.md` is byte-identical to its `.claude/` copy (base-commit check done via git diff, not encoded as a test — "base" has no meaning post-merge; the durable pin is that start-qa never routes to the DOM tier) -> assertions only; no implementation
 
 ## Task 7 — Behavioural evidence for AC-4 (the one static tests cannot cover)
 
-[ ] TDD: `tasks/e2e-log.md` gains an entry with `Browser: lightpanda 0.3.6 (DOM-tier)` showing one VISUAL AC as `BLOCKED` and one DOM-functional AC as `PASS`, run with lightpanda as the only available backend -> run against a throwaway two-AC spec via the pinned Docker image (no Windows binary exists). **If lightpanda cannot be run in this environment, mark this task BLOCKED and report it — do not mark AC-4 satisfied on static assertions alone**
+[x] TDD: `tasks/e2e-log.md` gains an entry with `Browser: lightpanda 0.3.6 (DOM-tier)` showing one VISUAL AC as `BLOCKED` and one DOM-functional AC as `PASS`, run with lightpanda as the only available backend -> run against a throwaway two-AC spec via the pinned Docker image (no Windows binary exists). **If lightpanda cannot be run in this environment, mark this task BLOCKED and report it — do not mark AC-4 satisfied on static assertions alone**
 
 ## Task 8 — Full suite + quality gate
 

--- a/tests/test-browser-runbook.sh
+++ b/tests/test-browser-runbook.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# tests/test-browser-runbook.sh — the browser-adapter runbook contract.
+#
+# WHY THIS EXISTS
+#
+# `/verify --scope e2e` may resolve to lightpanda, a headless browser that
+# executes JavaScript over a real network but has NO rendering path: no
+# screenshots, no Canvas/WebGL, partial CSS layout. A page whose layout is
+# broken can still expose a correct DOM, so a reviewer who does not know the
+# ceiling will read a PASS as "the feature works" when it means "the DOM was
+# right and nobody looked".
+#
+# The runbook is where that ceiling is written down. This test pins the
+# frontmatter contract that makes the file machine-readable, and pins the body
+# tokens that stop the ceiling being quietly dropped in a later edit. A ceiling
+# documented once and deleted later is worse than never documented, because the
+# skill still routes ACs to the tier on the strength of a file that no longer
+# warns about it.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+RUNBOOK=".claude/browsers/lightpanda.md"
+
+# --- 1. The file exists at the contracted location ---------------------------
+if [ -f "$RUNBOOK" ]; then
+  assert_eq "present" "present" "runbook: $RUNBOOK exists"
+else
+  assert_eq "present" "absent" "runbook: $RUNBOOK exists"
+  finish
+fi
+
+# --- 2. Frontmatter contract -------------------------------------------------
+# Extract the leading `---`-fenced block so a token appearing later in the body
+# cannot satisfy a frontmatter assertion.
+FRONTMATTER="$(awk 'NR==1 && $0=="---"{f=1;next} f&&$0=="---"{exit} f' "$RUNBOOK")"
+
+assert_not_contains "$FRONTMATTER" "PLACEHOLDER" "frontmatter: no placeholder values"
+
+for field in name display_name fidelity detect_command mcp_command platforms license; do
+  assert_contains "$FRONTMATTER" "$field:" "frontmatter: declares $field"
+done
+
+# `name` must match the filename stem — it is the stable key a skill resolves
+# the adapter by, mirroring the .claude/deployments/ contract.
+assert_contains "$FRONTMATTER" "name: lightpanda" "frontmatter: name matches filename stem"
+
+# `fidelity` is the field the classifier gates on. Anything outside the
+# enumeration would route ACs by an unrecognised value.
+FIDELITY="$(printf '%s\n' "$FRONTMATTER" | sed -n 's/^fidelity:[[:space:]]*//p' | tr -d '\r')"
+case "$FIDELITY" in
+  dom|full) assert_eq "valid" "valid" "frontmatter: fidelity is dom|full (got '$FIDELITY')" ;;
+  *)        assert_eq "valid" "invalid: '$FIDELITY'" "frontmatter: fidelity is dom|full" ;;
+esac
+
+# Lightpanda specifically is the DOM tier. A future edit flipping this to `full`
+# would silently make every VISUAL AC eligible for a browser that cannot render.
+assert_eq "dom" "$FIDELITY" "frontmatter: lightpanda is the dom tier, not full"
+
+# --- 3. The capability ceiling survives later edits --------------------------
+# Each token below is a capability the browser does NOT have. Losing any one of
+# them from the runbook is losing the warning that justifies the fail-closed
+# classifier.
+assert_file_contains "$RUNBOOK" "screenshot"     "ceiling: names the screenshot gap"
+assert_file_contains "$RUNBOOK" "Canvas"         "ceiling: names the Canvas/WebGL gap"
+assert_file_contains "$RUNBOOK" "Flexbox"        "ceiling: names the partial CSS layout gap"
+assert_file_contains "$RUNBOOK" "Service Worker" "ceiling: names the Service Worker gap"
+assert_file_contains "$RUNBOOK" "WebSocket"      "ceiling: names the limited WebSocket support"
+
+# --- 4. Operational facts a reader cannot derive from the frontmatter --------
+assert_file_contains "$RUNBOOK" "AGPL-3.0" "licensing: names the licence"
+assert_prose_contains "$RUNBOOK" "unmodified upstream" \
+  "licensing: states the unmodified-binary constraint"
+
+# No Windows binary is published. A reader on Windows must be told to reach for
+# WSL2 or Docker rather than concluding the tool is broken.
+assert_file_contains "$RUNBOOK" "Windows" "platform: addresses the Windows gap"
+assert_file_matches  "$RUNBOOK" "WSL2|Docker" "platform: offers the Windows workaround"
+
+# The release is pinned, not tracked. `nightly` on a beta project changes
+# unattended-run behaviour without a commit.
+assert_file_matches "$RUNBOOK" "0\.3\.6" "pinning: names an explicit release tag"
+
+# Registration is documented here because install.sh deliberately does not do it.
+assert_file_contains "$RUNBOOK" "lightpanda mcp" "registration: documents the MCP one-liner"
+
+# --- 5. platforms list excludes Windows, matching reality --------------------
+# The frontmatter must not claim a platform upstream does not ship, or a harness
+# reading this contract would try to resolve a binary that does not exist.
+PLATFORMS="$(printf '%s\n' "$FRONTMATTER" | sed -n 's/^platforms:[[:space:]]*//p')"
+assert_not_contains "$PLATFORMS" "windows" "frontmatter: platforms omits windows (no upstream build)"
+
+finish

--- a/tests/test-browser-runbook.sh
+++ b/tests/test-browser-runbook.sh
@@ -91,4 +91,17 @@ assert_file_contains "$RUNBOOK" "lightpanda mcp" "registration: documents the MC
 PLATFORMS="$(printf '%s\n' "$FRONTMATTER" | sed -n 's/^platforms:[[:space:]]*//p')"
 assert_not_contains "$PLATFORMS" "windows" "frontmatter: platforms omits windows (no upstream build)"
 
+# --- 6. Stubbed geometry is the ceiling's sharpest edge -----------------------
+# getBoundingClientRect() does not throw here — it returns synthetic values
+# (every element 5x5, x==y) that ignore CSS entirely. A missing API would be
+# caught by its caller; a stubbed one silently answers wrong, so the defensive
+# `r.width > 0 && r.x >= 0` visibility check passes for an off-screen element.
+# That is the specific reason VISUAL criteria are refused rather than attempted,
+# so losing this warning removes the justification for the whole fail-closed
+# design while leaving the design in place.
+assert_file_contains "$RUNBOOK" "getBoundingClientRect" \
+  "ceiling: warns that geometry APIs are stubbed, not absent"
+assert_prose_contains "$RUNBOOK" "stubbed" \
+  "ceiling: names the stubbed-not-missing distinction"
+
 finish

--- a/tests/test-doc-conventions.sh
+++ b/tests/test-doc-conventions.sh
@@ -281,4 +281,36 @@ assert_contains "$keydirs" "tasks/concepts.md" \
 assert_file_contains "project-template/CLAUDE.md" "concepts.md" \
   "M4: project-template CLAUDE.md lists the glossary"
 
+# --- lightpanda: JS-capable page reads offered as an OPTIONAL research fallback ---
+# WebFetch returns the empty shell for a JS-rendered page and gives no signal that
+# it did, so a research step can silently read nothing and report nothing found.
+# `lightpanda fetch` executes the scripts. It is optional everywhere: the machines
+# running this workflow differ (no Windows build exists), so each mention must say
+# absence is not an error, or a skill turns a missing optional tool into a blocker.
+for f in .agents/skills/prd/SKILL.md .claude/skills/prd/SKILL.md \
+         .agents/skills/brainstorm/SKILL.md .claude/skills/brainstorm/SKILL.md; do
+  assert_file_contains "$f" "lightpanda fetch" \
+    "lightpanda: $f offers the JS-capable fetch fallback"
+  assert_prose_contains "$f" "not an error" \
+    "lightpanda: $f states that its absence is not an error"
+done
+
+# --- lightpanda: the DOM tier must not leak into manual QA -------------------
+# /start-qa launches a browser for a HUMAN to look at. Lightpanda has no
+# rendering path, so routing manual QA to it would hand the user a browser that
+# cannot show them anything. This is not a preference — it is the one place the
+# tier is categorically wrong, so it is pinned rather than left to judgement.
+for f in .agents/skills/start-qa/SKILL.md .claude/skills/start-qa/SKILL.md; do
+  assert_file_not_matches "$f" "lightpanda"     "lightpanda: $f does NOT route manual QA to the DOM tier"
+done
+assert_files_identical .agents/skills/start-qa/SKILL.md .claude/skills/start-qa/SKILL.md   "lightpanda: start-qa stays byte-identical across both trees"
+
+# --- agent-reach was evaluated and declined ----------------------------------
+# Recorded as a guard so a later session does not quietly add the dependency the
+# spec argued its way out of. specs/ is exempt: that is where the decision and
+# its reversal path are written down. tests/ is exempt for the obvious reason
+# that this assertion names the token itself.
+reach_hits="$(grep -rl "agent-reach"   .agents .claude/skills .claude/agents .claude/hooks .claude/browsers   CLAUDE.md install.sh project-template 2>/dev/null | grep -v '.claude/worktrees' || true)"
+assert_eq "" "$reach_hits"   "lightpanda: agent-reach is not a dependency anywhere outside specs/"
+
 finish

--- a/tests/test-e2e-classifier.sh
+++ b/tests/test-e2e-classifier.sh
@@ -88,6 +88,15 @@ for f in "$CANONICAL" "$COMPAT"; do
   assert_prose_contains "$f" "DOM-tier" \
     "$f: e2e-log template records the fidelity tier"
 
+  # EVERY logged AC carries its tier, not only the blocked ones. A PASS whose
+  # tier is unrecorded is unreadable after the fact: the reader cannot tell
+  # whether the criterion was deliberately classified DOM-FUNCTIONAL or never
+  # classified at all — precisely the judgement the log exists to preserve.
+  assert_file_contains "$f" "Tier: DOM-FUNCTIONAL" \
+    "$f: the PASS example records its tier too"
+  assert_file_contains "$f" "Tier: VISUAL" \
+    "$f: the BLOCKED example records its tier"
+
 done
 
 # --- 7. Both trees agree ------------------------------------------------------

--- a/tests/test-e2e-classifier.sh
+++ b/tests/test-e2e-classifier.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# tests/test-e2e-classifier.sh — the e2e browser tier contract in /verify.
+#
+# WHY THIS EXISTS
+#
+# `/verify --scope e2e` may now resolve to lightpanda, which executes JavaScript
+# over a real network but never lays out or paints the result. A page with
+# completely broken layout still exposes a correct DOM, so "the button exists and
+# says Submit" passes on a page where the button is invisible, off-screen, or
+# behind a modal.
+#
+# The protection is a classifier that routes each acceptance criterion to a tier
+# and REFUSES to run visual criteria on a browser that cannot see. Its load-
+# bearing property is the direction it fails in: uncertain means VISUAL, never
+# DOM-functional. Reverse that one sentence and the whole gate inverts from
+# "refuse to guess" to "guess and pass" — silently, with every test still green,
+# because nothing else in the suite reads it.
+#
+# So this test pins the sentence verbatim rather than paraphrasing it, and pins
+# it in BOTH skill trees. A rule that holds in the canonical copy and not in the
+# one Claude Code actually loads protects nobody.
+#
+# SCOPE BOUNDARY — this is a prose contract, so these are static assertions:
+# they prove the rule is WRITTEN, not that an agent OBEYS it. Behavioural
+# evidence for the fail-closed rule lives in tasks/e2e-log.md per the spec's
+# AC-4. Neither check substitutes for the other.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+CANONICAL=".agents/skills/verify/SKILL.md"
+COMPAT=".claude/skills/verify/SKILL.md"
+
+for f in "$CANONICAL" "$COMPAT"; do
+
+  # --- 1. Backend resolution order -------------------------------------------
+  # Ordered, first match wins. A full-fidelity backend must outrank lightpanda,
+  # or the cheap tier would win on machines that have a real browser available.
+  assert_prose_contains "$f" "Chrome MCP" \
+    "$f: resolution order names Chrome MCP"
+  assert_prose_contains "$f" "Playwright MCP" \
+    "$f: resolution order names Playwright MCP"
+  assert_prose_contains "$f" "Lightpanda" \
+    "$f: resolution order names Lightpanda"
+
+  # Absence of every backend must still STOP — the pre-existing behaviour this
+  # change must not weaken.
+  assert_file_contains "$f" "MCP browser unavailable" \
+    "$f: retains the no-backend STOP rule"
+
+  # --- 2. Both tiers are defined ---------------------------------------------
+  assert_file_contains "$f" "DOM-FUNCTIONAL" "$f: defines the DOM-FUNCTIONAL tier"
+  assert_file_contains "$f" "VISUAL"         "$f: defines the VISUAL tier"
+
+  # --- 3. THE fail-closed sentence, verbatim ---------------------------------
+  # Pinned literally. A paraphrase here would let a reworded skill drift into
+  # permissive behaviour while this test kept passing.
+  assert_prose_contains "$f" "when classification is uncertain, the AC is VISUAL" \
+    "$f: states the fail-closed rule VERBATIM"
+
+  # --- 4. The BLOCKED outcome ------------------------------------------------
+  # A visual AC on a DOM-only backend is neither PASS nor a step failure: it was
+  # never attempted. Without a distinct outcome it would be recorded as one or
+  # the other, and PASS is the dangerous direction.
+  assert_file_contains "$f" "BLOCKED" \
+    "$f: defines the BLOCKED outcome for unrunnable ACs"
+  assert_prose_contains "$f" "never" \
+    "$f: BLOCKED is stated as never a PASS"
+
+  # A run containing any BLOCKED AC must not report overall success, or partial
+  # coverage would read as full coverage to /build Phase 4.
+  assert_prose_contains "$f" "non-success" \
+    "$f: a BLOCKED AC makes the run report non-success"
+
+  # --- 5. Iron Law 1 cross-reference -----------------------------------------
+  # Iron Law 1 forbids "headless emulation bypassing the network". Lightpanda
+  # loads over libcurl and does not bypass it, but a reader hitting that line
+  # will infer a contradiction unless the skill says so at that point.
+  assert_prose_contains "$f" "libcurl" \
+    "$f: explains why lightpanda satisfies Iron Law 1"
+
+  # --- 6. Evidence records which tier ran (Task 4 / AC-6) --------------------
+  # Without this, a reader six months on cannot tell whether a PASS was seen or
+  # inferred.
+  assert_file_contains "$f" "Browser:" \
+    "$f: e2e-log template records the backend"
+  assert_prose_contains "$f" "DOM-tier" \
+    "$f: e2e-log template records the fidelity tier"
+
+done
+
+# --- 7. Both trees agree ------------------------------------------------------
+# The canonical/compat split is only safe while the two are identical; a rule
+# present in one and not the other is worse than absent from both, because it
+# reads as covered.
+assert_files_identical "$CANONICAL" "$COMPAT" \
+  "verify/SKILL.md is byte-identical across both trees"
+
+finish


### PR DESCRIPTION
## What

Adopts [lightpanda](https://github.com/lightpanda-io/browser) as an **optional,
capability-scoped e2e browser tier** behind a fail-closed AC classifier. Declines
`agent-reach` outright.

Both repos were evaluated together (`/brainstorm` → spec §2). Only one is in.

## Why the classifier is the whole point

Lightpanda executes JavaScript over a real network but never lays out or paints the
result. A page with completely broken layout still exposes a correct DOM — so
"the button exists and says Submit" **passes on a page where the button is invisible,
off-screen, or behind a modal**. Adding a cheap browser without a gate would have
converted missing visual checks into green ones.

So `/verify --scope e2e` now:

1. Resolves a backend in order — Chrome MCP → Playwright MCP → Lightpanda MCP → STOP.
   A full-fidelity backend always outranks the cheap tier.
2. Classifies every AC as `VISUAL` or `DOM-FUNCTIONAL` **before** walking it.
3. Records `BLOCKED` — never `PASS` — for a VISUAL AC on a DOM-only backend, and
   reports the run as **non-success** so partial coverage cannot read as full coverage.

The load-bearing element is one sentence: *"when classification is uncertain, the AC is
VISUAL."* Reverse it and the gate inverts from *refuse to guess* to *guess and pass*,
silently, with every test still green — because nothing else in the suite reads it.
`tests/test-e2e-classifier.sh` therefore pins that sentence **verbatim in both skill
trees** rather than paraphrasing it.

## What the AC-4 evidence run changed

The behavioural run sharpened the design rather than just confirming it. Geometry APIs
are **stubbed, not absent**: `getBoundingClientRect()` returns every element as `5x5`
with `x == y`, ignoring CSS. So the canonical defensive visibility check —

```js
const r = el.getBoundingClientRect();
if (r.width > 0 && r.x >= 0) { /* "it's visible" */ }
```

— **passes for an element positioned 9999px off the left edge.** A capability gap that
*lies* cannot be caught by the caller's feature detection, which is why the ceiling is
enforced by refusing to route rather than by a runtime check. Documented in the runbook
and captured as a learning.

## Changes

| Area | Change |
|------|--------|
| `.claude/browsers/lightpanda.md` | New adapter runbook — frontmatter contract, capability ceiling, per-platform install, AGPL constraint, troubleshooting. Mirrors the `.claude/deployments/` precedent |
| `.agents/skills/verify` (+ parity copy) | Backend resolution, the two tiers, `BLOCKED`, evidence records backend + tier, Iron Law 1 cross-reference |
| `.agents/skills/{prd,brainstorm}` (+ copies) | `lightpanda fetch` as an optional research fallback for JS-rendered pages; absence is explicitly never an error |
| `.agents/skills/sync` (+ copy), `session-start.sh` | `.claude/browsers/` declared syncable across all 7 enumerations |
| `tests/` | `test-browser-runbook.sh` (26), `test-e2e-classifier.sh` (31), `test-doc-conventions.sh` (+32 lines) |
| `install.sh`, `/start-qa` | **Deliberately unchanged** (AC-10, AC-11), pinned by tests |

## Verification

**Suite: 21 files, all pass, 1395 assertions, exit 0** — run on master `8828ba0` after
rebase, on a settled tree (before/after `git status` snapshots taken, and one earlier run
discarded for overlapping edits).

All 11 ACs mapped to evidence in spec § Verification record. AC-4 is the one static
assertions cannot cover; it required a real lightpanda run, no Windows binary exists, so
it ran container-to-container against `lightpanda/browser:0.3.6`.

Earlier runs of this branch reported 20 files / 19 pass / 1347 assertions with
`tests/test-codex-install.sh` red. That was pre-existing on master and Windows-only
(reproduced at `0064efe` without this branch's commits) and is resolved upstream by #66
and #67. The spec keeps both numbers rather than overwriting the old one — this branch
was verified against a red baseline for most of its life.

## Known gaps, stated rather than hidden

- **No checksum on the pinned-release download** (`.claude/browsers/lightpanda.md:108`).
  Reported, not fixed: the digest is not verifiable offline, and an unverified one shipped
  as authoritative is worse than none. Version-pinned over HTTPS is the floor.
- **Lightpanda `0.3.7` is published upstream**; the pin stays at `0.3.6`, the version the
  AC-4 evidence was actually taken on.
- **Pre-existing and out of scope**: `.claude/deployments/` has the same syncable-path gap
  this PR closes for `.claude/browsers/`, and `/verify --scope deployment` names
  `tasks/deployments/<service>.md` while the directory in this repo is
  `.claude/deployments/`. Left alone under the orphan rule.

## Review

4 passes run **inline**, not dispatched — this session operated under a standing
no-subagent constraint. Per `CLAUDE.md` § *Independence Accounting* that forfeits
corroboration-based promotion, so **no finding here was promoted on agreement**.

Two real defects found and fixed:
- Passing walkthroughs were not recording their tier — only blocked ones were. A `PASS`
  with no tier is unreadable after the fact: you cannot tell whether it was deliberately
  classified DOM-FUNCTIONAL or never classified at all.
- A `harness: universal` skill pointed at a Claude-only `.claude/browsers/` path that
  `scripts/install-codex.sh:50` never copies. Only findable after the Codex adapter landed
  on master today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
