### PR TITLE
feat(skills): ship /eval as a runnable eval, not a playbook

### DIFF
--- a/.agents/skills/eval/SKILL.md
+++ b/.agents/skills/eval/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: eval
+description: "Blinded A/B evaluation of a skill, prompt, or workflow change before promoting it. Candidates run in sanitized worktrees on organic prompts and never learn they are being measured; grading comes from session transcripts, not self-report. Two runnable modes: triggerability (does the harness route to this skill at all) and variant lift (does variant A beat variant B). Use before merging a skill edit, when a skill seems never to fire, or when deciding whether a rewrite actually helped. Triggers on: 'does this skill even fire', 'A/B this prompt', 'did the rewrite improve anything', 'evaluate my skills', 'run an eval'."
+argument-hint: "[what changed] [vs what]"
+harness: universal
+---
+
+# /eval — Blinded Skill Evaluation
+
+## Overview
+
+An eval answers one question with evidence: **does this change alter agent
+behavior in the direction claimed?** The failure mode is the observer effect —
+an agent that knows it is being measured behaves differently — so candidates
+run blind on prompts that look like ordinary work.
+
+Adapted from poteto's [pstack](https://github.com/cursor/plugins/tree/main/pstack)
+`eval` playbook. The blinding rules are pstack's; the two modes below are what
+survives contact with a sub-agent harness that cannot ablate a skill.
+
+## The Iron Law
+
+```
+THE CANDIDATE NEVER KNOWS IT IS BEING EVALUATED
+```
+
+## Scope — read this before designing a run
+
+**Two things are measurable here, and one is not.** Designing a run against the
+third produces a number that looks like lift and means nothing.
+
+| Question | Mode | Status |
+|----------|------|--------|
+| Does the harness route to this skill from an organic prompt? | A — triggerability | runnable |
+| Does variant X of a skill outperform variant Y? | B — variant lift | runnable |
+| Does having the skill beat not having it? | presence/absence | **not available** |
+
+Presence/absence is unavailable because a skill cannot be removed from a
+candidate's reach: the roster is a spawn-time snapshot, and `install.sh` puts a
+copy of every skill in the user's global skills directory, so deleting the repo
+copy ablates nothing. Deleting the global copy would break every other project
+on that machine. If presence/absence lift is genuinely required, the only honest
+routes are a machine with no global install, or Mode B against a deliberately
+gutted variant — both stated as such, never reported as ablation.
+
+Say "not measurable here" and stop. A proxy that measures something else is
+worse than no number, because it gets quoted.
+
+## Blinding non-negotiables
+
+- No `eval`, `test`, `judge`, `experiment`, `rubric`, `score`, `compare`,
+  `benchmark`, `candidate`, or `arena` in any directory, worktree, file, or
+  prompt the candidate sees. Name worktrees after project-shaped slugs.
+- The candidate prompt is an organic user request. State the goal, not the meta.
+- No chain-eliciting cues. Never ask a candidate which skills or principles it
+  applied — that inflates citation and measures compliance theater. Grade from
+  the transcript.
+- Never tell the candidate other candidates exist.
+- The judge may know it is judging, but sees outputs by sanitized label only —
+  never a model name, never a variant name.
+- One judge scores both variants in **one pass on one scale**. Two judge runs
+  drift in calibration and their scores do not compare.
+- Write the rubric (3–6 concrete criteria) **before** spawning anyone, and hold
+  it back from candidates.
+
+## Preconditions belong in the prompt, not the repo
+
+Managed worktrees are cut from the remote default branch, so planted fixture
+state never reaches a candidate. A skill gated on open `tasks/todo.md` items, a
+failing test, or review comments therefore has nothing to fire on, and scores a
+false "never fired".
+
+Carry the precondition **in the prompt**: paste the failing test output, the
+plan, the reviewer's comments. A real user pastes exactly that, so the prompt
+stays organic and the fixture problem disappears. Never name a file the worktree
+does not contain — the candidate stops and asks, and the run is lost.
+
+## Mode A — triggerability
+
+Measures the real router, and is the cheapest useful eval in this repo.
+
+1. For each skill under test, write one organic prompt that its `description`
+   claims to cover, with any precondition pasted inline.
+2. Spawn one candidate per prompt per repetition, each in its own worktree.
+   **N >= 2** — a single miss is variance, not a verdict.
+3. Add a no-push clause to every prompt. Candidates can reach the real remote:
+   two separate runs shipped a live PR and a live branch before this was
+   guarded. For push-shaped asks, point `origin` at a throwaway bare repo.
+4. Grade with `scripts/grade-skill-loads.sh` (below). Three outcomes per run:
+   `FIRED`, `MISROUTED` (a different skill loaded — record which), `NONE`.
+5. A misroute is a **description defect**, not a candidate failure. Fix the
+   description; do not touch the prompt until the description has been read.
+
+`references/probe-recipe.md` carries the prompt recipe and a run skeleton.
+
+## Mode B — variant lift
+
+Both variants are present on disk; they differ in content, so nothing has to be
+removed. Use it for description rewrites and body rewrites alike.
+
+1. Put variant A and variant B on **two branches pushed to the remote**, or two
+   differently-named skills in one branch. Worktrees are cut from the remote
+   default branch, so an unpushed variant never reaches a candidate.
+2. Same organic prompt to both arms, N >= 2 per arm.
+3. Interleave both arms' outputs into **one** judge prompt under sanitized
+   labels. Judge on a stronger tier than the candidates (Ceiling judging
+   Builder); cross-vendor blinding is not available in-harness.
+4. Report cost beside lift. A variant that wins by 5% for 3x the tokens lost.
+
+## Grading — transcripts, not self-report
+
+```
+.agents/skills/eval/scripts/grade-skill-loads.sh <transcript-dir> [skill]
+```
+
+The transcript directory is the workflow's own, one `agent-<id>.jsonl` per
+candidate. The script counts genuine `Skill` tool-use blocks and nothing else.
+
+A bare string match on `SKILL.md` is not evidence of a load — a candidate's own
+test output prints those filenames. Citing a skill is not reading it, and
+reading it is not applying it: grade *following* from the shape of the work.
+
+Then read every candidate output end to end yourself and compare with the
+judge. Disagreement means the rubric is ambiguous or the judge is biased — fix
+the rubric and re-judge before trusting the result.
+
+## Reply format
+
+what is under test · mode · rubric · per-run grades with transcript evidence ·
+judge verdict · your synthesis including every disagreement · cost · one
+recommendation (promote / keep / rewrite / delete / not measurable here).
+
+## Anti-patterns
+
+| Smell | Why it fails |
+|-------|--------------|
+| Asking the candidate to delete the skill as the ablation | Not an ablation. A capable candidate checks, finds the directory tracked and referenced, and refuses — so the skill stays present and the run measures nothing. It also trips safety classifiers. |
+| Reporting presence/absence lift where a global install exists | The global copy still routes. The number is noise wearing a label. |
+| Naming a fixture file the worktree cannot have | The candidate stops and asks. Scored as "never fired", it is a broken fixture. |
+| Grading "never fired" without satisfying the skill's own precondition | Same defect, cheaper to miss: no open task, no failing test, no review comments means nothing to fire on. |
+| Telling the candidate its remote is safe to push to | It will verify. If `origin` can reach the real host, treat a push as inevitable and neuter the remote yourself. |
+| Judging variants in separate judge runs | Calibration drift; the scores are not comparable. |
+| Asking candidates which skills they used | Inflates citation, measures theater. |
+| One run, one verdict | Single-run variance routinely exceeds real lift. |
+| Comparing a full sweep against a subset chosen for having failed | Selection bias — the subset was selected on the outcome, so the difference proves nothing. |
+| Eval-aware directory names | Blinding dies the moment the candidate looks around. |

