### PR TITLE
feat(skills): add /eval — blinded skill evaluation playbook (pstack port)

### DIFF
--- a/.agents/skills/eval/SKILL.md
+++ b/.agents/skills/eval/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: eval
+description: Blinded A/B evals for skill, prompt, or workflow changes before promoting them. Use when deciding whether a new skill variant, prompt rewrite, or structural change actually improves agent behavior — and before merging any skill edit into .agents/skills/.
+argument-hint: "[what changed] [vs what]"
+harness: universal
+---
+
+# /eval — Blinded Skill Evaluation
+
+## Overview
+
+Evals test how a change affects agent behavior **before promoting it**: a new skill
+variant, a structural change, a prompt tweak. The failure mode is the **observer
+effect** — an agent that knows it is being evaluated behaves differently, so
+candidates must run blind. "Looks smart once" is not evidence.
+
+Adapted from poteto's [pstack](https://github.com/cursor/plugins/tree/main/pstack)
+`eval` playbook, translated from Cursor to pi's sub-agent system.
+
+## The Iron Law
+
+```
+THE CANDIDATE NEVER KNOWS IT IS BEING EVALUATED
+```
+
+## Non-negotiables for blinding
+
+- No `eval`, `test`, `judge`, `experiment`, `rubric`, `score`, `compare`,
+  `benchmark`, `candidate`, or `arena` in any directory, file, or prompt the
+  candidate sees.
+- The candidate prompt looks like an organic user request. State the goal, not
+  the meta. "build me a small todo cli" — not "show me how you follow the
+  skill chain".
+- No chain-eliciting cues. Don't ask the candidate to list which skills,
+  principles, or files it applied; that meta-prompt inflates citation behavior.
+  Ask for design notes generally and grade chain-following from code shape,
+  never self-report.
+- Sanitize directory and slug names. Use project-shaped names a user might
+  pick, not labels like `candidate-1` or `agent-a`.
+- Don't tell the candidate other candidates exist.
+- The judge can know it's judging but sees outputs by sanitized label only,
+  never by model name.
+- Comparing two variants: **one judge scores both sets in a single pass on one
+  scale**, blind to which set each came from. Two judge runs with different
+  prompts don't compare — the calibration drifts.
+
+## Steps
+
+1. **Frame.** State what variant is under test and what behavior counts as
+   success. Write the rubric (3–6 concrete criteria) for the judge only. Hold
+   it back from candidates.
+2. **Set up sanitized environments.** Per-candidate managed worktree
+   (`worktree: true` on the workflow/child) with the variant in place. Plant
+   any context an organic task would have: a project skeleton, the skills the
+   candidate would naturally read.
+3. **Author one organic prompt.** What a user would type. No leakage of what
+   is being measured.
+4. **Spawn N parallel candidates** via `pi-subagents` (`runs.all` inside one
+   workflowScript), one per variant, each in its own sanitized worktree. Same
+   prompt to each. Use the build tier (`qwen3-coder-next`) unless the change
+   specifically targets a different tier.
+5. **Spawn one blinded judge** on a **different model family** (reasoning
+   tier: `deepseek-v4-pro`). Judge sees outputs by sanitized label and the
+   rubric, never a model name.
+6. **Verify the chain from transcripts, not self-report.** Read each
+   candidate's session transcript under `.pi/agent/sessions/` for its
+   worktree. Look at which files each candidate actually opened. Citing a
+   skill is not reading it, and reading it is not applying it. Grade
+   chain-following from the files it really read plus the shape of the code,
+   never from the candidate's own claims.
+7. **Read every candidate output yourself**, end to end. Compare to the
+   judge's verdict. Disagreement means the judge is biased or the rubric is
+   ambiguous — fix the rubric and re-judge before trusting a result.
+8. **Decide.** Promote the variant only on a clear, reproducible lift. On an
+   ambiguous result, raise N (repeat count) before raising confidence.
+
+## Reply format
+
+variant under test · rubric · per-candidate notes · judge's verdict · your
+synthesis · recommendation (promote / reject / re-run with changes).
+
+## Anti-patterns
+
+| Smell | Why it fails |
+|-------|--------------|
+| Judging variants in separate judge runs | Calibration drift; scores aren't comparable |
+| Asking candidates which skills they used | Inflates citation, measures compliance theater |
+| Grading from candidate self-report | Verification theater — grade from transcripts and code shape |
+| Eval-aware directory names (`eval-runs/candidate-1`) | Breaks blinding the moment the candidate looks around |
+| One run, one verdict | Single-run variance can exceed real skill lift; repeat before deciding |

