### PR TITLE
fix(skills): resolve description collisions that misroute three skills

### DIFF
--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-gate
-description: "3-phase post-build quality review: structural quality (simplify), AI anti-patterns (deslop), APOSD design review. Run after all build tasks complete."
+description: "The post-build review gate: run when all tasks in tasks/todo.md are done, before wrap-up or commit. Three sequential phases — structural quality and reuse (simplify), AI anti-pattern cleanup (deslop), and APOSD design audit — emitting four-axis findings (severity, confidence, autofix_class, owner). Triggers on: 'review before I call it done', 'thorough review of what I just built', 'I finished the tasks, check the code', 'run the quality gate', 'post-build review'."
 argument-hint: "[--scope <path>]"
 ---
 

--- a/.agents/skills/refresh/SKILL.md
+++ b/.agents/skills/refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refresh
-description: Context reset — snapshot working state to disk, then hand off to a fresh context that rebuilds from the checkpoint. Backstop for very long tasks when context fills.
+description: "Context reset for a session running out of room: snapshot working state to disk, then continue the work in a fresh context rebuilt from that snapshot. Distinct from /checkpoint, which saves progress and stops — reach for /refresh when the work continues but the context must be recycled. Triggers on: 'this conversation is getting too long', 'you are losing track', 'start clean and keep going', 'context is full', 'reset and continue', or when /build's architectural circuit breaker trips."
 disable-model-invocation: false
 ---
 

--- a/.agents/skills/security-scan/SKILL.md
+++ b/.agents/skills/security-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-scan
-description: OWASP-focused security audit on recently changed files. Use after code changes to check for vulnerabilities.
+description: "OWASP-focused security audit scoped to the files changed in this session, worked through an explicit per-category checklist (input validation, authn/authz, secrets, crypto, dependencies, error handling). Use before committing or deploying changed code. Triggers on: 'security scan', 'check for vulnerabilities', 'any security issues in what I changed', 'is this safe to ship', 'OWASP audit'."
 disable-model-invocation: false
 harness: universal
 ---

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-gate
-description: "3-phase post-build quality review: structural quality (simplify), AI anti-patterns (deslop), APOSD design review. Run after all build tasks complete."
+description: "The post-build review gate: run when all tasks in tasks/todo.md are done, before wrap-up or commit. Three sequential phases — structural quality and reuse (simplify), AI anti-pattern cleanup (deslop), and APOSD design audit — emitting four-axis findings (severity, confidence, autofix_class, owner). Triggers on: 'review before I call it done', 'thorough review of what I just built', 'I finished the tasks, check the code', 'run the quality gate', 'post-build review'."
 argument-hint: "[--scope <path>]"
 ---
 

--- a/.claude/skills/refresh/SKILL.md
+++ b/.claude/skills/refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refresh
-description: Context reset — snapshot working state to disk, then hand off to a fresh context that rebuilds from the checkpoint. Backstop for very long tasks when context fills.
+description: "Context reset for a session running out of room: snapshot working state to disk, then continue the work in a fresh context rebuilt from that snapshot. Distinct from /checkpoint, which saves progress and stops — reach for /refresh when the work continues but the context must be recycled. Triggers on: 'this conversation is getting too long', 'you are losing track', 'start clean and keep going', 'context is full', 'reset and continue', or when /build's architectural circuit breaker trips."
 disable-model-invocation: false
 ---
 

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-scan
-description: OWASP-focused security audit on recently changed files. Use after code changes to check for vulnerabilities.
+description: "OWASP-focused security audit scoped to the files changed in this session, worked through an explicit per-category checklist (input validation, authn/authz, secrets, crypto, dependencies, error handling). Use before committing or deploying changed code. Triggers on: 'security scan', 'check for vulnerabilities', 'any security issues in what I changed', 'is this safe to ship', 'OWASP audit'."
 disable-model-invocation: false
 harness: universal
 ---


### PR DESCRIPTION
## What

Rewrites the `description:` frontmatter for three skills that a triggerability
audit found fire a **different, overlapping skill** instead of themselves:

| Skill | Was losing to | Now distinguished by |
|---|---|---|
| `security-scan` | built-in `security-review` | changed-file scope + explicit OWASP category checklist, pre-commit/pre-deploy moment |
| `quality-gate` | built-in `code-review` | pipeline position (all `tasks/todo.md` done, before wrap-up) + the four-axis Finding Model it emits |
| `refresh` | sibling `checkpoint` | the work **continues** in a new context, vs `checkpoint` which saves and stops |

One line changed per file, six files (both skill trees). No behavioral content touched.

## Why

All three lose for the same structural reason: the description leads with the
activity they *share* with the competing skill — "security audit of changed
files", "quality review", "snapshot for handoff" — and buries the condition that
makes them distinct. The router matches the shared vocabulary and picks the other
skill.

Each rewrite now (a) leads with the distinguishing condition and (b) carries an
explicit `Triggers on:` phrase list. That phrase-list pattern is the one signal
the audit found correlating with firing: both skills whose descriptions already
carry such a list (`html-presentation`, `software-design-expert-learn`) fired
correctly, versus 8 of 25 without one.

## Evidence

From an organic-prompt triggerability audit over all 27 skills in
`.agents/skills/` (one candidate per skill, isolated worktree, graded from
session transcripts rather than self-report — a genuine `Skill` tool_use block
with the matching `input.skill`, discarding incidental `SKILL.md` string matches):

- `refresh` probe called `Skill(skill:"checkpoint")`
- `security-scan` probe called `Skill(skill:"security-review")`
- `quality-gate` probe called `Skill(skill:"code-review")`

These three are the audit's most trustworthy results — the collisions are
verifiable by reading the descriptions side by side, independent of the run.

## Scope note

The same audit produced 14 "never fired" results, but **11 of those are invalid**
— the fixture was a clean, fully-committed tree with an all-`[x]` todo, so
precondition-gated skills (`build`, `tdd`, `verify`, `debug`, `receive-review`, …)
had no work to do and no reason to load. Those are deliberately **not** touched
here; they need a re-run against a fixture that satisfies their gates first. This
PR ships only what static evidence already supports.

## Testing

- Full suite green: **all 21 test files pass**
- Specifically covering these paths: `test-skill-frontmatter.sh` (224),
  `test-skill-parity.sh` (43), `test-refresh-skill.sh` (11),
  `test-doc-conventions.sh` (344) — 622 assertions
- `.agents/` ↔ `.claude/` byte-parity verified with `cmp` on all three pairs
- All three descriptions well under the 1024-char cap (393 / 471 / 492)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