--- a/.agents/skills/eval/references/probe-recipe.md
+++ b/.agents/skills/eval/references/probe-recipe.md
@@ -1,0 +1,92 @@
+# Probe recipe — Mode A prompts and run skeleton
+
+Reference for `/eval` Mode A (triggerability). The rules it implements are in
+`SKILL.md`; this file is the shape they take in practice.
+
+## Prompt template
+
+Four parts, in this order. Anything else is leakage.
+
+1. **The precondition, pasted.** Failing test output, the plan, the reviewer's
+   comments, the error. Never a path the worktree does not contain.
+2. **The ask, as a user would type it.** One or two sentences. No meta.
+3. **The scope limit**, if the skill would otherwise sprawl.
+4. **The no-push clause**, verbatim:
+
+   > Just do the work locally — don't push anything or open a PR, I'll handle
+   > that myself.
+
+Worked example, for a skill gated on a failing test:
+
+> tests/test-util-slug.sh is failing and I can't work out why:
+>
+> ```
+>   ok   slugify replaces spaces
+>   FAIL slugify collapses repeated separators -- want "a-b" got "a--b"
+>   -> 1 failure(s)
+> ```
+>
+> The function is:
+>
+> ```
+>   slugify() { printf '%s\n' "$1" | tr -c 'A-Za-z0-9\n' '-'; }
+> ```
+>
+> Can you dig in and fix it properly?
+>
+> Just do the work locally — don't push anything or open a PR, I'll handle that
+> myself.
+
+Note what the example does **not** contain: the skill's name, the word
+"process", any request to explain which guidance was followed, and any file the
+candidate would have to be told about.
+
+## Prompt smells
+
+| Smell | Fix |
+|-------|-----|
+| Names a file only this repo's working tree has | Paste the content instead |
+| "follow the usual process" | Delete it — that cue is what is being measured |
+| "explain which skills you used" | Delete it; grade from the transcript |
+| Push-shaped ("open a PR", "ship it") | Add the no-push clause, or neuter `origin` |
+| Slug like `probe-1`, `run-a` | Rename to something a user would pick |
+
+## Run skeleton
+
+One worktree per candidate, N >= 2, everything in one fan-out so the reps of a
+slow skill do not serialize behind a fast one.
+
+```js
+const PROBES = [
+  { skill: 'debug', prompt: '...pasted failing output... Can you dig in?' + NO_PUSH },
+  { skill: 'verify', prompt: '...I changed X. Is this done?' + NO_PUSH },
+]
+const REPS = 2
+
+const runs = await parallel(
+  PROBES.flatMap(p =>
+    Array.from({ length: REPS }, (_, i) => () =>
+      agent(p.prompt, { label: `${p.skill}-r${i + 1}`, isolation: 'worktree' })
+        .then(output => ({ skill: p.skill, rep: i + 1, output }))
+    )
+  )
+)
+```
+
+Labels are orchestrator-side only — a candidate never sees its own label, so
+`debug-r1` does not break blinding. Directory and worktree names do reach the
+candidate, and must stay project-shaped.
+
+## After the run
+
+1. Grade each probe against **its own** target skill:
+
+   ```
+   .agents/skills/eval/scripts/grade-skill-loads.sh <transcript-dir> debug
+   ```
+
+2. Read the outputs. A `NONE` that did good work by hand is a different finding
+   from a `NONE` that stalled asking for a missing file — the second is a broken
+   prompt, and its result is discarded, not reported.
+3. For every `MISROUTED`, diff the two descriptions before touching anything
+   else. The routed-to skill usually claims the ask more concretely.