--- a/tasks/evals/eval-run-prompt.md
+++ b/tasks/evals/eval-run-prompt.md
@@ -1,0 +1,58 @@
+# Full /eval Run — All Skills
+
+Copy-paste prompt for a fresh pi session. Run on the `skill/eval-playbook`
+branch (PR #70) so the `/eval` skill is loaded. Report lands in `tasks/evals/`.
+
+Budget note: ~25 Phase-1 runs + 32 Phase-2 runs on build tier (qwen3-coder-next),
+8 judges on reasoning tier (deepseek-v4-pro). Abort / downscope if spend looks wrong.
+
+---
+
+/eval Run the full evaluation across .agents/skills/ and generate a report at tasks/evals/skill-report-<date>.md
+
+Follow the /eval playbook exactly. This is a two-phase eval:
+
+PHASE 1 — TRIGGERABILITY AUDIT (all 25 skills, cheap)
+For every skill in .agents/skills/, test whether the harness actually fires it
+under progressive disclosure. For each skill, compose an organic user request
+that a real user would type and that the skill's description claims to cover
+(e.g. for verify: "is my work actually done? run what's needed before I commit").
+Spawn one candidate per request in its own sanitized worktree (worktree: true).
+The candidate sees ONLY the organic request. Grade from its session transcript:
+did the agent load the skill file, and did it follow it — or did it freestyle?
+Sanitize: no eval vocabulary in any directory name, worktree name, or prompt.
+Name worktrees after project-shaped slugs a user might pick.
+
+PHASE 2 — PAIRED LIFT (top 8 skills by Phase-1 relevance, paired A/B)
+For each of the 8 highest-stakes skills (pick: plan, build, verify, quality-gate,
+debug, wrap-up-session, receive-review, tdd — adjust if Phase 1 shows others
+matter more), run the paired design:
+- Variant A: candidate runs with the skill present in .agents/skills/
+- Variant B: candidate runs in a worktree where that skill's directory is removed
+- Same organic prompt to both, one prompt per skill, composed per the blinding
+  non-negotiables: organic, no meta, no chain-eliciting, no eval terms anywhere
+  the candidate can see, candidates unaware of each other.
+- N=2 repetitions per variant per skill (32 candidate runs total). Do not exceed
+  this without asking me.
+- One judge per skill, model family different from the candidate tier (candidates
+  on qwen3-coder-next, judge on deepseek-v4-pro), single pass, one scale, sees
+  outputs by sanitized label only, never model or variant names. Two variants'
+  outputs must be interleaved in one judge prompt, not judged separately.
+- Write the rubric (3-6 concrete criteria) BEFORE spawning anyone. Hold it back
+  from candidates. Judge only.
+
+VERIFICATION
+Do not trust candidate self-report. Read each candidate's transcript under
+.pi/agent/sessions/: which files did it actually open, what commands did it
+actually run, what does the code shape look like. Grade chain-following from
+evidence. Then read every candidate output yourself end to end; note every
+place your read disagrees with the judge.
+
+REPORT
+tasks/evals/skill-report-<date>.md with, per skill:
+- triggerability verdict (fired / fired-but-ignored / never fired) with transcript evidence
+- lift table (A vs B pass rate, wall-clock, tokens) — report cost alongside lift
+- judge verdict vs your synthesis, including disagreements
+- one-line recommendation per skill: promote / keep / rewrite / delete
+End with: overall stats, total spend, skills that never fired at all (deletion
+candidates), and any rubric ambiguities you had to resolve mid-run.


### PR DESCRIPTION
## What

Adds `.agents/skills/eval/SKILL.md` — a blinded A/B evaluation playbook for skill, prompt, and workflow changes, ported from [poteto's pstack](https://github.com/cursor/plugins/tree/main/pstack) (`skills/poteto-mode/playbooks/eval.md`) and adapted from Cursor to pi's `pi-subagents` system.

## Why

We ship 25+ skills but have no standard way to measure whether a skill *edit* actually improves agent behavior. Research baseline ([SkillsBench](https://arxiv.org/abs/2602.12670), [Skill-Use](https://arxiv.org/html/2608.04828), [skill-eval-harness](https://github.com/adewale/skill-eval-harness)) converged on the same playbook pstack uses: paired variants, blinded candidates, single-pass judge, transcript-based chain verification.

## How it maps from pstack → pi

| pstack (Cursor) | this port (pi) |
|---|---|
| N parallel candidates in per-candidate dirs | `runs.all` via `pi-subagents` with managed worktree isolation |
| Judge on different model family | Reasoning tier (`deepseek-v4-pro`) vs build tier (`qwen3-coder-next`) candidates |
| Transcript verification in `agent-transcripts/` | Session transcripts under `.pi/agent/sessions/` |
| Rubric held back from candidates | Same |

## Blinding non-negotiables (kept from upstream)

- No eval-aware terms in anything the candidate sees
- Organic user-shaped prompt; no chain-eliciting cues
- Sanitized slugs/dirs; candidates unaware of each other
- Judge blinded to model names; **one judge, one pass, one scale**
- Chain-following graded from files actually read + code shape, never self-report

## Out of scope / follow-ups

- No runner tooling yet — this is the instruction playbook only. A `skill-eval-harness`-style CLI (paired runs, answer-key leakage detection, deterministic grading) is a candidate follow-up.
- Triggerability audit (Skill-Use style: do skill descriptions actually fire?) is a separate skill.

🤖 Draft — review before promoting.