--- a/.agents/skills/eval/scripts/grade-skill-loads.sh
+++ b/.agents/skills/eval/scripts/grade-skill-loads.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# grade-skill-loads.sh — which skills did each candidate actually load?
+#
+# Grades a triggerability run from the transcripts rather than from what the
+# candidates said they did. A candidate that mentions a skill, prints a
+# SKILL.md path, or claims to have followed a process has not necessarily
+# loaded anything; the only evidence that survives is a Skill tool-use block.
+#
+# Usage:
+#   grade-skill-loads.sh <transcript-dir>          list loads per candidate
+#   grade-skill-loads.sh <transcript-dir> <skill>  grade against one skill
+#
+# <transcript-dir> is the workflow's own directory, holding one
+# agent-<id>.jsonl per candidate.
+#
+# Exit: 0 measured, 2 nothing to measure (bad path, no transcripts, or a
+# transcript this parser cannot read). Never 0 on a failed measurement — a
+# silent zero reads as "the skill never fired".
+
+set -euo pipefail
+
+die() { printf 'grade-skill-loads: %s\n' "$1" >&2; exit 2; }
+
+DIR="${1:-}"
+[ -n "$DIR" ] || die "usage: grade-skill-loads.sh <transcript-dir> [skill]"
+[ -d "$DIR" ] || die "no such directory: $DIR"
+WANT="${2:-}"
+
+# Grounded in the observed transcript shape:
+#   "name":"Skill","input":{"skill":"plan","args":"..."}
+# A load is counted only from a real tool-use block. Anything looser matches a
+# candidate's own console output and inflates every result.
+BLOCK='"name":[[:space:]]*"Skill"'
+
+loads_in() {
+  grep -oE "$BLOCK,[[:space:]]*\"input\":\{[[:space:]]*\"skill\":[[:space:]]*\"[^\"]+\"" "$1" 2>/dev/null \
+    | sed 's/.*"skill":[[:space:]]*"//; s/"$//' | sort -u | paste -sd, - || true
+}
+
+fired=0; misrouted=0; none=0; total=0
+
+for f in "$DIR"/agent-*.jsonl; do
+  [ -e "$f" ] || die "no agent-*.jsonl transcripts in $DIR"
+  total=$((total + 1))
+  id="$(basename "$f" .jsonl)"
+  got="$(loads_in "$f")"
+
+  # A transcript that holds a Skill block the extractor could not read means the
+  # transcript format moved. Reporting "NONE" there would be a false negative,
+  # which is the exact error this script exists to prevent.
+  if [ -z "$got" ] && grep -qE "$BLOCK" "$f"; then
+    die "$id holds a Skill block this parser cannot read — transcript format changed"
+  fi
+
+  if [ -z "$WANT" ]; then
+    printf '%s  %s\n' "$id" "${got:--}"
+    continue
+  fi
+
+  case ",$got," in
+    *",$WANT,"*) verdict=FIRED;     fired=$((fired + 1)) ;;
+    ,,)          verdict=NONE;      none=$((none + 1)) ;;
+    *)           verdict=MISROUTED; misrouted=$((misrouted + 1)) ;;
+  esac
+  printf '%-10s %s  loaded: %s\n' "$verdict" "$id" "${got:--}"
+done
+
+[ -n "$WANT" ] || exit 0
+printf -- '-> %s: %d/%d FIRED, %d MISROUTED, %d NONE\n' \
+  "$WANT" "$fired" "$total" "$misrouted" "$none"

--- a/.claude/skills/eval/SKILL.md
+++ b/.claude/skills/eval/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: eval
+description: "Blinded A/B evaluation of a skill, prompt, or workflow change before promoting it. Candidates run in sanitized worktrees on organic prompts and never learn they are being measured; grading comes from session transcripts, not self-report. Two runnable modes: triggerability (does the harness route to this skill at all) and variant lift (does variant A beat variant B). Use before merging a skill edit, when a skill seems never to fire, or when deciding whether a rewrite actually helped. Triggers on: 'does this skill even fire', 'A/B this prompt', 'did the rewrite improve anything', 'evaluate my skills', 'run an eval'."
+argument-hint: "[what changed] [vs what]"
+harness: universal
+---
+
+# /eval — Blinded Skill Evaluation
+
+## Overview
+
+An eval answers one question with evidence: **does this change alter agent
+behavior in the direction claimed?** The failure mode is the observer effect —
+an agent that knows it is being measured behaves differently — so candidates
+run blind on prompts that look like ordinary work.
+
+Adapted from poteto's [pstack](https://github.com/cursor/plugins/tree/main/pstack)
+`eval` playbook. The blinding rules are pstack's; the two modes below are what
+survives contact with a sub-agent harness that cannot ablate a skill.
+
+## The Iron Law
+
+```
+THE CANDIDATE NEVER KNOWS IT IS BEING EVALUATED
+```
+
+## Scope — read this before designing a run
+
+**Two things are measurable here, and one is not.** Designing a run against the
+third produces a number that looks like lift and means nothing.
+
+| Question | Mode | Status |
+|----------|------|--------|
+| Does the harness route to this skill from an organic prompt? | A — triggerability | runnable |
+| Does variant X of a skill outperform variant Y? | B — variant lift | runnable |
+| Does having the skill beat not having it? | presence/absence | **not available** |
+
+Presence/absence is unavailable because a skill cannot be removed from a
+candidate's reach: the roster is a spawn-time snapshot, and `install.sh` puts a
+copy of every skill in the user's global skills directory, so deleting the repo
+copy ablates nothing. Deleting the global copy would break every other project
+on that machine. If presence/absence lift is genuinely required, the only honest
+routes are a machine with no global install, or Mode B against a deliberately
+gutted variant — both stated as such, never reported as ablation.
+
+Say "not measurable here" and stop. A proxy that measures something else is
+worse than no number, because it gets quoted.
+
+## Blinding non-negotiables
+
+- No `eval`, `test`, `judge`, `experiment`, `rubric`, `score`, `compare`,
+  `benchmark`, `candidate`, or `arena` in any directory, worktree, file, or
+  prompt the candidate sees. Name worktrees after project-shaped slugs.
+- The candidate prompt is an organic user request. State the goal, not the meta.
+- No chain-eliciting cues. Never ask a candidate which skills or principles it
+  applied — that inflates citation and measures compliance theater. Grade from
+  the transcript.
+- Never tell the candidate other candidates exist.
+- The judge may know it is judging, but sees outputs by sanitized label only —
+  never a model name, never a variant name.
+- One judge scores both variants in **one pass on one scale**. Two judge runs
+  drift in calibration and their scores do not compare.
+- Write the rubric (3–6 concrete criteria) **before** spawning anyone, and hold
+  it back from candidates.
+
+## Preconditions belong in the prompt, not the repo
+
+Managed worktrees are cut from the remote default branch, so planted fixture
+state never reaches a candidate. A skill gated on open `tasks/todo.md` items, a
+failing test, or review comments therefore has nothing to fire on, and scores a
+false "never fired".
+
+Carry the precondition **in the prompt**: paste the failing test output, the
+plan, the reviewer's comments. A real user pastes exactly that, so the prompt
+stays organic and the fixture problem disappears. Never name a file the worktree
+does not contain — the candidate stops and asks, and the run is lost.
+
+## Mode A — triggerability
+
+Measures the real router, and is the cheapest useful eval in this repo.
+
+1. For each skill under test, write one organic prompt that its `description`
+   claims to cover, with any precondition pasted inline.
+2. Spawn one candidate per prompt per repetition, each in its own worktree.
+   **N >= 2** — a single miss is variance, not a verdict.
+3. Add a no-push clause to every prompt. Candidates can reach the real remote:
+   two separate runs shipped a live PR and a live branch before this was
+   guarded. For push-shaped asks, point `origin` at a throwaway bare repo.
+4. Grade with `scripts/grade-skill-loads.sh` (below). Three outcomes per run:
+   `FIRED`, `MISROUTED` (a different skill loaded — record which), `NONE`.
+5. A misroute is a **description defect**, not a candidate failure. Fix the
+   description; do not touch the prompt until the description has been read.
+
+`references/probe-recipe.md` carries the prompt recipe and a run skeleton.
+
+## Mode B — variant lift
+
+Both variants are present on disk; they differ in content, so nothing has to be
+removed. Use it for description rewrites and body rewrites alike.
+
+1. Put variant A and variant B on **two branches pushed to the remote**, or two
+   differently-named skills in one branch. Worktrees are cut from the remote
+   default branch, so an unpushed variant never reaches a candidate.
+2. Same organic prompt to both arms, N >= 2 per arm.
+3. Interleave both arms' outputs into **one** judge prompt under sanitized
+   labels. Judge on a stronger tier than the candidates (Ceiling judging
+   Builder); cross-vendor blinding is not available in-harness.
+4. Report cost beside lift. A variant that wins by 5% for 3x the tokens lost.
+
+## Grading — transcripts, not self-report
+
+```
+.agents/skills/eval/scripts/grade-skill-loads.sh <transcript-dir> [skill]
+```
+
+The transcript directory is the workflow's own, one `agent-<id>.jsonl` per
+candidate. The script counts genuine `Skill` tool-use blocks and nothing else.
+
+A bare string match on `SKILL.md` is not evidence of a load — a candidate's own
+test output prints those filenames. Citing a skill is not reading it, and
+reading it is not applying it: grade *following* from the shape of the work.
+
+Then read every candidate output end to end yourself and compare with the
+judge. Disagreement means the rubric is ambiguous or the judge is biased — fix
+the rubric and re-judge before trusting the result.
+
+## Reply format
+
+what is under test · mode · rubric · per-run grades with transcript evidence ·
+judge verdict · your synthesis including every disagreement · cost · one
+recommendation (promote / keep / rewrite / delete / not measurable here).
+
+## Anti-patterns
+
+| Smell | Why it fails |
+|-------|--------------|
+| Asking the candidate to delete the skill as the ablation | Not an ablation. A capable candidate checks, finds the directory tracked and referenced, and refuses — so the skill stays present and the run measures nothing. It also trips safety classifiers. |
+| Reporting presence/absence lift where a global install exists | The global copy still routes. The number is noise wearing a label. |
+| Naming a fixture file the worktree cannot have | The candidate stops and asks. Scored as "never fired", it is a broken fixture. |
+| Grading "never fired" without satisfying the skill's own precondition | Same defect, cheaper to miss: no open task, no failing test, no review comments means nothing to fire on. |
+| Telling the candidate its remote is safe to push to | It will verify. If `origin` can reach the real host, treat a push as inevitable and neuter the remote yourself. |
+| Judging variants in separate judge runs | Calibration drift; the scores are not comparable. |
+| Asking candidates which skills they used | Inflates citation, measures theater. |
+| One run, one verdict | Single-run variance routinely exceeds real lift. |
+| Comparing a full sweep against a subset chosen for having failed | Selection bias — the subset was selected on the outcome, so the difference proves nothing. |
+| Eval-aware directory names | Blinding dies the moment the candidate looks around. |

--- a/.claude/skills/eval/references/probe-recipe.md
+++ b/.claude/skills/eval/references/probe-recipe.md
@@ -1,0 +1,92 @@
+# Probe recipe — Mode A prompts and run skeleton
+
+Reference for `/eval` Mode A (triggerability). The rules it implements are in
+`SKILL.md`; this file is the shape they take in practice.
+
+## Prompt template
+
+Four parts, in this order. Anything else is leakage.
+
+1. **The precondition, pasted.** Failing test output, the plan, the reviewer's
+   comments, the error. Never a path the worktree does not contain.
+2. **The ask, as a user would type it.** One or two sentences. No meta.
+3. **The scope limit**, if the skill would otherwise sprawl.
+4. **The no-push clause**, verbatim:
+
+   > Just do the work locally — don't push anything or open a PR, I'll handle
+   > that myself.
+
+Worked example, for a skill gated on a failing test:
+
+> tests/test-util-slug.sh is failing and I can't work out why:
+>
+> ```
+>   ok   slugify replaces spaces
+>   FAIL slugify collapses repeated separators -- want "a-b" got "a--b"
+>   -> 1 failure(s)
+> ```
+>
+> The function is:
+>
+> ```
+>   slugify() { printf '%s\n' "$1" | tr -c 'A-Za-z0-9\n' '-'; }
+> ```
+>
+> Can you dig in and fix it properly?
+>
+> Just do the work locally — don't push anything or open a PR, I'll handle that
+> myself.
+
+Note what the example does **not** contain: the skill's name, the word
+"process", any request to explain which guidance was followed, and any file the
+candidate would have to be told about.
+
+## Prompt smells
+
+| Smell | Fix |
+|-------|-----|
+| Names a file only this repo's working tree has | Paste the content instead |
+| "follow the usual process" | Delete it — that cue is what is being measured |
+| "explain which skills you used" | Delete it; grade from the transcript |
+| Push-shaped ("open a PR", "ship it") | Add the no-push clause, or neuter `origin` |
+| Slug like `probe-1`, `run-a` | Rename to something a user would pick |
+
+## Run skeleton
+
+One worktree per candidate, N >= 2, everything in one fan-out so the reps of a
+slow skill do not serialize behind a fast one.
+
+```js
+const PROBES = [
+  { skill: 'debug', prompt: '...pasted failing output... Can you dig in?' + NO_PUSH },
+  { skill: 'verify', prompt: '...I changed X. Is this done?' + NO_PUSH },
+]
+const REPS = 2
+
+const runs = await parallel(
+  PROBES.flatMap(p =>
+    Array.from({ length: REPS }, (_, i) => () =>
+      agent(p.prompt, { label: `${p.skill}-r${i + 1}`, isolation: 'worktree' })
+        .then(output => ({ skill: p.skill, rep: i + 1, output }))
+    )
+  )
+)
+```
+
+Labels are orchestrator-side only — a candidate never sees its own label, so
+`debug-r1` does not break blinding. Directory and worktree names do reach the
+candidate, and must stay project-shaped.
+
+## After the run
+
+1. Grade each probe against **its own** target skill:
+
+   ```
+   .agents/skills/eval/scripts/grade-skill-loads.sh <transcript-dir> debug
+   ```
+
+2. Read the outputs. A `NONE` that did good work by hand is a different finding
+   from a `NONE` that stalled asking for a missing file — the second is a broken
+   prompt, and its result is discarded, not reported.
+3. For every `MISROUTED`, diff the two descriptions before touching anything
+   else. The routed-to skill usually claims the ask more concretely.

--- a/.claude/skills/eval/scripts/grade-skill-loads.sh
+++ b/.claude/skills/eval/scripts/grade-skill-loads.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# grade-skill-loads.sh — which skills did each candidate actually load?
+#
+# Grades a triggerability run from the transcripts rather than from what the
+# candidates said they did. A candidate that mentions a skill, prints a
+# SKILL.md path, or claims to have followed a process has not necessarily
+# loaded anything; the only evidence that survives is a Skill tool-use block.
+#
+# Usage:
+#   grade-skill-loads.sh <transcript-dir>          list loads per candidate
+#   grade-skill-loads.sh <transcript-dir> <skill>  grade against one skill
+#
+# <transcript-dir> is the workflow's own directory, holding one
+# agent-<id>.jsonl per candidate.
+#
+# Exit: 0 measured, 2 nothing to measure (bad path, no transcripts, or a
+# transcript this parser cannot read). Never 0 on a failed measurement — a
+# silent zero reads as "the skill never fired".
+
+set -euo pipefail
+
+die() { printf 'grade-skill-loads: %s\n' "$1" >&2; exit 2; }
+
+DIR="${1:-}"
+[ -n "$DIR" ] || die "usage: grade-skill-loads.sh <transcript-dir> [skill]"
+[ -d "$DIR" ] || die "no such directory: $DIR"
+WANT="${2:-}"
+
+# Grounded in the observed transcript shape:
+#   "name":"Skill","input":{"skill":"plan","args":"..."}
+# A load is counted only from a real tool-use block. Anything looser matches a
+# candidate's own console output and inflates every result.
+BLOCK='"name":[[:space:]]*"Skill"'
+
+loads_in() {
+  grep -oE "$BLOCK,[[:space:]]*\"input\":\{[[:space:]]*\"skill\":[[:space:]]*\"[^\"]+\"" "$1" 2>/dev/null \
+    | sed 's/.*"skill":[[:space:]]*"//; s/"$//' | sort -u | paste -sd, - || true
+}
+
+fired=0; misrouted=0; none=0; total=0
+
+for f in "$DIR"/agent-*.jsonl; do
+  [ -e "$f" ] || die "no agent-*.jsonl transcripts in $DIR"
+  total=$((total + 1))
+  id="$(basename "$f" .jsonl)"
+  got="$(loads_in "$f")"
+
+  # A transcript that holds a Skill block the extractor could not read means the
+  # transcript format moved. Reporting "NONE" there would be a false negative,
+  # which is the exact error this script exists to prevent.
+  if [ -z "$got" ] && grep -qE "$BLOCK" "$f"; then
+    die "$id holds a Skill block this parser cannot read — transcript format changed"
+  fi
+
+  if [ -z "$WANT" ]; then
+    printf '%s  %s\n' "$id" "${got:--}"
+    continue
+  fi
+
+  case ",$got," in
+    *",$WANT,"*) verdict=FIRED;     fired=$((fired + 1)) ;;
+    ,,)          verdict=NONE;      none=$((none + 1)) ;;
+    *)           verdict=MISROUTED; misrouted=$((misrouted + 1)) ;;
+  esac
+  printf '%-10s %s  loaded: %s\n' "$verdict" "$id" "${got:--}"
+done
+
+[ -n "$WANT" ] || exit 0
+printf -- '-> %s: %d/%d FIRED, %d MISROUTED, %d NONE\n' \
+  "$WANT" "$fired" "$total" "$misrouted" "$none"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,6 +426,7 @@ Rules:
 | `/start-qa` | Restart app + health check + browser with log monitoring |
 | `/wrap-up-session` | Learnings, tests, reviews, commit, push |
 | `/writing-skills` | Author new skills with proper structure |
+| `/eval` | Blinded A/B eval of a skill or prompt change before promoting it |
 | `/sync` | Pull latest skills, hooks, agents from template repo |
 | `/folder-context-optimization` | Sweep folder for legacy/unused files |
 | `/graphify` | Build a navigable code knowledge graph (clustered communities, HTML + JSON + report) |

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Invoke with `/skill-name` in any Claude Code session:
 | `/start-qa` | Discover project config, restart app, launch browser, background smoke tests |
 | `/wrap-up-session` | Parallel code review → verify → merge worktree → sync learnings → run tests → push |
 | `/writing-skills` | Author new skills with proper structure, iron laws, and reference docs |
+| `/eval` | Blinded A/B eval of a skill, prompt, or workflow change: sanitized worktrees, organic prompts, transcript-based grading |
 | `/sync` | Pull latest skills, hooks, agents from template repo into current project |
 | `/folder-context-optimization` | Sweep a folder for legacy/unused files, propose archival |
 

--- a/tests/test-eval-skill.sh
+++ b/tests/test-eval-skill.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# tests/test-eval-skill.sh — /eval ships runnable, and its grader cannot lie.
+#
+# WHY THIS EXISTS
+#
+# /eval was authored twice and deployed neither time. The first attempt shipped
+# the canonical copy without the `.claude/` copy, so the skill Claude Code
+# actually reads did not exist and the parity guard went red; the follow-up
+# stacked a fix on top of the broken branch instead of replacing it. Prose about
+# how to run an eval is not an eval that runs.
+#
+# Two classes of invariant, matching the two ways this skill dies:
+#
+#   1. DISTRIBUTION — both trees carry SKILL.md, the grader, and the recipe, and
+#      the grader is tracked executable. A skill whose script did not ship is
+#      what `test-syncable-paths.sh` was written for; this pins the same property
+#      for the one asset /eval executes.
+#
+#   2. GRADER HONESTY — the grader's whole job is refusing to count a load that
+#      did not happen. The eval that motivated this skill mis-scored 11 of 14
+#      skills as "never fired", so the failure mode is not hypothetical: a
+#      grader that says NONE when it cannot read the transcript, or FIRED
+#      because the candidate printed a filename, produces confident garbage.
+#      Every case below is a way that grader could be wrong and stay silent.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+GRADER_REL=".agents/skills/eval/scripts/grade-skill-loads.sh"
+
+# --- 1. distribution --------------------------------------------------------
+for tree in .agents .claude; do
+  assert_eq "present" "$([ -f "$tree/skills/eval/SKILL.md" ] && echo present || echo missing)" \
+    "$tree/skills/eval/SKILL.md exists"
+  assert_eq "present" "$([ -f "$tree/skills/eval/references/probe-recipe.md" ] && echo present || echo missing)" \
+    "$tree/skills/eval: probe recipe ships"
+  # Two independent failures. Mode is read from the git index, not the
+  # filesystem — Windows checkouts do not carry the executable bit and would
+  # fail for an unrelated reason — but an index-only check passes on a tree
+  # where the script itself was deleted, so on-disk presence is asserted too.
+  assert_eq "present" "$([ -f "$tree/skills/eval/scripts/grade-skill-loads.sh" ] && echo present || echo missing)" \
+    "$tree/skills/eval: grader is on disk"
+  assert_eq "100755" "$(git ls-files -s "$tree/skills/eval/scripts/grade-skill-loads.sh" | awk '{print $1}')" \
+    "$tree/skills/eval: grader is tracked executable"
+done
+
+# --- 2. doc invariants ------------------------------------------------------
+# The scope table is the one section a future editor is most likely to "helpfully"
+# complete by re-adding presence/absence as a third mode. It is not measurable
+# where a global install exists, and a run designed against it reports noise.
+for tree in .agents .claude; do
+  md="$tree/skills/eval/SKILL.md"
+  assert_file_contains "$md" "THE CANDIDATE NEVER KNOWS IT IS BEING EVALUATED" \
+    "$md: the Iron Law survives"
+  assert_file_contains "$md" "presence/absence" \
+    "$md: names the unavailable mode instead of omitting it"
+  assert_prose_contains "$md" "the roster is a spawn-time snapshot" \
+    "$md: states why ablation cannot work here"
+  assert_prose_contains "$md" "Carry the precondition **in the prompt**" \
+    "$md: fixture state goes in the prompt, not the repo"
+  assert_file_contains "$md" "scripts/grade-skill-loads.sh" \
+    "$md: grading routes through the grader"
+  assert_prose_contains "$tree/skills/eval/references/probe-recipe.md" \
+    "don't push anything or open a PR" \
+    "$tree/skills/eval: recipe carries the no-push clause"
+done
+
+# --- 3. grader honesty ------------------------------------------------------
+TMP="$(mktemp -d)"
+[ -n "$TMP" ] && [ -d "$TMP" ] || { printf '  FAIL could not create fixture dir\n'; exit 1; }
+trap 'rm -rf "$TMP"' EXIT
+
+# A genuine load: the tool-use shape observed in real transcripts.
+printf '%s\n' '{"type":"assistant","content":[{"type":"tool_use","name":"Skill","input":{"skill":"debug"}}]}' \
+  > "$TMP/agent-aaa.jsonl"
+
+# The false positive this grader exists to refuse: the candidate talks about the
+# skill and prints its path, and loads nothing.
+{
+  printf '%s\n' '{"type":"text","text":"I will follow the debug process in .agents/skills/debug/SKILL.md"}'
+  printf '%s\n' '{"type":"text","text":"ok tests/test-debug.sh -- printed SKILL.md again"}'
+} > "$TMP/agent-bbb.jsonl"
+
+# A misroute: something loaded, but not the skill under test.
+printf '%s\n' '{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"verify","args":"x"}}]}' \
+  > "$TMP/agent-ccc.jsonl"
+
+out="$(bash "$GRADER_REL" "$TMP" debug)"; rc=$?
+assert_eq "0" "$rc" "grader: exits 0 on a readable run"
+assert_contains "$out" "FIRED      agent-aaa" "grader: counts a real Skill tool-use block"
+assert_contains "$out" "NONE       agent-bbb" "grader: prose naming a SKILL.md path is not a load"
+assert_contains "$out" "MISROUTED  agent-ccc" "grader: a different skill loaded reads as MISROUTED"
+assert_contains "$out" "loaded: verify" "grader: names what was loaded instead of the target"
+assert_contains "$out" "-> debug: 1/3 FIRED, 1 MISROUTED, 1 NONE" "grader: summary counts every run"
+
+# Listing mode: no target skill, so every load is reported and nothing is graded.
+listing="$(bash "$GRADER_REL" "$TMP")"
+assert_contains "$listing" "agent-aaa  debug" "grader: listing mode reports loads per candidate"
+assert_contains "$listing" "agent-bbb  -" "grader: listing mode marks an empty candidate"
+assert_not_contains "$listing" "FIRED" "grader: listing mode does not grade"
+
+# --- the three ways a silent zero could be reported as a result -------------
+bash "$GRADER_REL" "$TMP/nope" debug >/dev/null 2>&1
+assert_eq "2" "$?" "grader: a bad transcript path is an error, not zero loads"
+
+EMPTY="$TMP/empty"; mkdir -p "$EMPTY"
+bash "$GRADER_REL" "$EMPTY" debug >/dev/null 2>&1
+assert_eq "2" "$?" "grader: a directory with no transcripts is an error, not zero loads"
+
+# Transcript format drift: a Skill block the extractor cannot parse must be
+# loud. Reporting NONE here is the false negative that scored 11 skills wrong.
+MOVED="$TMP/moved"; mkdir -p "$MOVED"
+printf '%s\n' '{"content":[{"name":"Skill","parameters":{"skillName":"debug"}}]}' \
+  > "$MOVED/agent-ddd.jsonl"
+err="$(bash "$GRADER_REL" "$MOVED" debug 2>&1)"; rc=$?
+assert_eq "2" "$rc" "grader: an unreadable Skill block is an error, not NONE"
+assert_contains "$err" "transcript format changed" "grader: says what broke"
+
+assert_eq "" "$(bash -n "$GRADER_REL" 2>&1)" "grader: parses under bash -n"
+
+finish


### PR DESCRIPTION
Replaces #70 and #73. Both are closed by this PR — #70 shipped only the canonical
copy, so the skill Claude Code actually reads did not exist and its CI is red;
#73 stacked the missing copy on top of that broken branch. Neither ever deployed
a working `/eval`, and both described a paired design that cannot run here.

## What was wrong with the ported design

The pstack playbook's core measurement is presence-vs-absence lift: run a
candidate with the skill, run one without, compare. Three measured facts say
that cannot happen on this harness.

- **The skill roster is a spawn-time snapshot.** Deleting a skill directory
  during a candidate's run does not remove it from that candidate's roster.
- **`install.sh` copies every skill into the user's global skills directory.**
  Removing the repo copy ablates nothing; the global copy still routes.
  Removing the global copy breaks every other project on that machine.
- **Managed worktrees are cut from the remote default branch**, so neither an
  ablation branch nor planted fixture state reaches a candidate.

An earlier attempt to run it anyway asked candidates to delete the skill
themselves. They checked `git log`, found the directory tracked and referenced,
and refused — correctly. The run measured nothing.

## What this ships instead

**Honest scope.** Presence/absence is listed as **not available**, with the
reason, in the skill itself. Two modes remain, and both run: triggerability
(does the harness route here from an organic prompt) and variant-vs-variant
(does rewrite A beat rewrite B, both present). Saying "not measurable here" is
the correct output; a proxy that measures something else is worse than no
number, because it gets quoted.

**Preconditions move into the prompt.** Since fixture state cannot reach a
worktree, a skill gated on open `tasks/todo.md` items or a failing test has
nothing to fire on and scores a false "never fired" — this is what invalidated
11 of 14 negatives in the last run. The recipe carries the precondition inline
(paste the failing output, the plan, the review comments), which is what a real
user does anyway.

**Grading is executable, not prose.** `scripts/grade-skill-loads.sh` reads the
transcripts and counts only genuine `Skill` tool-use blocks, so a candidate that
prints a `SKILL.md` path is not scored as having loaded anything. It exits 2
rather than reporting zero loads when it cannot measure — bad path, no
transcripts, or a transcript shape it cannot parse. A silent zero reads as
"never fired", which is exactly the error that produced the bad grades.

Verified against 27 real candidate transcripts from that run: 1 FIRED,
12 MISROUTED, 14 NONE against the target skill — matching the hand grading.

## Also carried forward

Two safety findings, written into the anti-patterns table because both cost real
cleanup: candidates in worktrees can reach the live remote (one run opened a real
PR, another pushed a real branch), and comparing a full sweep against a subset
selected for having already failed is selection bias, not evidence.

## Tests

`tests/test-eval-skill.sh`, 34 assertions, auto-discovered by `tests/run.sh`:
distribution (both trees, grader present on disk **and** tracked executable) and
grader honesty (prose is not a load, misroute is distinguished from silence, and
each of the three unmeasurable states exits 2).

Mutation-verified — each of these fails the suite: removing the format-drift
guard, deleting the grader from disk, dropping it from the index only, and
loosening the load pattern to match prose. Full suite green (23 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
