### PR TITLE
feat(verify): integrate pstack verification skills

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -176,6 +176,22 @@ If mismatches found: send feedback to the implementing agent for fixes, then re-
 - Move to the next `[ ]` task immediately (no user prompt)
 - If a task is blocked by a previous failure, note it and skip to the next unblocked task
 
+## Phase 1.5 — Changed Verification Map
+
+After all tasks are `[x]`, classify the completed work. If ANY acceptance
+criterion is `user-facing`:
+
+1. Invoke `/maintain-verification-skill --scope changed` with the session intent,
+   base-to-HEAD diff, touched specs, and completed task entries. This idempotently
+   reconciles the project-local feature map on the active branch.
+2. If no project-local verification skill exists, skip maintenance, recommend
+   `/create-verification-skill`, and never generate or launch it automatically.
+3. Handle the maintainer outcome: `clean` and `changed` continue; `blocked` STOPS
+   the build and reports the maintainer's evidence.
+
+Internal-only changes skip changed-scope maintenance silently. This phase runs
+before the full suite and quality gate so any map edits receive both checks.
+
 ## Phase 2 — Full Suite Validation
 
 After all tasks are `[x]`:
@@ -210,7 +226,9 @@ previous_failures: []
 | `integration` | Integration test passes (real API/DB/service interaction) |
 | `user-facing` | E2E walkthrough via `/verify --scope e2e` — entry in `tasks/e2e-log.md` for current commit short-sha |
 
-If ANY AC is classified `user-facing`, invoke `/verify --scope e2e` before declaring Phase 4 complete.
+If ANY AC is classified `user-facing`:
+
+1. Invoke `/verify --scope e2e` before declaring Phase 4 complete.
 
 **For each round**:
 

--- a/.agents/skills/create-verification-skill/LICENSE.pstack
+++ b/.agents/skills/create-verification-skill/LICENSE.pstack
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lauren Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/create-verification-skill/SKILL.md
+++ b/.agents/skills/create-verification-skill/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: create-verification-skill
+description: Generate a project-local verification skill that drives the real app through its user surface. Use when a repository has no grounded way to prove UI, CLI, desktop, API, mobile, or library behavior.
+argument-hint: "[application or surface]"
+disable-model-invocation: false
+harness: universal
+---
+
+# /create-verification-skill — Create a project verification skill
+
+## Overview
+
+Generate a project-local `verify-<app>` skill for the next agent to use cold. It
+must launch the real app, diagnose the instance, drive user behavior, preserve
+evidence, and clean up only resources created by its own run.
+
+## The Iron Law
+
+```
+NO GENERATED SKILL IS COMPLETE UNTIL ITS OWN INSTRUCTIONS PASS ONCE END TO END
+```
+
+## 1. Interview the repository
+
+Read the repository before asking questions. Establish:
+
+- **Surface:** Identify what users touch. Choose the primary observable surface,
+  record secondary surfaces, and ask only when repository evidence cannot choose.
+- **Run:** Find the repository's documented launch/build command, readiness
+  signal, ports, environment, seed data, and authentication.
+- **Drive:** Reuse an existing Playwright/Cypress suite, PTY helper, CLI, HTTP
+  client, or debug protocol before introducing a generic recipe.
+- **Observe:** Identify screenshots, accessibility snapshots, transcripts,
+  response bodies, logs, exit codes, and persisted side effects available as proof.
+- **Isolate:** Determine which ports, profiles, and data directories permit
+  concurrent runs. If isolation is impossible, make the generated skill refuse
+  to drive shared state concurrently.
+
+If the checkout cannot build or launch as-is, fix that separately or report the
+exact blocker. Do not generate instructions against a broken baseline.
+
+## 2. Generate and mirror the skill
+
+Write `verify-<app>/SKILL.md` in the canonical `.agents/skills/` tree, then
+mirror that complete directory into the compatibility `.claude/skills/` tree.
+Confirm all generated files are byte-identical across the two trees. Use valid universal frontmatter with
+`name: verify-<app>`, a grounded description, `disable-model-invocation: false`,
+and `harness: universal`.
+
+The generated skill must declare **Surface and capability ceiling** before its
+workflow. Name the primary surface, secondary surfaces, driver, and the strongest
+proof the driver can produce. A DOM-functional driver cannot satisfy a VISUAL
+criterion; record such a check as `BLOCKED`, never `PASS`.
+
+Include these grounded instructions, with no placeholders:
+
+- **Launch:** Exact start command, isolation inputs, readiness signal, and
+  teardown ownership. A short-lived CLI launches each drive in an isolated PTY.
+- **Doctor:** One read-only check proving this is the expected healthy instance,
+  build, port, data directory, and auth context.
+- **Drive:** Exact commands and stable handles found in this repository. Prefer
+  ARIA labels, data attributes, prompt strings, and route paths over coordinates.
+- **Evidence:** Capture the user action and resulting state. Verify persisted
+  side effects from a second user-facing view; do not substitute internal setters
+  or test-only endpoints. State an artifact path outside disposable run state.
+- **Cleanup:** Track process IDs, ports, sessions, profiles, and scratch paths
+  created by this run. Never kill by process name. Remove owned runtime state but
+  preserve evidence.
+- **Helpers:** List each shipped helper, make it executable, and show its exact
+  invocation. If no helper is needed, state that the grounded commands above are
+  the complete interface rather than creating an empty script.
+
+## 3. Seed the feature map
+
+Create `features/README.md` and one file for each of the top 3-5 user-facing
+features found in routes, commands, menus, or documentation. Follow
+[`references/feature-map-example/`](references/feature-map-example/).
+
+The README indexes every feature. Each feature file starts with an H1 and a
+user-visible summary, followed by exactly these four H2 sections in order:
+
+1. `Sub-features`
+2. `How to get to it (user POV)`
+3. `Driving it with <harness>`
+4. `Gotchas`
+
+List every documented user entry point and its distinct observable proof. Do not
+claim an untested entry point passed because a more convenient route worked.
+
+## 4. Prove the generated contract
+
+Run one complete walkthrough using the generated instructions:
+
+1. Launch the isolated application.
+2. Run Doctor and require success.
+3. Drive one mapped feature through one documented user entry point.
+4. Capture the named evidence and observable side effect.
+5. Run Cleanup, including after every failed iteration.
+6. Confirm the evidence still exists at the named location after cleanup.
+
+Record the command sequence, selected feature and entry point, evidence paths,
+doctor result, cleanup result, and surviving-artifact check. A failed or unrun
+walkthrough leaves the generated skill a draft and must not be reported complete.
+
+## 5. Hand off maintenance
+
+Point the user to `/maintain-verification-skill --scope changed` after sessions
+that alter user-facing behavior and `/maintain-verification-skill` for a full
+source-and-live audit. Suggest a schedule only when asked.
+
+## Integration
+
+- Called directly when a target repository has no project-local verification skill.
+- Produces the input maintained by `/maintain-verification-skill` and consumed by
+  `/verify --scope e2e`.
+
+## Provenance
+
+Adapted from pstack's `create-verification-skill` in `cursor/plugins`, revision
+`68836ddaf5697224520f1847d90cdb90ca8babaa`. The upstream MIT notice is bundled
+as `LICENSE.pstack`; repository-level provenance is in `THIRD_PARTY_NOTICES.md`.

--- a/.agents/skills/create-verification-skill/references/feature-map-example/README.md
+++ b/.agents/skills/create-verification-skill/references/feature-map-example/README.md
@@ -1,0 +1,54 @@
+# Notes verification map
+
+This directory is the maintained source for verifying the user-facing behavior
+of Notes. Read the index before driving the app, then use the matching feature
+file as the recipe.
+
+## Baseline preconditions
+
+- Launch Notes at `http://127.0.0.1:4173` with a disposable data directory.
+- Set `NOTES_DATA_DIR=/tmp/notes-verify-$RUN_ID` so concurrent runs do not share state.
+- Seed notes titled `Quarterly plan` and `Grocery list`.
+- Put `control-notes` and the `notes` CLI on `PATH`.
+- Run `control-notes doctor` and require the expected URL, data directory, and build revision.
+- Never drive an instance that was not started by this verification run.
+
+## Driving conventions
+
+- Start every recipe from the baseline state unless its preconditions say otherwise.
+- Prefer ARIA roles and accessible names over CSS selectors or DOM position.
+- Treat every command as literal. Keep quoted names and flags unchanged.
+- Run browser actions through `control-notes browser`.
+- Run terminal actions through `control-notes cli -- <command>`.
+- Restore seeded data after a mutation. Do not remove proof artifacts during cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- UI proof includes an ARIA snapshot and a screenshot with the app identity visible.
+- CLI proof includes the command, stdout, stderr, and exit code.
+- Mutation proof includes a read-only second view of the stored value.
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and unmet precondition.
+- Account for every user entry point separately; do not report a skipped entry
+  point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the
+user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with <harness>` starts with `Preconditions:` and uses labeled
+   bullets pairing each action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable
+handles, required state, commands, and observable proof.
+
+## Features
+
+- [Create a note](./create-note.md) covers browser and CLI creation, cancellation, persistence, and cleanup.
+- [Search notes](./search.md) covers toolbar, keyboard, and CLI search with matching, empty, and clear states.
+- [Archive a note](./archive-note.md) covers browser and CLI archive entry points, list removal, and restoration.

--- a/.agents/skills/create-verification-skill/references/feature-map-example/archive-note.md
+++ b/.agents/skills/create-verification-skill/references/feature-map-example/archive-note.md
@@ -1,0 +1,36 @@
+# Archive a note
+
+Archive lets a user remove a note from the active list without deleting it and
+restore the same note later from the archive.
+
+## Sub-features
+
+- `archive-browser` archives an open note from the browser.
+- `archive-cli` archives a note by ID from the terminal.
+- `archive-restore` restores an archived note to the active list.
+
+## How to get to it (user POV)
+
+- Open a note and choose `Archive` from its actions menu.
+- Run `notes archive <id>` in a terminal.
+- Open `Archived notes` and choose `Restore` for an archived note.
+
+## Driving it with control-notes
+
+Preconditions:
+
+- Notes is healthy at `http://127.0.0.1:4173`.
+- The disposable data directory contains `Quarterly plan` in the active list.
+- `control-notes doctor` reports the expected URL and data directory.
+
+- **Browser archive.** Open `Quarterly plan`, choose `Note actions`, then `Archive`. The active list no longer contains the note.
+- **Confirm archive.** Open `Archived notes`. `Quarterly plan` is present with an `Archived` status.
+- **Restore.** Choose `Restore`. The archive no longer contains the note and the active list does.
+- **CLI entry.** Run `control-notes cli -- notes archive <id> --format json`. Exit code `0` and stdout identify the archived note.
+- **Proof.** Capture `artifacts/archive/archive.aria.txt` and `artifacts/archive/active.aria.txt`; together they show the note moving between views.
+
+## Gotchas
+
+- Archive is reversible and must not be described or tested as deletion.
+- A missing active-list row is insufficient proof; confirm the archived view.
+- Restore the seeded note during fixture cleanup, but retain proof artifacts.

--- a/.agents/skills/create-verification-skill/references/feature-map-example/create-note.md
+++ b/.agents/skills/create-verification-skill/references/feature-map-example/create-note.md
@@ -1,0 +1,40 @@
+# Create a note
+
+Create note lets a user save a titled note from the browser or CLI, cancel an
+unfinished draft, and confirm the saved note from a second user-facing view.
+
+## Sub-features
+
+- `create-open` opens a blank editor from each browser entry point.
+- `create-save` persists a title and body.
+- `create-cancel` discards an unfinished browser draft.
+- `create-cli` creates the same note shape from the terminal.
+
+## How to get to it (user POV)
+
+- Choose the `New note` button in the browser toolbar.
+- Press `n` in the browser while focus is outside an editable field.
+- Run `notes create --title <title> --body <body>` in a terminal.
+
+## Driving it with control-notes
+
+Preconditions:
+
+- Notes is healthy at `http://127.0.0.1:4173`.
+- No note is titled `Release checklist`.
+- `control-notes doctor` reports the expected URL and disposable data directory.
+
+- **Open editor.** Run `control-notes browser click --role button --name "New note"`. A form named `Note editor` appears with focus in `Title`.
+- **Enter content.** Fill `Title` with `Release checklist` and `Body` with `Tag and publish`. The `Save note` button becomes enabled.
+- **Save note.** Choose `Save note`. A status named `Note saved` appears and the heading reads `Release checklist`.
+- **Confirm persistence.** Return to `All notes` and reopen `Release checklist`. Both saved values appear.
+- **Cancel draft.** Open a new note, enter `Discard me`, and choose `Cancel`. The list has no `Discard me` link.
+- **CLI entry.** Run `control-notes cli -- notes create --title "CLI note" --body "Created from terminal" --format json`. Exit code `0` and stdout contain the new ID and title.
+- **Proof.** Run `control-notes browser snapshot --aria --path artifacts/create-note/list.aria.txt` and `control-notes browser screenshot --path artifacts/create-note/list.png`. Both saved notes appear.
+
+## Gotchas
+
+- Pressing `n` while a textbox has focus types the character instead of opening an editor.
+- Titles are trimmed on save. Assert the rendered title, not the draft value.
+- A save status alone is insufficient proof. Reopen the note from the list.
+- Remove created notes during fixture cleanup, but retain proof artifacts.

--- a/.agents/skills/create-verification-skill/references/feature-map-example/search.md
+++ b/.agents/skills/create-verification-skill/references/feature-map-example/search.md
@@ -1,0 +1,46 @@
+# Search notes
+
+Search lets a user find notes by title or body text, inspect a matching note,
+and distinguish no matches from an unavailable search.
+
+## Sub-features
+
+- `search-open` opens search from each supported browser entry point.
+- `search-match` returns title and body matches without changing note data.
+- `search-open-result` opens a result in the note editor.
+- `search-empty` shows a complete empty state for a query with no matches.
+- `search-clear` removes the query and restores the recent-notes view.
+- `search-cli` returns the same matching notes from the terminal.
+
+## How to get to it (user POV)
+
+- Choose the `Search` button in the browser toolbar.
+- Press `/` in the browser while focus is outside an editable field.
+- Run `notes search <query>` in a terminal.
+
+## Driving it with control-notes
+
+Preconditions:
+
+- Notes is healthy at `http://127.0.0.1:4173`.
+- The disposable data directory contains `Quarterly plan` with body `Draft budget`.
+- `control-notes doctor` reports the expected URL and data directory.
+
+- **Toolbar entry.** Choose `Search`. A dialog named `Search notes` appears with focus in its searchbox.
+- **Keyboard entry.** Close the dialog, focus the page, and press `/`. The same dialog appears without inserting a slash.
+- **Title match.** Enter `quarterly`. Results contain `Quarterly plan` but not `Grocery list`.
+- **Body match.** Replace the query with `budget`. `Quarterly plan` remains with a body-match excerpt.
+- **Open result.** Choose `Quarterly plan`. The dialog closes and the editor heading matches.
+- **Empty state.** Search for `volcano`. A status named `No matching notes` appears after completion.
+- **Clear query.** Choose `Clear search`. The query empties and `Recent notes` replaces results.
+- **CLI match.** Run `control-notes cli -- notes search "quarterly" --format json`. Exit code `0` and stdout contain one matching object.
+- **CLI miss.** Run the same command with `volcano`. Exit code `0` and stdout are `[]`.
+- **Proof.** Capture `artifacts/search/results.aria.txt` and `artifacts/search/results.png`; both identify Notes, the query, and `Quarterly plan`.
+
+## Gotchas
+
+- Pressing `/` while an editor or searchbox has focus inserts text.
+- Results update after a debounce. Wait for results or empty status, not a fixed sleep.
+- Archived notes require `Include archived`.
+- Use `--format json` for stable CLI assertions.
+- Opening a result changes browser state; reopen search before proving another query.

--- a/.agents/skills/maintain-verification-skill/LICENSE.pstack
+++ b/.agents/skills/maintain-verification-skill/LICENSE.pstack
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lauren Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/maintain-verification-skill/SKILL.md
+++ b/.agents/skills/maintain-verification-skill/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: maintain-verification-skill
+description: Reconcile a project verification skill after changed user behavior or run a full source-and-live feature audit. Use after user-facing changes or when auditing a verify-app feature map.
+argument-hint: "[--scope changed]"
+disable-model-invocation: false
+harness: universal
+---
+
+# /maintain-verification-skill — Maintain verification knowledge
+
+## Overview
+
+Keep a project-local `verify-<app>` skill and its feature map aligned with the
+real user experience. `--scope changed` is a cheap session reconciliation; the
+default is a comprehensive source-and-live audit.
+
+## The Iron Law
+
+```
+NEVER CLAIM COVERAGE FOR A FEATURE OR ENTRY POINT THAT WAS NOT ACTUALLY CHECKED
+```
+
+## Outcomes
+
+Emit exactly one outcome word and its evidence:
+
+- **clean** — required coverage completed and no verification content changed,
+  or changed scope proved maintenance not applicable without claiming coverage.
+- **changed** — proven verification-skill corrections remain on the active branch.
+- **blocked** — required coverage or a safe correction could not finish; name the blocker.
+
+## Locate and protect the target
+
+Find every `verify-*` directory in the canonical `.agents/skills/` tree and
+count candidates before validating their contents. This must use the same
+candidate set as `/verify --scope e2e`.
+
+- Exactly one candidate: require its `SKILL.md` to have Launch, Doctor, Drive,
+  Evidence, and Cleanup instructions plus `features/README.md`, then use it and
+  require a byte-identical mirror under the `.claude/skills/` compatibility tree.
+- Several candidates: stop and ask which application is in scope; never guess.
+- None in changed scope: return `clean` with evidence that no project-local
+  target exists and one recommendation to run `/create-verification-skill`.
+- None in full mode: return `blocked` and point to `/create-verification-skill`.
+
+Only edit the selected verification skill's own directory in both skill trees:
+its `SKILL.md`, `features/`, and owned helpers. Never edit product code. Treat a
+behavior mismatch as documentation drift, a harness gap, or a product regression;
+report product regressions instead of rewriting the map to hide them.
+
+## Changed-scope pass
+
+Run this pass only for `/maintain-verification-skill --scope changed`.
+
+1. Read the current session intent: touched specs, completed task entries, and
+   session notes. Read the session's base-to-HEAD diff, including user-facing bug
+   fixes that touched no spec.
+2. Classify whether behavior visible through the selected skill's declared
+   surface changed. For internal-only changes, skip silently and emit `clean`.
+3. Map each visible change to affected feature files and user entry points.
+   Require a concrete changed source path before adding a missing feature.
+4. Reconcile only affected or missing entries. Preserve the four required H2
+   sections and the feature index; do not drive unrelated features or regenerate
+   the whole map.
+5. Mirror the `verify-<app>` files byte-identically under `.claude/skills/` and
+   leave edits on the active branch for the caller's normal review and commit.
+   This mode does not open a separate PR.
+6. Re-read the same session evidence and map. If a second pass would change
+   anything, reconcile again before returning; the result must be idempotent.
+
+Do not launch the app in this pass. The caller's immediately following
+`/verify --scope e2e` supplies live evidence for changed acceptance criteria.
+Return only `clean`, `changed`, or `blocked` with affected feature IDs and paths.
+
+## Full pass
+
+Run this pass when no scope argument is supplied.
+
+1. **Index hygiene.** Compare `features/README.md` with sibling feature files.
+   Correct missing, extra, duplicate, and dead entries.
+2. **Source wave.** Dispatch one read-only subagent per feature concurrently.
+   Each independently explains the user-visible behavior from source, cites
+   entry points, reports likely drift or none, and returns one concise live
+   recipe. Subagents never drive the app or edit files. If independent dispatch
+   is unavailable, return `blocked` and state the lost coverage.
+3. **Reconcile.** Require a returned summary for every feature. Spot-check cited
+   drift and inspect recent user-facing source churn for missing mapped features.
+   Merge recipes into as few app states as practical without dropping entry points.
+4. **Live pass.** The coordinator launches and doctors the target through its
+   own verification skill. Exercise every feature at least once. Doctor each
+   fresh session, doctor again after surprising failures, and reset a wedged UI
+   even when the process is healthy. Record concrete prerequisites for unreachable
+   paths. A skipped entry point is not covered by another route.
+5. **Evidence and cleanup.** Preserve evidence already captured across every
+   cleanup. Remove only processes and state owned by the run, including residue
+   after failed drives. After the final teardown, confirm all named evidence paths
+   still exist.
+6. **Triage.** Fix verified map drift and harness gaps inside edit scope, then
+   re-drive any harness correction. Report product regressions without editing
+   product code.
+7. **Ship or stop.** For `changed`, re-read all edits and create at most one PR
+   containing proven verification corrections. For `clean` or `blocked`, create
+   no PR. Keep run notes in scratch storage, never in the commit.
+
+## Integration
+
+- Called with `--scope changed` by `/build` and `/wrap-up-session` before their
+  E2E verification gate for user-facing session changes.
+- Called directly or by approved scheduling for a complete audit.
+- Maintains output from `/create-verification-skill`; live driving follows the
+  selected project skill and `/verify --scope e2e` capability rules.
+
+## Provenance
+
+Adapted from pstack's `maintain-verification-skill` in `cursor/plugins`, revision
+`68836ddaf5697224520f1847d90cdb90ca8babaa`. The upstream MIT notice is bundled
+as `LICENSE.pstack`; repository-level provenance is in `THIRD_PARTY_NOTICES.md`.

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -111,9 +111,37 @@ Unit tests prove functions work. E2E walkthroughs prove features work.
 ### Pre-Flight
 
 1. Read the active spec from `specs/` and extract **user-facing ACs**
-2. Verify the app is running locally (check dev server, start via `/start-qa` if not)
-3. Resolve a browser backend and classify every AC (below)
-4. Load authentication state as a real user would — cookie-based session, not injected tokens
+2. Classify every AC before selecting a driver or backend
+3. Resolve a project-local verification skill, then resolve its compatible
+   driver or the generic browser backend (below)
+4. Launch and diagnose the app using the selected local recipe, or `/start-qa`
+   when using the generic fallback
+5. Load authentication state as a real user would — cookie-based session, not injected tokens
+
+### Project-local verification skill resolution
+
+Discover `verify-*` entries in the canonical `.agents/skills/` tree; treat their
+byte-identical `.claude/skills/` copies as mirrors, not additional candidates.
+
+- With **exactly one project-local `verify-<app>` skill**, read it and use its
+  grounded Launch, Doctor, Drive, Evidence, Cleanup, and Helpers contract. Its
+  declared surface and capability ceiling must satisfy the classified AC. A
+  local recipe selects *how* to drive the app; it never relaxes the classifier.
+- With **more than one project-local `verify-<app>` skill**, STOP and ask which
+  application is in scope. List the candidates and do not choose one.
+- With **no project-local `verify-<app>` skill**, recommend
+  `/create-verification-skill`, then continue through the unchanged generic
+  backend resolution below. This is a recommendation only: never create or
+  launch it automatically.
+
+If the selected local skill's capability ceiling is below an AC's tier, use a
+compatible higher-fidelity backend when the recipe permits it; otherwise record
+`BLOCKED`. A DOM-only local driver cannot pass a VISUAL AC.
+
+For a non-browser surface, follow the local skill's Drive contract without
+requiring an MCP browser. For a browser surface, resolve the recipe's compatible
+driver first. When there is no local skill, use the generic order below exactly
+as before.
 
 ### Backend resolution
 
@@ -239,4 +267,5 @@ The log is **append-only**. Never overwrite prior walkthroughs — they form the
 
 - **Default mode required by**: `/build` (after each task and in Phase 4), `/debug` (Phase 3), `/wrap-up-session` (Step 6)
 - **`--scope e2e` invoked by**: `/build` Phase 4 (user-facing ACs), `/wrap-up-session` Step 6.3
+- **Project recipe maintained by**: `/maintain-verification-skill --scope changed`
 - **`--scope deployment` invoked by**: `/wrap-up-session` Step 8

--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -101,6 +101,23 @@ Run `/memory-maintain` (it self-gates on the session count — runs every 5 sess
 
 ---
 
+## Step 3.3 — Changed Verification Map
+
+Classify the session diff, touched specs, and completed task entries. If any
+acceptance criterion or bug fix is user-facing:
+
+1. Invoke `/maintain-verification-skill --scope changed` with the session intent,
+   base-to-HEAD diff, touched specs, and completed task entries.
+2. If no project-local verification skill exists, skip maintenance, recommend
+   `/create-verification-skill`, and never generate or launch it automatically.
+3. Handle the maintainer outcome: `clean` and `changed` continue; `blocked` STOPS
+   wrap-up and reports the maintainer's evidence without committing.
+
+Internal-only sessions skip this step silently. This step runs before security,
+review, and tests so any verification-map edits are included in every gate.
+
+---
+
 ## Step 3.5 — Security Scan
 
 Run `/security-scan` on files changed this session (`git diff --name-only <base-branch>...HEAD`).
@@ -320,7 +337,9 @@ For every user-facing AC in specs touched this session:
 3. On `run`: invoke `/verify --scope e2e`, then re-check
 4. On `acknowledge`: record the gap as a knowledge-track document in `tasks/solutions/process/` (tags: `[e2e-gap]`)
 
-If no specs were touched: skip this gate silently.
+If no specs were touched, classify the session diff and task evidence so a
+user-facing bug fix still enters this gate. Skip silently only when the session
+is internal-only.
 
 ---
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -361,6 +361,8 @@ echo "  /auto-improve — Unattended discover→fix→PR loop (daily cloud runs)
 echo "  /tdd         — Manual TDD loop with user checkpoints"
 echo "  /debug       — Root cause analysis + bug-track store docs"
 echo "  /verify      — Evidence-based verification (--scope e2e|deployment)"
+echo "  /create-verification-skill — Generate a project-local verification recipe + feature map"
+echo "  /maintain-verification-skill — Reconcile --scope changed, or omit it for a full audit"
 echo "  /quality-gate — 3-phase post-build review: structural, anti-patterns, APOSD"
 echo "  /software-design-expert-review — APOSD design audit (GO/HOLD/STOP)"
 echo "  /software-design-expert-learn  — APOSD design tutorial (end-of-session)"

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -176,6 +176,22 @@ If mismatches found: send feedback to the implementing agent for fixes, then re-
 - Move to the next `[ ]` task immediately (no user prompt)
 - If a task is blocked by a previous failure, note it and skip to the next unblocked task
 
+## Phase 1.5 — Changed Verification Map
+
+After all tasks are `[x]`, classify the completed work. If ANY acceptance
+criterion is `user-facing`:
+
+1. Invoke `/maintain-verification-skill --scope changed` with the session intent,
+   base-to-HEAD diff, touched specs, and completed task entries. This idempotently
+   reconciles the project-local feature map on the active branch.
+2. If no project-local verification skill exists, skip maintenance, recommend
+   `/create-verification-skill`, and never generate or launch it automatically.
+3. Handle the maintainer outcome: `clean` and `changed` continue; `blocked` STOPS
+   the build and reports the maintainer's evidence.
+
+Internal-only changes skip changed-scope maintenance silently. This phase runs
+before the full suite and quality gate so any map edits receive both checks.
+
 ## Phase 2 — Full Suite Validation
 
 After all tasks are `[x]`:
@@ -210,7 +226,9 @@ previous_failures: []
 | `integration` | Integration test passes (real API/DB/service interaction) |
 | `user-facing` | E2E walkthrough via `/verify --scope e2e` — entry in `tasks/e2e-log.md` for current commit short-sha |
 
-If ANY AC is classified `user-facing`, invoke `/verify --scope e2e` before declaring Phase 4 complete.
+If ANY AC is classified `user-facing`:
+
+1. Invoke `/verify --scope e2e` before declaring Phase 4 complete.
 
 **For each round**:
 

--- a/.claude/skills/create-verification-skill/LICENSE.pstack
+++ b/.claude/skills/create-verification-skill/LICENSE.pstack
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lauren Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/create-verification-skill/SKILL.md
+++ b/.claude/skills/create-verification-skill/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: create-verification-skill
+description: Generate a project-local verification skill that drives the real app through its user surface. Use when a repository has no grounded way to prove UI, CLI, desktop, API, mobile, or library behavior.
+argument-hint: "[application or surface]"
+disable-model-invocation: false
+harness: universal
+---
+
+# /create-verification-skill — Create a project verification skill
+
+## Overview
+
+Generate a project-local `verify-<app>` skill for the next agent to use cold. It
+must launch the real app, diagnose the instance, drive user behavior, preserve
+evidence, and clean up only resources created by its own run.
+
+## The Iron Law
+
+```
+NO GENERATED SKILL IS COMPLETE UNTIL ITS OWN INSTRUCTIONS PASS ONCE END TO END
+```
+
+## 1. Interview the repository
+
+Read the repository before asking questions. Establish:
+
+- **Surface:** Identify what users touch. Choose the primary observable surface,
+  record secondary surfaces, and ask only when repository evidence cannot choose.
+- **Run:** Find the repository's documented launch/build command, readiness
+  signal, ports, environment, seed data, and authentication.
+- **Drive:** Reuse an existing Playwright/Cypress suite, PTY helper, CLI, HTTP
+  client, or debug protocol before introducing a generic recipe.
+- **Observe:** Identify screenshots, accessibility snapshots, transcripts,
+  response bodies, logs, exit codes, and persisted side effects available as proof.
+- **Isolate:** Determine which ports, profiles, and data directories permit
+  concurrent runs. If isolation is impossible, make the generated skill refuse
+  to drive shared state concurrently.
+
+If the checkout cannot build or launch as-is, fix that separately or report the
+exact blocker. Do not generate instructions against a broken baseline.
+
+## 2. Generate and mirror the skill
+
+Write `verify-<app>/SKILL.md` in the canonical `.agents/skills/` tree, then
+mirror that complete directory into the compatibility `.claude/skills/` tree.
+Confirm all generated files are byte-identical across the two trees. Use valid universal frontmatter with
+`name: verify-<app>`, a grounded description, `disable-model-invocation: false`,
+and `harness: universal`.
+
+The generated skill must declare **Surface and capability ceiling** before its
+workflow. Name the primary surface, secondary surfaces, driver, and the strongest
+proof the driver can produce. A DOM-functional driver cannot satisfy a VISUAL
+criterion; record such a check as `BLOCKED`, never `PASS`.
+
+Include these grounded instructions, with no placeholders:
+
+- **Launch:** Exact start command, isolation inputs, readiness signal, and
+  teardown ownership. A short-lived CLI launches each drive in an isolated PTY.
+- **Doctor:** One read-only check proving this is the expected healthy instance,
+  build, port, data directory, and auth context.
+- **Drive:** Exact commands and stable handles found in this repository. Prefer
+  ARIA labels, data attributes, prompt strings, and route paths over coordinates.
+- **Evidence:** Capture the user action and resulting state. Verify persisted
+  side effects from a second user-facing view; do not substitute internal setters
+  or test-only endpoints. State an artifact path outside disposable run state.
+- **Cleanup:** Track process IDs, ports, sessions, profiles, and scratch paths
+  created by this run. Never kill by process name. Remove owned runtime state but
+  preserve evidence.
+- **Helpers:** List each shipped helper, make it executable, and show its exact
+  invocation. If no helper is needed, state that the grounded commands above are
+  the complete interface rather than creating an empty script.
+
+## 3. Seed the feature map
+
+Create `features/README.md` and one file for each of the top 3-5 user-facing
+features found in routes, commands, menus, or documentation. Follow
+[`references/feature-map-example/`](references/feature-map-example/).
+
+The README indexes every feature. Each feature file starts with an H1 and a
+user-visible summary, followed by exactly these four H2 sections in order:
+
+1. `Sub-features`
+2. `How to get to it (user POV)`
+3. `Driving it with <harness>`
+4. `Gotchas`
+
+List every documented user entry point and its distinct observable proof. Do not
+claim an untested entry point passed because a more convenient route worked.
+
+## 4. Prove the generated contract
+
+Run one complete walkthrough using the generated instructions:
+
+1. Launch the isolated application.
+2. Run Doctor and require success.
+3. Drive one mapped feature through one documented user entry point.
+4. Capture the named evidence and observable side effect.
+5. Run Cleanup, including after every failed iteration.
+6. Confirm the evidence still exists at the named location after cleanup.
+
+Record the command sequence, selected feature and entry point, evidence paths,
+doctor result, cleanup result, and surviving-artifact check. A failed or unrun
+walkthrough leaves the generated skill a draft and must not be reported complete.
+
+## 5. Hand off maintenance
+
+Point the user to `/maintain-verification-skill --scope changed` after sessions
+that alter user-facing behavior and `/maintain-verification-skill` for a full
+source-and-live audit. Suggest a schedule only when asked.
+
+## Integration
+
+- Called directly when a target repository has no project-local verification skill.
+- Produces the input maintained by `/maintain-verification-skill` and consumed by
+  `/verify --scope e2e`.
+
+## Provenance
+
+Adapted from pstack's `create-verification-skill` in `cursor/plugins`, revision
+`68836ddaf5697224520f1847d90cdb90ca8babaa`. The upstream MIT notice is bundled
+as `LICENSE.pstack`; repository-level provenance is in `THIRD_PARTY_NOTICES.md`.

--- a/.claude/skills/create-verification-skill/references/feature-map-example/README.md
+++ b/.claude/skills/create-verification-skill/references/feature-map-example/README.md
@@ -1,0 +1,54 @@
+# Notes verification map
+
+This directory is the maintained source for verifying the user-facing behavior
+of Notes. Read the index before driving the app, then use the matching feature
+file as the recipe.
+
+## Baseline preconditions
+
+- Launch Notes at `http://127.0.0.1:4173` with a disposable data directory.
+- Set `NOTES_DATA_DIR=/tmp/notes-verify-$RUN_ID` so concurrent runs do not share state.
+- Seed notes titled `Quarterly plan` and `Grocery list`.
+- Put `control-notes` and the `notes` CLI on `PATH`.
+- Run `control-notes doctor` and require the expected URL, data directory, and build revision.
+- Never drive an instance that was not started by this verification run.
+
+## Driving conventions
+
+- Start every recipe from the baseline state unless its preconditions say otherwise.
+- Prefer ARIA roles and accessible names over CSS selectors or DOM position.
+- Treat every command as literal. Keep quoted names and flags unchanged.
+- Run browser actions through `control-notes browser`.
+- Run terminal actions through `control-notes cli -- <command>`.
+- Restore seeded data after a mutation. Do not remove proof artifacts during cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- UI proof includes an ARIA snapshot and a screenshot with the app identity visible.
+- CLI proof includes the command, stdout, stderr, and exit code.
+- Mutation proof includes a read-only second view of the stored value.
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and unmet precondition.
+- Account for every user entry point separately; do not report a skipped entry
+  point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the
+user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with <harness>` starts with `Preconditions:` and uses labeled
+   bullets pairing each action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable
+handles, required state, commands, and observable proof.
+
+## Features
+
+- [Create a note](./create-note.md) covers browser and CLI creation, cancellation, persistence, and cleanup.
+- [Search notes](./search.md) covers toolbar, keyboard, and CLI search with matching, empty, and clear states.
+- [Archive a note](./archive-note.md) covers browser and CLI archive entry points, list removal, and restoration.

--- a/.claude/skills/create-verification-skill/references/feature-map-example/archive-note.md
+++ b/.claude/skills/create-verification-skill/references/feature-map-example/archive-note.md
@@ -1,0 +1,36 @@
+# Archive a note
+
+Archive lets a user remove a note from the active list without deleting it and
+restore the same note later from the archive.
+
+## Sub-features
+
+- `archive-browser` archives an open note from the browser.
+- `archive-cli` archives a note by ID from the terminal.
+- `archive-restore` restores an archived note to the active list.
+
+## How to get to it (user POV)
+
+- Open a note and choose `Archive` from its actions menu.
+- Run `notes archive <id>` in a terminal.
+- Open `Archived notes` and choose `Restore` for an archived note.
+
+## Driving it with control-notes
+
+Preconditions:
+
+- Notes is healthy at `http://127.0.0.1:4173`.
+- The disposable data directory contains `Quarterly plan` in the active list.
+- `control-notes doctor` reports the expected URL and data directory.
+
+- **Browser archive.** Open `Quarterly plan`, choose `Note actions`, then `Archive`. The active list no longer contains the note.
+- **Confirm archive.** Open `Archived notes`. `Quarterly plan` is present with an `Archived` status.
+- **Restore.** Choose `Restore`. The archive no longer contains the note and the active list does.
+- **CLI entry.** Run `control-notes cli -- notes archive <id> --format json`. Exit code `0` and stdout identify the archived note.
+- **Proof.** Capture `artifacts/archive/archive.aria.txt` and `artifacts/archive/active.aria.txt`; together they show the note moving between views.
+
+## Gotchas
+
+- Archive is reversible and must not be described or tested as deletion.
+- A missing active-list row is insufficient proof; confirm the archived view.
+- Restore the seeded note during fixture cleanup, but retain proof artifacts.

--- a/.claude/skills/create-verification-skill/references/feature-map-example/create-note.md
+++ b/.claude/skills/create-verification-skill/references/feature-map-example/create-note.md
@@ -1,0 +1,40 @@
+# Create a note
+
+Create note lets a user save a titled note from the browser or CLI, cancel an
+unfinished draft, and confirm the saved note from a second user-facing view.
+
+## Sub-features
+
+- `create-open` opens a blank editor from each browser entry point.
+- `create-save` persists a title and body.
+- `create-cancel` discards an unfinished browser draft.
+- `create-cli` creates the same note shape from the terminal.
+
+## How to get to it (user POV)
+
+- Choose the `New note` button in the browser toolbar.
+- Press `n` in the browser while focus is outside an editable field.
+- Run `notes create --title <title> --body <body>` in a terminal.
+
+## Driving it with control-notes
+
+Preconditions:
+
+- Notes is healthy at `http://127.0.0.1:4173`.
+- No note is titled `Release checklist`.
+- `control-notes doctor` reports the expected URL and disposable data directory.
+
+- **Open editor.** Run `control-notes browser click --role button --name "New note"`. A form named `Note editor` appears with focus in `Title`.
+- **Enter content.** Fill `Title` with `Release checklist` and `Body` with `Tag and publish`. The `Save note` button becomes enabled.
+- **Save note.** Choose `Save note`. A status named `Note saved` appears and the heading reads `Release checklist`.
+- **Confirm persistence.** Return to `All notes` and reopen `Release checklist`. Both saved values appear.
+- **Cancel draft.** Open a new note, enter `Discard me`, and choose `Cancel`. The list has no `Discard me` link.
+- **CLI entry.** Run `control-notes cli -- notes create --title "CLI note" --body "Created from terminal" --format json`. Exit code `0` and stdout contain the new ID and title.
+- **Proof.** Run `control-notes browser snapshot --aria --path artifacts/create-note/list.aria.txt` and `control-notes browser screenshot --path artifacts/create-note/list.png`. Both saved notes appear.
+
+## Gotchas
+
+- Pressing `n` while a textbox has focus types the character instead of opening an editor.
+- Titles are trimmed on save. Assert the rendered title, not the draft value.
+- A save status alone is insufficient proof. Reopen the note from the list.
+- Remove created notes during fixture cleanup, but retain proof artifacts.

--- a/.claude/skills/create-verification-skill/references/feature-map-example/search.md
+++ b/.claude/skills/create-verification-skill/references/feature-map-example/search.md
@@ -1,0 +1,46 @@
+# Search notes
+
+Search lets a user find notes by title or body text, inspect a matching note,
+and distinguish no matches from an unavailable search.
+
+## Sub-features
+
+- `search-open` opens search from each supported browser entry point.
+- `search-match` returns title and body matches without changing note data.
+- `search-open-result` opens a result in the note editor.
+- `search-empty` shows a complete empty state for a query with no matches.
+- `search-clear` removes the query and restores the recent-notes view.
+- `search-cli` returns the same matching notes from the terminal.
+
+## How to get to it (user POV)
+
+- Choose the `Search` button in the browser toolbar.
+- Press `/` in the browser while focus is outside an editable field.
+- Run `notes search <query>` in a terminal.
+
+## Driving it with control-notes
+
+Preconditions:
+
+- Notes is healthy at `http://127.0.0.1:4173`.
+- The disposable data directory contains `Quarterly plan` with body `Draft budget`.
+- `control-notes doctor` reports the expected URL and data directory.
+
+- **Toolbar entry.** Choose `Search`. A dialog named `Search notes` appears with focus in its searchbox.
+- **Keyboard entry.** Close the dialog, focus the page, and press `/`. The same dialog appears without inserting a slash.
+- **Title match.** Enter `quarterly`. Results contain `Quarterly plan` but not `Grocery list`.
+- **Body match.** Replace the query with `budget`. `Quarterly plan` remains with a body-match excerpt.
+- **Open result.** Choose `Quarterly plan`. The dialog closes and the editor heading matches.
+- **Empty state.** Search for `volcano`. A status named `No matching notes` appears after completion.
+- **Clear query.** Choose `Clear search`. The query empties and `Recent notes` replaces results.
+- **CLI match.** Run `control-notes cli -- notes search "quarterly" --format json`. Exit code `0` and stdout contain one matching object.
+- **CLI miss.** Run the same command with `volcano`. Exit code `0` and stdout are `[]`.
+- **Proof.** Capture `artifacts/search/results.aria.txt` and `artifacts/search/results.png`; both identify Notes, the query, and `Quarterly plan`.
+
+## Gotchas
+
+- Pressing `/` while an editor or searchbox has focus inserts text.
+- Results update after a debounce. Wait for results or empty status, not a fixed sleep.
+- Archived notes require `Include archived`.
+- Use `--format json` for stable CLI assertions.
+- Opening a result changes browser state; reopen search before proving another query.

--- a/.claude/skills/maintain-verification-skill/LICENSE.pstack
+++ b/.claude/skills/maintain-verification-skill/LICENSE.pstack
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lauren Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/maintain-verification-skill/SKILL.md
+++ b/.claude/skills/maintain-verification-skill/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: maintain-verification-skill
+description: Reconcile a project verification skill after changed user behavior or run a full source-and-live feature audit. Use after user-facing changes or when auditing a verify-app feature map.
+argument-hint: "[--scope changed]"
+disable-model-invocation: false
+harness: universal
+---
+
+# /maintain-verification-skill — Maintain verification knowledge
+
+## Overview
+
+Keep a project-local `verify-<app>` skill and its feature map aligned with the
+real user experience. `--scope changed` is a cheap session reconciliation; the
+default is a comprehensive source-and-live audit.
+
+## The Iron Law
+
+```
+NEVER CLAIM COVERAGE FOR A FEATURE OR ENTRY POINT THAT WAS NOT ACTUALLY CHECKED
+```
+
+## Outcomes
+
+Emit exactly one outcome word and its evidence:
+
+- **clean** — required coverage completed and no verification content changed,
+  or changed scope proved maintenance not applicable without claiming coverage.
+- **changed** — proven verification-skill corrections remain on the active branch.
+- **blocked** — required coverage or a safe correction could not finish; name the blocker.
+
+## Locate and protect the target
+
+Find every `verify-*` directory in the canonical `.agents/skills/` tree and
+count candidates before validating their contents. This must use the same
+candidate set as `/verify --scope e2e`.
+
+- Exactly one candidate: require its `SKILL.md` to have Launch, Doctor, Drive,
+  Evidence, and Cleanup instructions plus `features/README.md`, then use it and
+  require a byte-identical mirror under the `.claude/skills/` compatibility tree.
+- Several candidates: stop and ask which application is in scope; never guess.
+- None in changed scope: return `clean` with evidence that no project-local
+  target exists and one recommendation to run `/create-verification-skill`.
+- None in full mode: return `blocked` and point to `/create-verification-skill`.
+
+Only edit the selected verification skill's own directory in both skill trees:
+its `SKILL.md`, `features/`, and owned helpers. Never edit product code. Treat a
+behavior mismatch as documentation drift, a harness gap, or a product regression;
+report product regressions instead of rewriting the map to hide them.
+
+## Changed-scope pass
+
+Run this pass only for `/maintain-verification-skill --scope changed`.
+
+1. Read the current session intent: touched specs, completed task entries, and
+   session notes. Read the session's base-to-HEAD diff, including user-facing bug
+   fixes that touched no spec.
+2. Classify whether behavior visible through the selected skill's declared
+   surface changed. For internal-only changes, skip silently and emit `clean`.
+3. Map each visible change to affected feature files and user entry points.
+   Require a concrete changed source path before adding a missing feature.
+4. Reconcile only affected or missing entries. Preserve the four required H2
+   sections and the feature index; do not drive unrelated features or regenerate
+   the whole map.
+5. Mirror the `verify-<app>` files byte-identically under `.claude/skills/` and
+   leave edits on the active branch for the caller's normal review and commit.
+   This mode does not open a separate PR.
+6. Re-read the same session evidence and map. If a second pass would change
+   anything, reconcile again before returning; the result must be idempotent.
+
+Do not launch the app in this pass. The caller's immediately following
+`/verify --scope e2e` supplies live evidence for changed acceptance criteria.
+Return only `clean`, `changed`, or `blocked` with affected feature IDs and paths.
+
+## Full pass
+
+Run this pass when no scope argument is supplied.
+
+1. **Index hygiene.** Compare `features/README.md` with sibling feature files.
+   Correct missing, extra, duplicate, and dead entries.
+2. **Source wave.** Dispatch one read-only subagent per feature concurrently.
+   Each independently explains the user-visible behavior from source, cites
+   entry points, reports likely drift or none, and returns one concise live
+   recipe. Subagents never drive the app or edit files. If independent dispatch
+   is unavailable, return `blocked` and state the lost coverage.
+3. **Reconcile.** Require a returned summary for every feature. Spot-check cited
+   drift and inspect recent user-facing source churn for missing mapped features.
+   Merge recipes into as few app states as practical without dropping entry points.
+4. **Live pass.** The coordinator launches and doctors the target through its
+   own verification skill. Exercise every feature at least once. Doctor each
+   fresh session, doctor again after surprising failures, and reset a wedged UI
+   even when the process is healthy. Record concrete prerequisites for unreachable
+   paths. A skipped entry point is not covered by another route.
+5. **Evidence and cleanup.** Preserve evidence already captured across every
+   cleanup. Remove only processes and state owned by the run, including residue
+   after failed drives. After the final teardown, confirm all named evidence paths
+   still exist.
+6. **Triage.** Fix verified map drift and harness gaps inside edit scope, then
+   re-drive any harness correction. Report product regressions without editing
+   product code.
+7. **Ship or stop.** For `changed`, re-read all edits and create at most one PR
+   containing proven verification corrections. For `clean` or `blocked`, create
+   no PR. Keep run notes in scratch storage, never in the commit.
+
+## Integration
+
+- Called with `--scope changed` by `/build` and `/wrap-up-session` before their
+  E2E verification gate for user-facing session changes.
+- Called directly or by approved scheduling for a complete audit.
+- Maintains output from `/create-verification-skill`; live driving follows the
+  selected project skill and `/verify --scope e2e` capability rules.
+
+## Provenance
+
+Adapted from pstack's `maintain-verification-skill` in `cursor/plugins`, revision
+`68836ddaf5697224520f1847d90cdb90ca8babaa`. The upstream MIT notice is bundled
+as `LICENSE.pstack`; repository-level provenance is in `THIRD_PARTY_NOTICES.md`.

--- a/.claude/skills/task-registry/references/configuration.md
+++ b/.claude/skills/task-registry/references/configuration.md
@@ -111,7 +111,7 @@ silently leaving the status wrong.
 ```ini
 [tracker]
 provider = github
-repository = my-org/ascii-video-pipeline
+repository = my-org/project-name
 require_write_approval = true
 
 [labels.kind]

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -111,9 +111,37 @@ Unit tests prove functions work. E2E walkthroughs prove features work.
 ### Pre-Flight
 
 1. Read the active spec from `specs/` and extract **user-facing ACs**
-2. Verify the app is running locally (check dev server, start via `/start-qa` if not)
-3. Resolve a browser backend and classify every AC (below)
-4. Load authentication state as a real user would — cookie-based session, not injected tokens
+2. Classify every AC before selecting a driver or backend
+3. Resolve a project-local verification skill, then resolve its compatible
+   driver or the generic browser backend (below)
+4. Launch and diagnose the app using the selected local recipe, or `/start-qa`
+   when using the generic fallback
+5. Load authentication state as a real user would — cookie-based session, not injected tokens
+
+### Project-local verification skill resolution
+
+Discover `verify-*` entries in the canonical `.agents/skills/` tree; treat their
+byte-identical `.claude/skills/` copies as mirrors, not additional candidates.
+
+- With **exactly one project-local `verify-<app>` skill**, read it and use its
+  grounded Launch, Doctor, Drive, Evidence, Cleanup, and Helpers contract. Its
+  declared surface and capability ceiling must satisfy the classified AC. A
+  local recipe selects *how* to drive the app; it never relaxes the classifier.
+- With **more than one project-local `verify-<app>` skill**, STOP and ask which
+  application is in scope. List the candidates and do not choose one.
+- With **no project-local `verify-<app>` skill**, recommend
+  `/create-verification-skill`, then continue through the unchanged generic
+  backend resolution below. This is a recommendation only: never create or
+  launch it automatically.
+
+If the selected local skill's capability ceiling is below an AC's tier, use a
+compatible higher-fidelity backend when the recipe permits it; otherwise record
+`BLOCKED`. A DOM-only local driver cannot pass a VISUAL AC.
+
+For a non-browser surface, follow the local skill's Drive contract without
+requiring an MCP browser. For a browser surface, resolve the recipe's compatible
+driver first. When there is no local skill, use the generic order below exactly
+as before.
 
 ### Backend resolution
 
@@ -239,4 +267,5 @@ The log is **append-only**. Never overwrite prior walkthroughs — they form the
 
 - **Default mode required by**: `/build` (after each task and in Phase 4), `/debug` (Phase 3), `/wrap-up-session` (Step 6)
 - **`--scope e2e` invoked by**: `/build` Phase 4 (user-facing ACs), `/wrap-up-session` Step 6.3
+- **Project recipe maintained by**: `/maintain-verification-skill --scope changed`
 - **`--scope deployment` invoked by**: `/wrap-up-session` Step 8

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -101,6 +101,23 @@ Run `/memory-maintain` (it self-gates on the session count — runs every 5 sess
 
 ---
 
+## Step 3.3 — Changed Verification Map
+
+Classify the session diff, touched specs, and completed task entries. If any
+acceptance criterion or bug fix is user-facing:
+
+1. Invoke `/maintain-verification-skill --scope changed` with the session intent,
+   base-to-HEAD diff, touched specs, and completed task entries.
+2. If no project-local verification skill exists, skip maintenance, recommend
+   `/create-verification-skill`, and never generate or launch it automatically.
+3. Handle the maintainer outcome: `clean` and `changed` continue; `blocked` STOPS
+   wrap-up and reports the maintainer's evidence without committing.
+
+Internal-only sessions skip this step silently. This step runs before security,
+review, and tests so any verification-map edits are included in every gate.
+
+---
+
 ## Step 3.5 — Security Scan
 
 Run `/security-scan` on files changed this session (`git diff --name-only <base-branch>...HEAD`).
@@ -320,7 +337,9 @@ For every user-facing AC in specs touched this session:
 3. On `run`: invoke `/verify --scope e2e`, then re-check
 4. On `acknowledge`: record the gap as a knowledge-track document in `tasks/solutions/process/` (tags: `[e2e-gap]`)
 
-If no specs were touched: skip this gate silently.
+If no specs were touched, classify the session diff and task evidence so a
+user-facing bug fix still enters this gate. Skip silently only when the session
+is internal-only.
 
 ---
 

--- a/.github/upstreams.json
+++ b/.github/upstreams.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "sources": [
+    {
+      "id": "pstack-verification-skills",
+      "url": "https://github.com/cursor/plugins.git",
+      "ref": "refs/heads/main",
+      "baseline": "68836ddaf5697224520f1847d90cdb90ca8babaa",
+      "paths": [
+        "pstack/LICENSE",
+        "pstack/skills/create-verification-skill",
+        "pstack/skills/maintain-verification-skill"
+      ],
+      "source_notice": "THIRD_PARTY_NOTICES.md"
+    }
+  ]
+}

--- a/.github/workflows/check-upstream-drift.yml
+++ b/.github/workflows/check-upstream-drift.yml
@@ -1,0 +1,31 @@
+name: check upstream drift
+
+on:
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Check registered upstreams
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/check-upstream-drift.py 2>upstream-drift-report.txt
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            {
+              echo '## Upstream drift check'
+              sed 's/^/    /' upstream-drift-report.txt
+            } >> "$GITHUB_STEP_SUMMARY"
+            cat upstream-drift-report.txt >&2
+            exit "$status"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,8 @@ authorization unless the project's configuration enables them.
 | `/debug` | Root cause analysis, bug-track store documents, loop verification |
 | `/tdd` | Manual TDD loop with user checkpoints |
 | `/verify` | Evidence-based verification gate (`--scope deployment|e2e`) |
+| `/create-verification-skill` | Generate a grounded project-local `verify-<app>` recipe and feature map, with one live proof |
+| `/maintain-verification-skill` | Reconcile current user-facing changes with `--scope changed`; omit the option for a full audit |
 | `/quality-gate` | 3-phase post-build review: structural quality, AI anti-patterns, APOSD design |
 | `/software-design-expert-review` | APOSD structural design gate — depth, leakage, error design; GO/HOLD/STOP verdict |
 | `/software-design-expert-learn` | APOSD design tutorial — end-of-session learning review based on Ousterhout |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A reusable, project-agnostic configuration system that enforces **spec-driven, T
 | Layer | What it does |
 |-------|-------------|
 | **CLAUDE.md** | Core rules: Spec → Plan → TDD workflow, Clean Code, SOLID, quality gate |
-| **Skills** (`.claude/skills/`) | 16 skills: `/brainstorm`, `/plan`, `/build`, `/tdd`, `/debug`, `/verify`, `/quality-gate`, `/receive-review`, `/learn`, `/checkpoint`, `/security-scan`, `/start-qa`, `/wrap-up-session`, `/writing-skills`, `/sync`, `/folder-context-optimization` |
+| **Skills** (`.claude/skills/`) | Cross-harness workflows for planning, building, verification, review, learning, synchronization, and project-specific verification recipes |
 | **Agents** (`.claude/agents/`) | 8 specialized subagents for planning, coding, review, debugging, security |
 | **Hooks** (`.claude/hooks/`) | Session start orientation + auto test runner on file save |
 | **Learning store** (`tasks/solutions/`) | Typed per-document learnings, grep-first retrieval, written via `/learn` |
@@ -245,6 +245,12 @@ flowchart TD
 
 **Internal calls**: /build delegates to sub-agents for TDD, invokes code-reviewer for 2-stage review, /debug on failures, /quality-gate after all tasks, and /verify before any completion claims.
 
+Project verification maps use a two-speed update path. `/build` and
+`/wrap-up-session` invoke `/maintain-verification-skill --scope changed` before
+E2E checks for user-facing session changes. Invoke
+`/maintain-verification-skill` without that option for a full audit of every
+mapped feature.
+
 **Standalone skills** (bottom): Can be invoked independently at any time.
 
 ---
@@ -261,6 +267,8 @@ Invoke with `/skill-name` in any Claude Code session:
 | `/tdd` | Manual TDD loop with user checkpoints: failing test → code → pass → refactor → `[x]` |
 | `/debug` | Root cause analysis with architecture questioning after 3 fails, bug-track store documents |
 | `/verify` | Evidence-based verification gate — no completion claims without fresh command output |
+| `/create-verification-skill` | Discover an app's real user surface, generate its `verify-<app>` recipe and feature map, then prove one feature live |
+| `/maintain-verification-skill` | Reconcile changed user behavior with `--scope changed`, or run a full audit of the complete feature map |
 | `/quality-gate` | 3-phase post-build review: structural quality, AI anti-patterns, APOSD design |
 | `/receive-review` | Process code review feedback: technical evaluation, pushback protocol, no performative agreement |
 | `/learn` | Extracts session learnings into typed documents under `tasks/solutions/` |
@@ -337,7 +345,7 @@ Claude delegates to these automatically (or you can invoke them via the Agent to
 │   ├── AGENTS.md                    ← Agent reference documentation
 │   ├── settings.json                ← Hook configuration
 │   ├── agents/                      ← 8 specialized subagents
-│   ├── skills/                      ← 16 skills, each with SKILL.md + optional reference docs
+│   ├── skills/                      ← skills, each with SKILL.md + optional reference docs
 │   └── hooks/
 │       ├── session-start.sh         ← Orientation + skill awareness
 │       └── auto-test-runner.sh
@@ -373,3 +381,4 @@ Effect is cosmetic noise only. Nothing in this repo emits it, and no change here
 - [shanraisshan/claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) — Command/agent/skill architecture
 - [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) — Memory system, hook lifecycle, continuous learning
 - [obra/superpowers](https://github.com/obra/superpowers) — Iron laws, verification patterns, brainstorming workflow, systematic debugging
+- [cursor/plugins — pstack](https://github.com/cursor/plugins/tree/68836ddaf5697224520f1847d90cdb90ca8babaa/pstack) — Lauren Tan's MIT-licensed verification-skill creator, maintainer, and feature-map pattern (adapted from revision `68836ddaf5697224520f1847d90cdb90ca8babaa`; see `THIRD_PARTY_NOTICES.md`)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,40 @@
+# Third-Party Notices
+
+## pstack verification skills
+
+The adapted `create-verification-skill` and `maintain-verification-skill` content
+in this repository comes from the pstack plugin in
+[cursor/plugins](https://github.com/cursor/plugins), pinned at revision
+`68836ddaf5697224520f1847d90cdb90ca8babaa`.
+
+Original source files:
+
+- [`pstack/skills/create-verification-skill/SKILL.md`](https://github.com/cursor/plugins/blob/68836ddaf5697224520f1847d90cdb90ca8babaa/pstack/skills/create-verification-skill/SKILL.md)
+- [`pstack/skills/maintain-verification-skill/SKILL.md`](https://github.com/cursor/plugins/blob/68836ddaf5697224520f1847d90cdb90ca8babaa/pstack/skills/maintain-verification-skill/SKILL.md)
+- [`pstack/skills/create-verification-skill/references/feature-map-example/`](https://github.com/cursor/plugins/tree/68836ddaf5697224520f1847d90cdb90ca8babaa/pstack/skills/create-verification-skill/references/feature-map-example)
+
+The upstream pstack material is licensed as follows:
+
+> MIT License
+>
+> Copyright (c) 2026 Lauren Tan
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+This notice applies only to the identified third-party material. It does not declare a license for the repository as a whole.

--- a/scripts/check-upstream-drift.py
+++ b/scripts/check-upstream-drift.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Report drift between reviewed Git revisions and registered upstream refs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+try:
+    import resource
+except ImportError:  # Windows has no POSIX resource limits.
+    resource = None
+
+MAX_REGISTRY_BYTES = 1_000_000
+MAX_SOURCES = 100
+MAX_CHANGED_PATHS = 20
+MAX_FIELD_LENGTH = 2_048
+MAX_GIT_DIAGNOSTIC_BYTES = 4_096
+CHECK_DEADLINE_SECONDS = 600
+MAX_GIT_FILE_BYTES = 512 * 1024 * 1024
+MAX_GIT_MEMORY_BYTES = 1024 * 1024 * 1024
+COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+CHECK_DEADLINE = float("inf")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", default=".github/upstreams.json")
+    parser.add_argument("--repository-root")
+    parser.add_argument("--deadline-seconds", type=float, default=CHECK_DEADLINE_SECONDS)
+    return parser.parse_args()
+
+
+def safe_relative(value: object) -> bool:
+    if not isinstance(value, str) or not value or len(value) > MAX_FIELD_LENGTH:
+        return False
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        return False
+    path = PurePosixPath(value)
+    return not path.is_absolute() and all(part not in ("", ".", "..") for part in path.parts)
+
+
+def required_string(source: dict[str, Any], field: str, index: int) -> tuple[str, list[str]]:
+    errors = []
+    value = source.get(field)
+    has_control = isinstance(value, str) and any(ord(character) < 32 or ord(character) == 127 for character in value)
+    if not isinstance(value, str) or not value or len(value) > MAX_FIELD_LENGTH or has_control:
+        errors.append(f"sources[{index}].{field} must be a non-empty bounded string")
+        return "", errors
+    if value.startswith("-"):
+        errors.append(f"sources[{index}].{field} must not begin with '-'")
+    return value, errors
+
+
+def validate_paths(source: dict[str, Any], index: int) -> list[str]:
+    if "paths" not in source:
+        return []
+    errors = []
+    paths = source["paths"]
+    if not isinstance(paths, list) or not paths:
+        errors.append(f"sources[{index}].paths must be a non-empty list when present")
+        return errors
+    if len(paths) != len(set(item for item in paths if isinstance(item, str))):
+        errors.append(f"sources[{index}].paths contains duplicates")
+    for path_index, path in enumerate(paths):
+        if not safe_relative(path):
+            errors.append(f"sources[{index}].paths[{path_index}] must be a safe relative path")
+    return errors
+
+
+def validate_identity(fields: dict[str, str], index: int, seen: set[str]) -> list[str]:
+    errors = []
+    source_id = fields["id"]
+    if source_id and not ID_RE.fullmatch(source_id):
+        errors.append(f"sources[{index}].id has an invalid format")
+    if source_id in seen:
+        errors.append(f"sources[{index}].id duplicates '{source_id}'")
+    seen.add(source_id)
+    baseline = fields["baseline"]
+    if baseline and not COMMIT_RE.fullmatch(baseline):
+        errors.append(f"sources[{index}].baseline must be a full 40-character commit")
+    return errors
+
+
+def validate_ref(ref: str, index: int) -> list[str]:
+    forbidden = ("..", "@{", "\\", " ", "~", "^", ":", "?", "*", "[")
+    parts = ref.split("/")
+    valid_prefix = ref.startswith("refs/heads/") or ref.startswith("refs/tags/")
+    invalid_part = any(not part or part.startswith(".") or part.endswith(".") or part.endswith(".lock") for part in parts)
+    if not valid_prefix or invalid_part or ref.endswith("/") or any(token in ref for token in forbidden):
+        return [f"sources[{index}].ref must be a valid refs/heads/* or refs/tags/* name"]
+    return []
+
+
+def validate_source(source: object, index: int, seen: set[str]) -> list[str]:
+    if not isinstance(source, dict):
+        return [f"sources[{index}] must be an object"]
+    fields = {}
+    errors = []
+    for field in ("id", "url", "ref", "baseline"):
+        fields[field], field_errors = required_string(source, field, index)
+        errors.extend(field_errors)
+    errors.extend(validate_identity(fields, index, seen))
+    errors.extend(validate_ref(fields["ref"], index))
+    notice = source.get("source_notice")
+    if not safe_relative(notice):
+        errors.append(f"sources[{index}].source_notice must be a safe relative path")
+    errors.extend(validate_paths(source, index))
+    return errors
+
+
+def validate_registry(registry: object) -> list[str]:
+    if not isinstance(registry, dict):
+        return ["registry root must be an object"]
+    errors = []
+    if registry.get("version") != 1:
+        errors.append("version must equal 1")
+    sources = registry.get("sources")
+    if not isinstance(sources, list) or not sources or len(sources) > MAX_SOURCES:
+        errors.append(f"sources must contain 1-{MAX_SOURCES} entries")
+        return errors
+    seen: set[str] = set()
+    for index, source in enumerate(sources):
+        errors.extend(validate_source(source, index, seen))
+    return errors
+
+
+def validate_notices(registry: dict[str, Any], repository_root: Path) -> list[str]:
+    errors = []
+    for index, source in enumerate(registry["sources"]):
+        notice = source["source_notice"]
+        if not (repository_root / notice).is_file():
+            errors.append(f"sources[{index}].source_notice must name an existing file")
+    return errors
+
+
+def resolve_repository_root(registry_path: Path, configured: str | None) -> Path:
+    if configured:
+        return Path(configured).resolve()
+    if registry_path.parent.name == ".github":
+        return registry_path.parent.parent.resolve()
+    return Path.cwd()
+
+
+def load_registry(path: Path, repository_root: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    try:
+        if path.stat().st_size > MAX_REGISTRY_BYTES:
+            return None, [f"registry exceeds {MAX_REGISTRY_BYTES} bytes"]
+        registry = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        return None, [f"cannot read registry: {error}"]
+    errors = validate_registry(registry)
+    if not errors:
+        errors.extend(validate_notices(registry, repository_root))
+    return (registry if not errors else None), errors
+
+
+def failed_git(command: list[str], returncode: int, message: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.CompletedProcess(command, returncode, b"", message.encode("utf-8", "replace"))
+
+
+def child_resource_limits() -> Any:
+    if resource is None:
+        return None
+
+    def apply_limits() -> None:
+        limits = (("RLIMIT_FSIZE", MAX_GIT_FILE_BYTES), ("RLIMIT_AS", MAX_GIT_MEMORY_BYTES))
+        for name, requested in limits:
+            if not hasattr(resource, name):
+                continue
+            kind = getattr(resource, name)
+            _, hard = resource.getrlimit(kind)
+            bounded = requested if hard == resource.RLIM_INFINITY else min(requested, hard)
+            resource.setrlimit(kind, (bounded, bounded))
+
+    return apply_limits
+
+
+def git_timeout() -> float | None:
+    remaining = CHECK_DEADLINE - time.monotonic()
+    return min(120, remaining) if remaining > 0 else None
+
+
+def git_stdio(capture_output: bool) -> tuple[Any, Any]:
+    if capture_output:
+        return subprocess.PIPE, subprocess.PIPE
+    return subprocess.DEVNULL, subprocess.DEVNULL
+
+
+def run_git(repo: Path, *arguments: str, capture_output: bool = True) -> subprocess.CompletedProcess[bytes]:
+    command = ["git", "-C", str(repo), *arguments]
+    timeout = git_timeout()
+    if timeout is None:
+        return failed_git(command, 124, "total checker deadline exceeded")
+    stdout, stderr = git_stdio(capture_output)
+    try:
+        return subprocess.run(
+            command,
+            stdout=stdout,
+            stderr=stderr,
+            timeout=timeout,
+            check=False,
+            preexec_fn=child_resource_limits(),
+        )
+    except subprocess.TimeoutExpired:
+        return failed_git(command, 124, "Git command timed out")
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        return failed_git(command, 127, f"Git could not start: {error}")
+
+
+def drain_bounded(stream: Any, captured: bytearray) -> None:
+    try:
+        while chunk := stream.read(8_192):
+            remaining = MAX_GIT_DIAGNOSTIC_BYTES - len(captured)
+            if remaining > 0:
+                captured.extend(chunk[:remaining])
+    except (OSError, ValueError):
+        return
+
+
+def process_group_options() -> dict[str, Any]:
+    if os.name == "posix":
+        return {"start_new_session": True}
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {}
+
+
+def kill_process_tree(process: subprocess.Popen[bytes]) -> None:
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+    except ProcessLookupError:
+        return
+
+
+def wait_for_process(process: subprocess.Popen[bytes], timeout: float) -> int:
+    try:
+        return process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        kill_process_tree(process)
+        process.wait()
+        return 124
+
+
+def run_git_with_diagnostic(repo: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    command = ["git", "-C", str(repo), *arguments]
+    timeout = git_timeout()
+    if timeout is None:
+        return failed_git(command, 124, "total checker deadline exceeded")
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            preexec_fn=child_resource_limits(),
+            **process_group_options(),
+        )
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        return failed_git(command, 127, f"Git could not start: {error}")
+    captured = bytearray()
+    reader = threading.Thread(target=drain_bounded, args=(process.stderr, captured), daemon=True)
+    reader.start()
+    returncode = wait_for_process(process, timeout)
+    reader.join(timeout=1)
+    return subprocess.CompletedProcess(command, returncode, b"", bytes(captured))
+
+
+def git_diagnostic(completed: subprocess.CompletedProcess[bytes]) -> str:
+    lines = (completed.stderr or b"").decode("utf-8", "replace").splitlines()
+    message = " | ".join(lines) if lines else "Git returned no diagnostic"
+    message = re.sub(r"(://)[^/@\s]+@", r"\1[redacted]@", message)
+    return "".join(character if character.isprintable() else "?" for character in message)[:240]
+
+
+def fetch_commit(repo: Path, url: str, revision: str) -> tuple[str | None, str]:
+    fetched = run_git_with_diagnostic(
+        repo,
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "--filter=blob:none",
+        "--",
+        url,
+        revision,
+    )
+    if fetched.returncode != 0:
+        return None, git_diagnostic(fetched)
+    resolved = run_git(repo, "rev-parse", "--verify", "FETCH_HEAD^{commit}")
+    if resolved.returncode != 0:
+        return None, git_diagnostic(resolved)
+    return resolved.stdout.decode("ascii").strip(), ""
+
+
+def changed_paths(repo: Path, revisions: tuple[str, str], paths: list[str] | None) -> list[str] | None:
+    baseline, head = revisions
+    arguments = ["diff", "--name-only", "--no-renames", "-z", baseline, head, "--"]
+    if paths:
+        arguments.extend(f":(literal){path}" for path in paths)
+    completed = run_git(repo, *arguments)
+    if completed.returncode != 0:
+        return None
+    return [item.decode("utf-8", "replace") for item in completed.stdout.split(b"\0") if item]
+
+
+def display_path(path: str) -> str:
+    visible = "".join(character if character.isalnum() or character in "/._@-" else "?" for character in path)
+    return visible[:240]
+
+
+def source_revisions(repo: Path, source: dict[str, Any]) -> tuple[str, str] | str:
+    baseline, diagnostic = fetch_commit(repo, source["url"], source["baseline"])
+    if baseline is None:
+        return f"unavailable: {source['id']}: could not fetch reviewed baseline ({diagnostic})"
+    head, diagnostic = fetch_commit(repo, source["url"], source["ref"])
+    if head is None:
+        return f"unavailable: {source['id']}: could not fetch tracked ref ({diagnostic})"
+    return baseline, head
+
+
+def history_issue(repo: Path, source_id: str, revisions: tuple[str, str]) -> list[str]:
+    baseline, head = revisions
+    ancestor = run_git(repo, "merge-base", "--is-ancestor", baseline, head)
+    if ancestor.returncode not in (0, 1):
+        return [f"unavailable: {source_id}: could not compare Git history"]
+    if ancestor.returncode == 1:
+        return [f"history-diverged: {source_id}: baseline {baseline}; head {head}; manual review required"]
+    return []
+
+
+def drift_report(source_id: str, revisions: tuple[str, str], changes: list[str]) -> list[str]:
+    baseline, head = revisions
+    report = [f"drift: {source_id}: baseline {baseline}; head {head}"]
+    report.extend(f"  changed: {display_path(path)}" for path in changes[:MAX_CHANGED_PATHS])
+    if len(changes) > MAX_CHANGED_PATHS:
+        report.append(f"  changed: ... {len(changes) - MAX_CHANGED_PATHS} more path(s) omitted")
+    return report
+
+
+def inspect_source(repo: Path, source: dict[str, Any]) -> list[str]:
+    revisions = source_revisions(repo, source)
+    if isinstance(revisions, str):
+        return [revisions]
+    issues = history_issue(repo, source["id"], revisions)
+    if issues:
+        return issues
+    changes = changed_paths(repo, revisions, source.get("paths"))
+    if changes is None:
+        return [f"unavailable: {source['id']}: could not diff reviewed content"]
+    return drift_report(source["id"], revisions, changes) if changes else []
+
+
+def check_source(source: dict[str, Any]) -> list[str]:
+    with tempfile.TemporaryDirectory(prefix="upstream-drift-") as directory:
+        repo = Path(directory)
+        initialized = run_git(repo, "init", "--quiet")
+        if initialized.returncode != 0:
+            return [f"unavailable: {source['id']}: could not initialize isolated Git repository"]
+        return inspect_source(repo, source)
+
+
+def configure_deadline(seconds: float) -> bool:
+    global CHECK_DEADLINE
+    if not math.isfinite(seconds) or seconds <= 0:
+        print("deadline-seconds must be positive", file=sys.stderr)
+        return False
+    CHECK_DEADLINE = time.monotonic() + seconds
+    return True
+
+
+def main() -> int:
+    arguments = parse_args()
+    if not configure_deadline(arguments.deadline_seconds):
+        return 2
+    registry_path = Path(arguments.registry)
+    repository_root = resolve_repository_root(registry_path, arguments.repository_root)
+    registry, errors = load_registry(registry_path, repository_root)
+    if errors:
+        print("invalid registry:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 2
+    failures = []
+    for source in registry["sources"]:
+        failures.extend(check_source(source))
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/pstack-verification-skill-integration.md
+++ b/specs/pstack-verification-skill-integration.md
@@ -1,0 +1,321 @@
+# Spec: pstack Verification Skill Integration
+
+## Behavior
+
+The workflow distributes harness-neutral adaptations of pstack's
+`create-verification-skill` and `maintain-verification-skill`. The creator
+interviews a target repository, generates a project-local `verify-<app>` skill
+and feature map, and proves one mapped feature end to end before handing the
+skill over. The maintainer supports two modes:
+
+- `--scope changed` reconciles only user-facing behavior changed by the current
+  session. `/build` runs it before E2E verification and `/wrap-up-session` runs
+  it as an idempotent backstop.
+- Full mode retains pstack's complete source-and-live audit of every mapped
+  feature and is invoked directly or by scheduled automation.
+
+`/verify --scope e2e` prefers one project-local `verify-<app>` skill when one
+exists, while preserving the current fail-closed acceptance-criterion
+classifier and generic browser fallback. Session Stop hooks do not run agentic
+maintenance; lifecycle integration remains in explicit skill chains.
+
+The adaptation preserves the upstream MIT notice and records pstack, Lauren
+Tan, the source files, and the pinned source revision. A general-purpose
+upstream registry and scheduled checker monitor pstack and any future declared
+source for drift without modifying vendored files.
+
+## Inputs
+
+- Explicit `/create-verification-skill` invocation in a target repository.
+- Explicit `/maintain-verification-skill` invocation, optionally with
+  `--scope changed`.
+- A user-facing acceptance criterion classified by `/build` or
+  `/wrap-up-session`.
+- The current session's base-to-HEAD diff, touched specs, and completed task
+  entries for changed-scope reconciliation.
+- Existing project launch commands, user surfaces, driving harnesses, and
+  observable proof mechanisms discovered from the target repository.
+- A committed upstream registry entry containing a stable ID, Git URL, tracked
+  ref, imported baseline commit, and optional path scope.
+
+## Outputs
+
+- Global, installable canonical skills under `.agents/skills/`, with
+  byte-identical Claude compatibility copies under `.claude/skills/`.
+- A generated project-local `.agents/skills/verify-<app>/SKILL.md`, mirrored to
+  `.claude/skills/verify-<app>/SKILL.md`, plus `features/README.md` and the first
+  3-5 user-facing feature files.
+- Launch, Doctor, Drive, Evidence, Cleanup, and Helpers instructions grounded in
+  the target repository, with a stated surface and capability ceiling.
+- Preserved evidence after one creation-time live proof.
+- Incremental feature-map edits on the active session branch, or a `clean`,
+  `changed`, or `blocked` maintenance result.
+- Full-audit corrections confined to the generated verification skill, with
+  product regressions reported rather than hidden by documentation edits.
+- Third-party license and attribution records in this repository.
+- A failure-only scheduled/manual upstream-drift report that names every
+  registered source whose tracked content changed or became unavailable.
+
+## Design Decisions
+
+### Canonical and generated paths
+
+The imported skills are adapted from Cursor-specific `.cursor/skills/` paths to
+this harness's `.agents/skills/` canonical tree. Every generated project-local
+skill and asset is copied byte-identically into `.claude/skills/` so the existing
+parity contract remains true across Codex, Pi, and Claude Code.
+
+### Resolution and fallback
+
+`/verify --scope e2e` resolves project-local verification skills before its
+generic browser backend:
+
+1. Exactly one `verify-<app>` skill: read it and use its grounded launch, doctor,
+   drive, evidence, and cleanup contract.
+2. More than one: stop and ask which application is in scope; never guess.
+3. None: retain the existing Chrome -> Playwright -> Lightpanda -> STOP behavior.
+
+A local skill is a driving recipe, not permission to weaken verification. Its
+declared surface and capability ceiling must satisfy the classified AC. In
+particular, uncertain browser ACs remain VISUAL, DOM-only drivers cannot pass
+VISUAL ACs, and blocked checks remain non-success.
+
+### Two-speed map maintenance
+
+Changed scope runs only when the caller has identified user-facing behavior in
+the current session. It reconciles affected and newly introduced behavior,
+updates the feature index, and leaves edits on the current branch for the normal
+review and commit flow. It does not open a separate PR or re-drive the entire
+map. The following `/verify --scope e2e` invocation supplies live evidence for
+the changed ACs.
+
+Full mode performs index hygiene, one independent read-only source inspection
+per feature, reconciliation against recent user-facing source churn, and one
+coordinator-owned live pass over every feature. It may ship at most one PR of
+proven corrections and never edits product code.
+
+If no project-local verification skill exists, automatic chains retain generic
+E2E behavior and emit one actionable recommendation to run the creator; they do
+not generate files or launch an application implicitly. A direct maintenance
+invocation with no target stops and points to the creator.
+
+### Lifecycle placement
+
+- `/build` invokes changed-scope maintenance after classifying user-facing ACs
+  and before Phase 4 E2E verification.
+- `/wrap-up-session` invokes the same idempotent reconciliation before its E2E
+  coverage gate, covering debug/manual sessions that did not use `/build`.
+- The Stop hook remains limited to cleanup and warnings. It must not edit files,
+  launch the application, dispatch agents, or attempt live verification.
+- Direct full maintenance is the comprehensive manual or scheduled drift audit.
+
+### Licensing and attribution
+
+This repository currently has no root license, so the change does not imply a
+license for the whole repository. It includes the full upstream pstack MIT
+notice in a third-party notice, credits `Copyright (c) 2026 Lauren Tan`, links
+the original repository and both adapted skills, and pins provenance to upstream
+revision `68836ddaf5697224520f1847d90cdb90ca8babaa`. README Sources carries the
+human-facing credit.
+
+### General-purpose upstream drift detection
+
+`.github/upstreams.json` is the machine-readable registry for material vendored
+or adapted into this repository. Each entry contains:
+
+- `id`: stable unique identifier used in reports.
+- `url`: Git remote URL; the checker is not GitHub-specific.
+- `ref`: tracked branch or tag reference.
+- `baseline`: exact commit whose content was imported or last reviewed.
+- `paths`: optional repository-relative path list. Omit it to monitor the whole
+  upstream; include it to avoid unrelated monorepo churn.
+- `source_notice`: repository-relative attribution or license record associated
+  with the import.
+
+The first entry tracks pstack's creator, maintainer, feature-map references, and
+license at the pinned baseline. Future imports register another entry rather
+than adding source-specific checking code.
+
+`scripts/check-upstream-drift.py` validates the complete registry before network
+access, fetches each baseline and tracked ref into an isolated temporary Git
+repository without checking out or executing upstream content, verifies that
+the baseline is an ancestor of the current ref, and diffs only the registered
+paths. It processes every entry so one unavailable source does not hide drift
+in another. Results are:
+
+- `clean`: all registered content matches its reviewed baseline; exit 0 and no
+  routine output.
+- `drift`: at least one registered path changed; non-zero with a bounded report
+  containing source ID, baseline, current commit, and changed paths.
+- `unavailable`: a ref, baseline, remote, or network lookup failed; non-zero and
+  names the failed source without claiming it is clean.
+- `history-diverged`: the baseline is no longer an ancestor of the tracked ref;
+  non-zero and requires manual review rather than treating a force-push as a
+  normal update.
+
+A least-privilege GitHub Actions workflow (`contents: read`) runs the checker on
+a weekly schedule and through `workflow_dispatch`. Clean runs are silent.
+Drift, unavailable sources, invalid registry data, and rewritten history fail
+the job and write the bounded report to the workflow summary, using GitHub's
+failed-workflow notification rather than opening or mutating issues. The
+workflow never updates a baseline, copies upstream files, executes fetched
+content, or opens a PR. Accepting an upstream change remains a separately
+reviewed change that updates the vendored files, notice when needed, and
+registry baseline together.
+
+This registry monitors every source explicitly declared in it; it does not
+pretend to discover undocumented provenance or replace package-manager security
+and dependency update tooling. The existing downstream `workflow` remote drift
+notice remains separate because it compares a consumer repository with this
+template, whereas this checker compares this template's vendored material with
+its original sources.
+
+## Edge Cases
+
+- No launchable application or broken baseline: creator reports the exact
+  blocker and does not emit an unproved deliverable.
+- More than one user surface: creator chooses the primary observable surface,
+  records secondary surfaces, and asks only when repository evidence cannot
+  resolve the choice.
+- More than one generated `verify-*` skill: verification and maintenance stop
+  for target selection.
+- No generated skill: normal E2E fallback remains backward-compatible; changed
+  maintenance is skipped with a creator recommendation.
+- Internal-only session changes: feature-map maintenance is skipped silently.
+- User-facing bug fix without a touched spec: wrap-up classifies the diff and
+  task/session evidence rather than assuming there was no visible change.
+- Map lists multiple entry points: verification cannot prove one convenient
+  path and report all entry points covered.
+- Cleanup failure or failed proof iteration: clean only resources started by
+  that run, preserve evidence, and never kill by process name.
+- Evidence is removed by cleanup: creation or maintenance is blocked until the
+  proof survives teardown.
+- Product behavior disagrees with the map: documentation drift is corrected;
+  a product regression is reported and product code remains untouched.
+- Reduced-fidelity browser driver: it cannot satisfy a VISUAL AC and must record
+  `BLOCKED` rather than `PASS`.
+- Concurrent verification runs: use isolated ports, profiles, and data
+  directories when supported; otherwise refuse to double-drive shared state.
+- Full maintenance cannot dispatch independent feature readers: report the lost
+  coverage/corroboration and return `blocked`, never imply a complete audit.
+- Upstream changes after the pinned revision: no automatic fetch or overwrite;
+  the scheduled checker reports drift and future adoption is a separately
+  reviewed sync.
+- Upstream repository or ref is deleted, made private, or temporarily
+  unreachable: the checker reports `unavailable`; vendored skills and notices
+  remain usable in this repository.
+- Upstream force-push removes the baseline from the tracked history: report
+  `history-diverged`, never silently reset the baseline.
+- One of several upstreams fails: finish checking the remaining entries and
+  report the aggregate non-clean result.
+- Upstream monorepo changes outside registered paths: treat the registered
+  import as clean; an entry with no `paths` monitors the entire repository.
+- Invalid or duplicate registry entries: fail before fetching anything and name
+  the exact field error.
+- Scheduled runner is offline: fail loudly as `unavailable`; fixture tests never
+  rely on public network access.
+
+## Acceptance Criteria
+
+- [x] AC-1: `create-verification-skill` and `maintain-verification-skill` exist
+  in both skill trees, use valid harness-universal frontmatter with model
+  invocation enabled, and remain byte-identical across canonical and Claude
+  copies.
+- [x] AC-2: The creator generates a project-local `verify-<app>` skill in both
+  trees with grounded Launch, Doctor, Drive, Evidence, Cleanup, and Helpers
+  instructions, a declared surface/capability ceiling, no placeholders, and no
+  process-name cleanup.
+- [x] AC-3: The creator generates an indexed 3-5 entry feature map whose feature
+  files use the required four H2 sections and distinguish every documented user
+  entry point and observable proof.
+- [x] AC-4: The creator's contract requires and records a successful
+  launch -> doctor -> one mapped drive -> evidence -> cleanup walkthrough, with
+  evidence confirmed to survive cleanup; a failed or unrun proof cannot be
+  called complete.
+- [x] AC-5: Full maintenance performs index hygiene, separately dispatched
+  read-only source coverage per feature, recent-surface reconciliation, one
+  coordinator-owned live pass over every feature, and emits exactly `clean`,
+  `changed`, or `blocked` while editing only the verification-skill directory.
+- [x] AC-6: `--scope changed` consumes current session intent and diff, updates
+  only affected/missing feature-map entries on the active branch, is idempotent,
+  does not open a separate PR, and skips internal-only changes.
+- [x] AC-7: `/verify --scope e2e` uses exactly one project-local verification
+  skill when available, stops on ambiguity, falls back unchanged when absent,
+  and never allows a local driver to bypass the existing fail-closed
+  VISUAL/DOM-functional capability gate.
+- [x] AC-8: Both `/build` and `/wrap-up-session` invoke changed-scope maintenance
+  before E2E verification for user-facing session changes; the static invocation
+  chain is pinned in both trees, and no Stop hook invokes maintenance.
+- [x] AC-9: Absence of a project-local verification skill remains
+  backward-compatible: generic E2E still runs, automatic creation never occurs,
+  and the user receives an actionable creator recommendation.
+- [x] AC-10: The full pstack MIT notice, Lauren Tan copyright, source repository,
+  original skill links, and pinned upstream revision are preserved; README
+  Sources credits pstack without licensing the entire repository implicitly.
+- [x] AC-11: README, CLAUDE.md, and the session-start skill list describe both
+  skills and the two-speed update mechanism; installation and sync distribute
+  them through the existing skill-tree mechanisms without a new dependency.
+- [x] AC-12: Focused mutation-capable tests prove registration, feature-map
+  contract, resolution/fallback, capability ceiling, lifecycle chains,
+  attribution, and tree parity; the complete `bash tests/run.sh` suite passes.
+- [x] AC-13: A schema-validated, multi-source upstream registry and
+  general-purpose Git checker support whole-repository or path-scoped tracking;
+  pstack is registered at the imported baseline, clean checks are silent, and
+  drift, unavailable sources, invalid configuration, or rewritten history fail
+  with bounded actionable evidence while never changing vendored content or a
+  baseline.
+- [x] AC-14: A least-privilege weekly and manually dispatchable GitHub workflow
+  runs the general checker, exposes non-clean evidence in the workflow summary,
+  relies on failed-workflow notification, and never executes upstream content,
+  opens issues/PRs, or applies updates automatically.
+
+## Files Likely Involved
+
+- `.agents/skills/create-verification-skill/` — canonical adapted creator and
+  feature-map reference assets.
+- `.agents/skills/maintain-verification-skill/SKILL.md` — canonical full and
+  changed-scope maintenance workflows.
+- `.claude/skills/create-verification-skill/` — byte-identical compatibility
+  copy.
+- `.claude/skills/maintain-verification-skill/SKILL.md` — byte-identical
+  compatibility copy.
+- `.agents/skills/verify/SKILL.md` and `.claude/skills/verify/SKILL.md` — local
+  skill resolution, fallback, and capability-gate integration.
+- `.agents/skills/build/SKILL.md` and `.claude/skills/build/SKILL.md` — pre-E2E
+  changed-map reconciliation.
+- `.agents/skills/wrap-up-session/SKILL.md` and
+  `.claude/skills/wrap-up-session/SKILL.md` — session backstop before E2E.
+- `tests/test-verification-skill-integration.sh` — focused static and fixture
+  contract tests.
+- `tests/test-skill-invocation-chain.sh` — lifecycle handoff guards.
+- `tests/test-e2e-classifier.sh` — local-driver resolution and fail-closed
+  classifier guards.
+- `tests/test-skill-parity.sh` — existing byte-parity enforcement.
+- `THIRD_PARTY_NOTICES.md` — upstream MIT notice and pinned provenance.
+- `.github/upstreams.json` — extensible registry of reviewed upstream baselines
+  and optional imported path scopes.
+- `scripts/check-upstream-drift.py` — host-neutral Git drift checker with
+  failure-only output.
+- `.github/workflows/check-upstream-drift.yml` — weekly/manual notification
+  workflow with read-only repository permissions.
+- `tests/test-upstream-drift.sh` — local Git-fixture coverage for clean, drift,
+  unavailable, rewritten-history, multi-source, and invalid-registry outcomes.
+- `README.md`, `CLAUDE.md`, `.claude/hooks/session-start.sh` — discoverability,
+  credits, and update-mechanism documentation.
+
+## Verification
+
+- Run each focused test red before implementation and green afterward.
+- Mutation-probe at least one load-bearing assertion in each area: remove a
+  required feature heading, sever a lifecycle invocation, remove the local
+  skill fallback, weaken the VISUAL gate, remove the upstream notice, and alter
+  a registry baseline/path; each mutation must make the relevant focused test
+  fail.
+- Exercise upstream checking only against temporary local Git repositories:
+  clean and unrelated path churn exit 0 silently; relevant drift, unavailable
+  remotes, non-ancestor history, duplicate IDs, and malformed fields exit
+  non-zero with the expected source ID and bounded evidence.
+- Run `bash tests/test-skill-parity.sh` after canonical-to-compat copies.
+- Run `bash tests/run.sh` after all tasks and record test-file/assertion counts.
+- During `/build`, run the normal quality gate and validate every acceptance
+  criterion against fresh evidence.

--- a/tasks/checkpoint.md
+++ b/tasks/checkpoint.md
@@ -1,19 +1,42 @@
-# Checkpoint — 2026-08-13T13:18:59Z
+# Checkpoint — 2026-08-29T18:14:39Z
 
-> Auto-written by PreCompact hook (trigger: unknown). Re-read on resume.
+> Auto-written by PreCompact hook (trigger: manual). Re-read on resume.
 
 ## Git
-- Branch: worktree-m3-typed-learning-store
+- Branch: Joaovsales/pstack-create-verification-skill
 
 ```
-(working tree clean)
+ M .agents/skills/build/SKILL.md
+ M .agents/skills/verify/SKILL.md
+ M .agents/skills/wrap-up-session/SKILL.md
+ M .claude/hooks/session-start.sh
+ M .claude/skills/build/SKILL.md
+ M .claude/skills/verify/SKILL.md
+ M .claude/skills/wrap-up-session/SKILL.md
+ M CLAUDE.md
+ M README.md
+ M tasks/checkpoint.md
+ M tasks/todo.md
+ M tests/test-e2e-classifier.sh
+ M tests/test-skill-invocation-chain.sh
+?? .agents/skills/create-verification-skill/
+?? .agents/skills/maintain-verification-skill/
+?? .claude/skills/create-verification-skill/
+?? .claude/skills/maintain-verification-skill/
+?? .github/upstreams.json
+?? .github/workflows/check-upstream-drift.yml
+?? THIRD_PARTY_NOTICES.md
+?? scripts/check-upstream-drift.py
+?? specs/pstack-verification-skill-integration.md
+?? tests/test-upstream-drift.sh
+?? tests/test-verification-skill-integration.sh
 ```
 
 ## In-Progress & Pending Tasks (tasks/todo.md)
 (none)
 
 ## Active Spec
-- specs/compound-engineering-adoption.md
+- specs/pstack-verification-skill-integration.md
 
 ## How to Resume
 1. Read this file and `tasks/todo.md`

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -200,3 +200,23 @@
   and the walkthrough then ran container-to-container.
 - Learnings captured: `tasks/solutions/patterns/a-stubbed-web-api-is-more-dangerous-than-an-absent-one.md`,
   `tasks/solutions/patterns/a-null-probe-result-needs-a-control-run.md`
+
+### [2026-08-29] — Verification skill integration
+
+- Key changes: Adapted pstack's MIT-licensed verification-skill creator and
+  maintainer into both harness skill trees; integrated changed-scope maintenance
+  into `/build`, `/wrap-up-session`, and `/verify`; added complete provenance;
+  and added a general-purpose registry, checker, and weekly GitHub workflow for
+  detecting path-scoped upstream drift without mutating downstream content.
+- Verification: all 24 test files passed, including 64 verification-integration
+  assertions and 32 upstream-drift assertions; 10/10 load-bearing mutation probes
+  were rejected; the live registered upstream check exited cleanly.
+- Wrap-up review: three independently dispatched review lenses plus one inline
+  adversarial pass found 13 issues, all resolved. The fixes aligned candidate
+  discovery across maintenance and E2E, made the example a fully indexed
+  three-feature contract, closed false-green tests, and hardened the external Git
+  checker with ref validation, bounded resources and diagnostics, process-tree
+  timeout cleanup, safe workflow summary rendering, and an immutable
+  checkout-action pin.
+- Learnings captured: `tasks/solutions/patterns/markdown-heading-contracts-must-match-heading-levels-exactly.md`,
+  `tasks/solutions/patterns/count-candidates-before-validating-the-selected-target.md`

--- a/tasks/project-context.md
+++ b/tasks/project-context.md
@@ -4,7 +4,21 @@
 **Purpose**: A reusable, project-agnostic coding agent configuration system — consolidated rules, subagents, skills, hooks, and workflows that enforce spec-driven, TDD-first development.
 
 **Structure**:
+- `.agents/skills/` — canonical, harness-neutral skills
 - `.claude/agents/` — specialized subagents
-- `.claude/skills/` — skills invokable with `/skill-name`
+- `.claude/skills/` — byte-identical compatibility copies of canonical skills
 - `.claude/hooks/` — lifecycle automation
+- `.github/upstreams.json` — registered upstream sources and pinned baselines
+- `.github/workflows/` — repository automation, including upstream drift checks
+- `scripts/` — standard-library and shell maintenance utilities
+- `specs/` — feature specifications and acceptance criteria
+- `tasks/solutions/` — typed, grep-first learning store
+- `tests/` — shell contract and integration tests
 - `CLAUDE.md` — root-level Claude Code config
+
+**Conventions**:
+- Edit canonical skills under `.agents/skills/` and keep their `.claude/skills/`
+  compatibility copies byte-identical.
+- Vendored skill directories carry their own upstream license notice; repository-
+  level attribution and pinned provenance live in `THIRD_PARTY_NOTICES.md`.
+- Recurring checks are silent on success and actionable on failure.

--- a/tasks/solutions/bugs/task-registry-configuration-mirror-broke-skill-parity.md
+++ b/tasks/solutions/bugs/task-registry-configuration-mirror-broke-skill-parity.md
@@ -1,0 +1,28 @@
+---
+title: Task registry configuration mirror broke skill parity
+date: 2026-08-30
+problem_type: bug
+module: .agents/skills/task-registry/references/configuration.md, .claude/skills/task-registry/references/configuration.md
+tags: [task-registry, skill-parity, canonical-mirror, rebase]
+symptoms: The full suite failed after rebasing PR #78 because the task-registry configuration reference differed across skill trees
+root_cause: The task-registry merge carried a repository-specific GitHub example only in the Claude compatibility copy while the canonical copy retained the generic example
+resolution: Restored the Claude reference to the canonical generic repository example and verified byte parity through the focused and full suites
+---
+
+**Status**: fixed — 2026-08-30
+**Regression test**: `tests/test-skill-parity.sh`
+
+During the PR #78 rebase, the controlled focused run reported one mismatch:
+`.agents/skills/task-registry/references/configuration.md` used
+`repository = my-org/project-name`, while the Claude mirror used
+`repository = my-org/ascii-video-pipeline`. Direct blob inspection showed the
+mismatch already existed on `origin/master`, ruling out the pstack rebase as its
+source (Level 2 Git artifact evidence).
+
+The canonical skill tree is the source of truth, and the parity test enumerates
+this reference as a required byte-identical mirror. The compatibility copy now
+matches the canonical example (`.claude/skills/task-registry/references/configuration.md:114`).
+The focused parity suite passed 69 assertions, and the complete suite passed all
+25 test files after the correction.
+
+Related pattern: [A parity `cp` can clobber a legitimate harness divergence](../patterns/a-parity-cp-can-clobber-a-legitimate-harness-divergence.md).

--- a/tasks/solutions/patterns/count-candidates-before-validating-the-selected-target.md
+++ b/tasks/solutions/patterns/count-candidates-before-validating-the-selected-target.md
@@ -1,0 +1,25 @@
+---
+title: Count candidates before validating the selected target
+date: 2026-08-30
+problem_type: pattern
+module: .agents/skills/maintain-verification-skill, .agents/skills/verify
+tags: [skills, discovery, ambiguity, validation, lifecycle]
+applies_when: two or more chained workflow stages discover and operate on the same class of project-local resource
+---
+
+When chained consumers resolve the same resource type, they must first count the
+same raw candidate set and only then validate the uniquely selected candidate.
+Filtering malformed candidates during discovery makes one stage silently ignore
+an ambiguity that the next stage rejects.
+
+The verification maintainer now counts every canonical `verify-*` directory
+before checking its required files (`.agents/skills/maintain-verification-skill/SKILL.md:34`).
+That matches the E2E resolver, which also discovers canonical `verify-*` entries
+before selecting exactly one (`.agents/skills/verify/SKILL.md:123`).
+
+Apply this order whenever stages share a discovery boundary:
+
+1. Discover and count raw candidates with one common rule.
+2. Stop on zero or ambiguity according to the shared contract.
+3. Validate the contents of the single selected target.
+4. Test malformed extra candidates so filtering cannot silently change cardinality.

--- a/tasks/solutions/patterns/markdown-heading-contracts-must-match-heading-levels-exactly.md
+++ b/tasks/solutions/patterns/markdown-heading-contracts-must-match-heading-levels-exactly.md
@@ -1,0 +1,24 @@
+---
+title: Markdown heading contracts must match heading levels exactly
+date: 2026-08-29
+problem_type: pattern
+module: tests/test-verification-skill-integration.sh
+tags: [testing, markdown, contract-tests, mutation-testing, false-green]
+applies_when: writing contract tests that require a Markdown section at a specific heading level or in a specific order
+---
+
+A contract test that searches for `## Gotchas` as a substring also accepts
+`### Gotchas`. The 2026-08-29 session exposed that false green with a mutation
+probe, then changed the test to collect only exact H2 lines and assert the count
+and order (`tests/test-verification-skill-integration.sh:50`).
+
+When a document's structure is load-bearing, test the structure rather than a
+token contained inside it:
+
+- Anchor the heading level (`^## `), not only the heading text.
+- Assert the expected number of peer headings.
+- Assert their order when a consumer depends on a fixed schema.
+- Mutate the heading level once to prove the test rejects the malformed shape.
+
+This is distinct from a prose-presence assertion: the words can still exist
+while the document no longer satisfies the structural contract.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -274,3 +274,28 @@
 - Carry-forward (unchanged): minted ids from long TDD row titles read poorly; a shorter
   minting strategy would be an improvement, and migration output is a human-edited
   proposal, so it stays cosmetic.
+
+---
+
+## Plan: pstack Verification Skill Integration
+> Spec: specs/pstack-verification-skill-integration.md
+> Upstream: cursor/plugins pstack @ 68836ddaf5697224520f1847d90cdb90ca8babaa
+
+[x] TDD: `tests/test-verification-skill-integration.sh` rejects missing or invalid creator/maintainer frontmatter, required workflow sections, feature-map reference headings, unsafe process-name cleanup, and absent provenance -> add the focused red contract test, the full pstack MIT notice in `THIRD_PARTY_NOTICES.md`, and README source credit
+[x] TDD: creator contract assertions require instructions that generate canonical `.agents/skills/verify-<app>/` output mirrored byte-identically to `.claude/skills/`, grounded Launch/Doctor/Drive/Evidence/Cleanup/Helpers sections, a declared surface/capability ceiling, a 3-5 entry indexed map, and creation-time proof whose evidence survives cleanup -> adapt `create-verification-skill` and its reference assets from the pinned upstream revision
+[x] TDD: maintainer contract assertions require full mode's index/source/live coverage and exact `clean|changed|blocked` outcomes plus idempotent `--scope changed` reconciliation that consumes session intent/diff, edits only the verification skill on the active branch, skips internal-only changes, and never opens its own PR -> adapt `maintain-verification-skill`
+[x] TDD: `tests/test-e2e-classifier.sh` fails when project-local resolution, ambiguity STOP, absent-skill fallback, or capability-ceiling enforcement is removed -> integrate exactly-one `verify-*` discovery into `/verify --scope e2e` without weakening the Chrome/Playwright/Lightpanda fail-closed classifier
+[x] TDD: `tests/test-skill-invocation-chain.sh` fails unless both skill trees route user-facing changes from `/build` and `/wrap-up-session` through `/maintain-verification-skill --scope changed` before `/verify --scope e2e`, and the Stop hook remains free of maintenance invocation -> add the two idempotent lifecycle handoffs and backward-compatible no-skill recommendation
+[x] TDD: documentation/distribution assertions require both skills and the two-speed update mechanism in README, CLAUDE.md, and the session-start banner while existing install/sync paths remain sufficient -> update only those discoverability surfaces and preserve canonical/compat parity
+[x] TDD: `tests/test-upstream-drift.sh` uses temporary local Git repositories to cover schema validation, multiple registered sources, whole-repo and path-scoped clean/drift detection, unavailable refs/remotes, rewritten history, aggregate checking, silent success, and bounded failure evidence -> add `.github/upstreams.json` with the pinned pstack import, a stdlib-plus-Git `scripts/check-upstream-drift.py`, and a read-only weekly/manual `.github/workflows/check-upstream-drift.yml` that reports non-clean results without applying updates
+[x] TDD: mutation probes make each load-bearing contract fail, including a registry baseline/path mutation; `bash tests/test-skill-parity.sh` and `bash tests/run.sh` pass with recorded counts -> run focused mutations, full validation, `/quality-gate`, and acceptance-criterion evidence review
+
+Build evidence: 10/10 mutation probes rejected after tightening one false-green
+heading assertion. Wrap-up review resolved all 13 findings and strengthened the
+focused gates to 82 verification-integration assertions, 64 upstream-drift
+assertions, and 51 parity assertions. Initial quality gate: APOSD GO.
+
+## Session Summary — [2026-08-29] [2022b10..HEAD]
+- Completed: 8 planned tasks
+- Pending: 0
+- Carry-forward: none; wrap-up review fixes completed 2026-08-30

--- a/tests/test-e2e-classifier.sh
+++ b/tests/test-e2e-classifier.sh
@@ -34,6 +34,24 @@ COMPAT=".claude/skills/verify/SKILL.md"
 
 for f in "$CANONICAL" "$COMPAT"; do
 
+  # --- 0. Project-local verification skill resolution ----------------------
+  assert_prose_contains "$f" 'exactly one project-local `verify-<app>` skill' \
+    "$f: exactly one local verification skill is selected"
+  assert_prose_contains "$f" 'more than one project-local `verify-<app>` skill' \
+    "$f: ambiguous local verification skills STOP for selection"
+  assert_prose_contains "$f" "do not choose one" \
+    "$f: ambiguity never guesses a target"
+  assert_prose_contains "$f" 'no project-local `verify-<app>` skill' \
+    "$f: absence preserves the generic backend fallback"
+  assert_prose_contains "$f" 'recommend `/create-verification-skill`' \
+    "$f: absent local skill yields an actionable recommendation"
+  assert_prose_contains "$f" "never create or launch it automatically" \
+    "$f: fallback never performs implicit generation or launch"
+  assert_prose_contains "$f" "declared surface and capability ceiling" \
+    "$f: local recipes declare their usable verification ceiling"
+  assert_prose_contains "$f" "must satisfy the classified AC" \
+    "$f: local recipes cannot bypass the AC classifier"
+
   # --- 1. Backend resolution order -------------------------------------------
   # Ordered, first match wins. A full-fidelity backend must outrank lightpanda,
   # or the cheap tier would win on machines that have a real browser available.

--- a/tests/test-skill-invocation-chain.sh
+++ b/tests/test-skill-invocation-chain.sh
@@ -59,11 +59,74 @@ done
 # enforcement point is wrap-up-session, not /verify itself.
 for tree in $TREES; do
   f="$tree/skills/wrap-up-session/SKILL.md"
+  assert_file_contains "$f" "/maintain-verification-skill --scope changed" \
+    "Chain: $tree/wrap-up-session reconciles the feature map"
   assert_file_contains "$f" "/verify --scope e2e" \
     "Chain: $tree/wrap-up-session invokes /verify --scope e2e"
   assert_file_contains "$f" "tasks/e2e-log.md" \
     "Chain: $tree/wrap-up-session checks the e2e evidence log"
 done
+
+
+# ── user-facing build/wrap-up -> changed map -> e2e --------------------------
+# Maintenance must precede live verification so the walkthrough reads the map
+# produced for the current session, not yesterday's behavior.
+for tree in $TREES; do
+  for skill in build wrap-up-session; do
+    f="$tree/skills/$skill/SKILL.md"
+    maintain_line=$(grep -nF "/maintain-verification-skill --scope changed" "$f" | head -1 | cut -d: -f1)
+    verify_line=$(grep -niF 'invoke `/verify --scope e2e`' "$f" | head -1 | cut -d: -f1)
+    review_line=$(grep -nE '^## (Phase 3|Step 4) .*Quality Gate|^## Step 4 .*Code Review' "$f" | head -1 | cut -d: -f1)
+    full_test_line=$(grep -nE '^## Phase 2 .*Full Suite|^## Step 6 .*Run Tests' "$f" | head -1 | cut -d: -f1)
+    assert_file_contains "$f" "/maintain-verification-skill --scope changed" \
+      "Chain: $tree/$skill names changed-scope maintenance"
+    assert_file_matches "$f" '`blocked`.*STOP' \
+      "Chain: $tree/$skill stops when maintenance is blocked"
+    if [ -n "${maintain_line:-}" ] && [ -n "${verify_line:-}" ] && [ "$maintain_line" -lt "$verify_line" ]; then
+      assert_eq "before" "before" "Chain: $tree/$skill maintains before e2e"
+    else
+      assert_eq "maintenance before e2e" "${maintain_line:-missing} / ${verify_line:-missing}" \
+        "Chain: $tree/$skill maintains before e2e"
+    fi
+    if [ -n "${maintain_line:-}" ] && [ -n "${full_test_line:-}" ] && [ "$maintain_line" -lt "$full_test_line" ]; then
+      assert_eq "before" "before" "Chain: $tree/$skill maintains before full tests"
+    else
+      assert_eq "maintenance before full tests" "${maintain_line:-missing} / ${full_test_line:-missing}" \
+        "Chain: $tree/$skill maintains before full tests"
+    fi
+    if [ -n "${maintain_line:-}" ] && [ -n "${review_line:-}" ] && [ "$maintain_line" -lt "$review_line" ]; then
+      assert_eq "before" "before" "Chain: $tree/$skill maintains before review"
+    else
+      assert_eq "maintenance before review" "${maintain_line:-missing} / ${review_line:-missing}" \
+        "Chain: $tree/$skill maintains before review"
+    fi
+  done
+done
+
+# Stop is a shell cleanup/warning hook, not an agentic editing lifecycle.
+for hook in .claude/hooks/*stop*.sh; do
+  assert_file_not_matches "$hook" 'maintain-verification-skill|create-verification-skill' \
+    "Chain: $hook does not invoke verification-skill maintenance"
+done
+
+# ── discoverability and two-speed maintenance --------------------------------
+for doc in README.md CLAUDE.md; do
+  assert_file_contains "$doc" "/create-verification-skill" \
+    "Docs: $doc lists the verification-skill creator"
+  assert_file_contains "$doc" "/maintain-verification-skill" \
+    "Docs: $doc lists verification-skill maintenance"
+  assert_file_contains "$doc" "--scope changed" \
+    "Docs: $doc explains changed-scope maintenance"
+  assert_file_contains "$doc" "full audit" \
+    "Docs: $doc distinguishes full maintenance"
+done
+
+assert_file_contains .claude/hooks/session-start.sh "/create-verification-skill" \
+  "Banner: lists the verification-skill creator"
+assert_file_contains .claude/hooks/session-start.sh "/maintain-verification-skill" \
+  "Banner: lists verification-skill maintenance"
+assert_file_contains .claude/hooks/session-start.sh "--scope changed" \
+  "Banner: identifies incremental maintenance"
 
 # ── /auto-push and /yolo -> the phases they promise ──────────────────────────
 # Both advertise an autonomous pipeline in their own descriptions. If a stage

--- a/tests/test-upstream-drift.sh
+++ b/tests/test-upstream-drift.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+# Local-only contract tests for the general-purpose upstream drift checker.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+CHECKER="$REPO/scripts/check-upstream-drift.py"
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+new_repo() {
+  _repo="$1"
+  git init -q --initial-branch=main "$_repo"
+  git -C "$_repo" config user.name fixture
+  git -C "$_repo" config user.email fixture@example.test
+}
+
+commit_file() {
+  _repo="$1" _path="$2" _content="$3"
+  mkdir -p "$_repo/$(dirname "$_path")"
+  printf '%s\n' "$_content" > "$_repo/$_path"
+  git -C "$_repo" add "$_path"
+  git -C "$_repo" commit -qm "update $_path"
+}
+
+run_checker() {
+  _registry="$1"
+  shift
+  CHECK_STDOUT="$FIXTURE_ROOT/stdout"
+  CHECK_STDERR="$FIXTURE_ROOT/stderr"
+  python3 "$CHECKER" --registry "$_registry" "$@" >"$CHECK_STDOUT" 2>"$CHECK_STDERR"
+  CHECK_STATUS=$?
+  CHECK_OUTPUT="$(cat "$CHECK_STDOUT"; cat "$CHECK_STDERR")"
+}
+
+# Static distribution and least-privilege workflow contract.
+assert_file_contains ".github/upstreams.json" '"id": "pstack-verification-skills"' \
+  "registry: identifies the pstack import"
+assert_file_contains ".github/upstreams.json" '68836ddaf5697224520f1847d90cdb90ca8babaa' \
+  "registry: pins the reviewed pstack baseline"
+assert_file_contains ".github/upstreams.json" 'pstack/skills/create-verification-skill' \
+  "registry: scopes creator provenance"
+assert_file_contains ".github/upstreams.json" 'pstack/skills/maintain-verification-skill' \
+  "registry: scopes maintainer provenance"
+assert_file_contains ".github/upstreams.json" 'pstack/LICENSE' \
+  "registry: scopes the upstream license"
+
+WORKFLOW=".github/workflows/check-upstream-drift.yml"
+assert_file_contains "$WORKFLOW" "workflow_dispatch:" "workflow: supports manual runs"
+assert_file_contains "$WORKFLOW" "cron:" "workflow: runs on a schedule"
+assert_file_contains "$WORKFLOW" "contents: read" "workflow: grants only read access"
+assert_file_contains "$WORKFLOW" 'GITHUB_STEP_SUMMARY' "workflow: publishes failure evidence"
+assert_file_contains "$WORKFLOW" 'python3 scripts/check-upstream-drift.py' \
+  "workflow: invokes the registered-source checker"
+assert_file_contains "$WORKFLOW" 'status=$?' "workflow: captures the checker status"
+assert_file_contains "$WORKFLOW" 'if [ "$status" -ne 0 ]; then' \
+  "workflow: only non-clean checker status enters the failure branch"
+assert_file_contains "$WORKFLOW" 'exit "$status"' "workflow: propagates checker failures"
+assert_file_matches "$WORKFLOW" 'uses: actions/checkout@[0-9a-f]{40}([[:space:]]|$)' \
+  "workflow: third-party action is pinned to an immutable commit"
+assert_file_contains "$WORKFLOW" "sed 's/^/    /' upstream-drift-report.txt" \
+  "workflow: untrusted diagnostics are rendered as indented code"
+assert_file_contains "$WORKFLOW" 'timeout-minutes: 15' "workflow: has a bounded outer deadline"
+assert_file_contains "$CHECKER" 'CHECK_DEADLINE_SECONDS = 600' \
+  "checker: leaves time to publish evidence before workflow timeout"
+assert_file_contains "$CHECKER" 'RLIMIT_FSIZE' \
+  "checker: Git children have a file-size resource ceiling"
+assert_file_contains "$CHECKER" 'RLIMIT_AS' \
+  "checker: Git children have a memory resource ceiling"
+assert_file_contains "$CHECKER" 'return subprocess.DEVNULL, subprocess.DEVNULL' \
+  "checker: fetch output cannot accumulate in parent memory"
+assert_file_contains "$CHECKER" '"--filter=blob:none"' \
+  "checker: fetch excludes unneeded blob payloads"
+assert_file_not_matches "$WORKFLOW" 'issues:[[:space:]]*write|pull-requests:[[:space:]]*write' \
+  "workflow: cannot open issues or pull requests"
+assert_file_not_matches "$WORKFLOW" 'checkout.*upstream|git[[:space:]]+checkout|git[[:space:]]+merge|git[[:space:]]+cherry-pick' \
+  "workflow: does not apply upstream content"
+
+# Build two local upstreams. One is path-scoped; one monitors the whole repo.
+SCOPED_REPO="$FIXTURE_ROOT/scoped"
+WHOLE_REPO="$FIXTURE_ROOT/whole"
+new_repo "$SCOPED_REPO"
+commit_file "$SCOPED_REPO" "tracked/skill.md" "reviewed"
+SCOPED_BASELINE="$(git -C "$SCOPED_REPO" rev-parse HEAD)"
+commit_file "$SCOPED_REPO" "unrelated/readme.md" "monorepo churn"
+
+new_repo "$WHOLE_REPO"
+commit_file "$WHOLE_REPO" "notice.txt" "reviewed"
+WHOLE_BASELINE="$(git -C "$WHOLE_REPO" rev-parse HEAD)"
+
+CLEAN_REGISTRY="$FIXTURE_ROOT/clean.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"scoped\",\"url\":\"$SCOPED_REPO\",\"ref\":\"refs/heads/main\",\"baseline\":\"$SCOPED_BASELINE\",\"paths\":[\"tracked\"],\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}," \
+  "{\"id\":\"whole\",\"url\":\"$WHOLE_REPO\",\"ref\":\"refs/heads/main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$CLEAN_REGISTRY"
+
+run_checker "$CLEAN_REGISTRY"
+assert_eq "0" "$CHECK_STATUS" "clean: multiple sources succeed"
+assert_eq "" "$(cat "$CHECK_STDOUT")" "clean: stdout is silent"
+assert_eq "" "$(cat "$CHECK_STDERR")" "clean: stderr is silent"
+
+# A failing remote helper can be noisy, but its bounded diagnostic remains actionable.
+NOISY_BIN="$FIXTURE_ROOT/noisy-bin"
+mkdir -p "$NOISY_BIN"
+printf '#!/bin/sh\nprintf "distinctive remote failure\\n" >&2\ni=0; while [ "$i" -lt 2000 ]; do printf "noise-%04d xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n" "$i" >&2; i=$((i + 1)); done\nexit 1\n' \
+  > "$NOISY_BIN/git-remote-noisy"
+chmod +x "$NOISY_BIN/git-remote-noisy"
+NOISY_REGISTRY="$FIXTURE_ROOT/noisy.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"noisy\",\"url\":\"noisy::target\",\"ref\":\"refs/heads/main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$NOISY_REGISTRY"
+PATH="$NOISY_BIN:$PATH" run_checker "$NOISY_REGISTRY"
+assert_eq "1" "$CHECK_STATUS" "bounded diagnostic: failing helper is unavailable"
+assert_contains "$CHECK_OUTPUT" "distinctive remote failure" \
+  "bounded diagnostic: useful fetch evidence survives"
+if [ "$(wc -c < "$CHECK_STDERR")" -le 1000 ]; then
+  assert_eq "bounded" "bounded" "bounded diagnostic: noisy helper cannot flood output"
+else
+  assert_eq "at-most-1000" "$(wc -c < "$CHECK_STDERR")" \
+    "bounded diagnostic: noisy helper cannot flood output"
+fi
+
+# A remote helper that outlives Git must not keep the stderr reader past the deadline.
+printf '#!/bin/sh\nprintf "%s" "$$" > "%s"\nsleep 3\nexit 1\n' '%s' "$FIXTURE_ROOT/hanging-helper.pid" \
+  > "$NOISY_BIN/git-remote-hanging"
+chmod +x "$NOISY_BIN/git-remote-hanging"
+HANGING_REGISTRY="$FIXTURE_ROOT/hanging.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"hanging\",\"url\":\"hanging::target\",\"ref\":\"refs/heads/main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$HANGING_REGISTRY"
+HANGING_STARTED="$(date +%s)"
+PATH="$NOISY_BIN:$PATH" run_checker "$HANGING_REGISTRY" --deadline-seconds 0.1
+HANGING_ELAPSED="$(( $(date +%s) - HANGING_STARTED ))"
+assert_eq "1" "$CHECK_STATUS" "process tree: hanging helper is unavailable"
+if [ "$HANGING_ELAPSED" -lt 2 ]; then
+  assert_eq "bounded" "bounded" "process tree: helper cannot outlive the checker deadline"
+else
+  assert_eq "under-2-seconds" "$HANGING_ELAPSED" \
+    "process tree: helper cannot outlive the checker deadline"
+fi
+
+# Relevant scoped drift and an unavailable ref are both reported in one run.
+commit_file "$SCOPED_REPO" "tracked/skill.md" "changed upstream"
+AGGREGATE_REGISTRY="$FIXTURE_ROOT/aggregate.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"scoped\",\"url\":\"$SCOPED_REPO\",\"ref\":\"refs/heads/main\",\"baseline\":\"$SCOPED_BASELINE\",\"paths\":[\"tracked\"],\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}," \
+  "{\"id\":\"missing-ref\",\"url\":\"$WHOLE_REPO\",\"ref\":\"refs/heads/absent\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}," \
+  "{\"id\":\"missing-remote\",\"url\":\"$FIXTURE_ROOT/absent-repo\",\"ref\":\"refs/heads/main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$AGGREGATE_REGISTRY"
+
+run_checker "$AGGREGATE_REGISTRY"
+assert_eq "1" "$CHECK_STATUS" "aggregate: any non-clean source fails"
+assert_contains "$CHECK_OUTPUT" "drift: scoped" "aggregate: reports scoped drift"
+assert_contains "$CHECK_OUTPUT" "tracked/skill.md" "drift: reports the changed registered path"
+assert_contains "$CHECK_OUTPUT" "$SCOPED_BASELINE" "drift: reports the reviewed baseline"
+assert_contains "$CHECK_OUTPUT" "unavailable: missing-ref" "aggregate: later source failure is not hidden"
+assert_contains "$CHECK_OUTPUT" "unavailable: missing-remote" "aggregate: reports an unavailable remote"
+assert_not_contains "$CHECK_OUTPUT" "unrelated/readme.md" "drift: omits monorepo churn outside the scope"
+
+# Omitting paths makes any repository change load-bearing.
+WHOLE_DRIFT_REGISTRY="$FIXTURE_ROOT/whole-drift.json"
+commit_file "$WHOLE_REPO" "anywhere.txt" "whole repository drift"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"whole\",\"url\":\"$WHOLE_REPO\",\"ref\":\"refs/heads/main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$WHOLE_DRIFT_REGISTRY"
+run_checker "$WHOLE_DRIFT_REGISTRY"
+assert_eq "1" "$CHECK_STATUS" "whole repository: drift fails"
+assert_contains "$CHECK_OUTPUT" "anywhere.txt" "whole repository: reports changes with paths omitted"
+
+# Large diffs remain actionable without flooding CI logs or the workflow summary.
+for number in $(seq 1 25); do
+  mkdir -p "$SCOPED_REPO/tracked"
+  printf 'change %s\n' "$number" > "$SCOPED_REPO/tracked/change-$number.txt"
+done
+git -C "$SCOPED_REPO" add tracked
+git -C "$SCOPED_REPO" commit -qm "many upstream changes"
+run_checker "$AGGREGATE_REGISTRY"
+CHANGED_LINES="$(grep -c '^  changed:' "$CHECK_STDERR")"
+assert_eq "21" "$CHANGED_LINES" "bounded report: caps paths and adds one omission line"
+assert_contains "$CHECK_OUTPUT" "more path(s) omitted" "bounded report: explains truncated evidence"
+
+# Both commits remain fetchable, but the tracked ref no longer descends from the baseline.
+DIVERGED_REPO="$FIXTURE_ROOT/diverged"
+new_repo "$DIVERGED_REPO"
+commit_file "$DIVERGED_REPO" "old.txt" "old history"
+DIVERGED_BASELINE="$(git -C "$DIVERGED_REPO" rev-parse HEAD)"
+git -C "$DIVERGED_REPO" checkout -q --orphan rewritten
+git -C "$DIVERGED_REPO" rm -q -rf .
+commit_file "$DIVERGED_REPO" "new.txt" "rewritten history"
+git -C "$DIVERGED_REPO" branch -M main
+DIVERGED_REGISTRY="$FIXTURE_ROOT/diverged.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"rewritten\",\"url\":\"$DIVERGED_REPO\",\"ref\":\"refs/heads/main\",\"baseline\":\"$DIVERGED_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$DIVERGED_REGISTRY"
+run_checker "$DIVERGED_REGISTRY"
+assert_eq "1" "$CHECK_STATUS" "rewritten history: fails"
+assert_contains "$CHECK_OUTPUT" "history-diverged: rewritten" "rewritten history: requires manual review"
+
+# The entire registry is rejected before the first Git invocation.
+INVALID_REGISTRY="$FIXTURE_ROOT/invalid.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"duplicate\",\"url\":\"never-contact-one\",\"ref\":\"main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"NOTICE.md\"}," \
+  "{\"id\":\"duplicate\",\"url\":\"never-contact-two\",\"ref\":\"main\",\"baseline\":\"not-a-commit\",\"paths\":[\"../escape\"],\"source_notice\":\"/absolute\"}" \
+  ']}' > "$INVALID_REGISTRY"
+
+FAKE_BIN="$FIXTURE_ROOT/bin"
+GIT_MARKER="$FIXTURE_ROOT/git-was-called"
+mkdir -p "$FAKE_BIN"
+printf '#!/bin/sh\nprintf called > "%s"\nexit 99\n' "$GIT_MARKER" > "$FAKE_BIN/git"
+chmod +x "$FAKE_BIN/git"
+CHECK_STDOUT="$FIXTURE_ROOT/invalid-stdout"
+CHECK_STDERR="$FIXTURE_ROOT/invalid-stderr"
+PATH="$FAKE_BIN:$PATH" python3 "$CHECKER" --registry "$INVALID_REGISTRY" >"$CHECK_STDOUT" 2>"$CHECK_STDERR"
+CHECK_STATUS=$?
+CHECK_OUTPUT="$(cat "$CHECK_STDOUT"; cat "$CHECK_STDERR")"
+assert_eq "2" "$CHECK_STATUS" "invalid registry: uses configuration-error status"
+assert_contains "$CHECK_OUTPUT" "invalid registry" "invalid registry: labels the failure"
+assert_contains "$CHECK_OUTPUT" "duplicate" "invalid registry: names the duplicate ID"
+assert_contains "$CHECK_OUTPUT" "baseline" "invalid registry: names malformed fields"
+if [ -e "$GIT_MARKER" ]; then
+  assert_eq "not-called" "called" "invalid registry: validates everything before Git/network"
+else
+  assert_eq "not-called" "not-called" "invalid registry: validates everything before Git/network"
+fi
+
+INVALID_REF_REGISTRY="$FIXTURE_ROOT/invalid-ref.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"invalid-ref\",\"url\":\"never-contact\",\"ref\":\"refs/heads/bad ref\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$INVALID_REF_REGISTRY"
+rm -f "$GIT_MARKER"
+PATH="$FAKE_BIN:$PATH" run_checker "$INVALID_REF_REGISTRY"
+assert_eq "2" "$CHECK_STATUS" "invalid ref: uses configuration-error status"
+assert_contains "$CHECK_OUTPUT" "ref" "invalid ref: names the malformed field"
+if [ -e "$GIT_MARKER" ]; then
+  assert_eq "not-called" "called" "invalid ref: rejected before Git/network"
+else
+  assert_eq "not-called" "not-called" "invalid ref: rejected before Git/network"
+fi
+
+# Control characters fail validation instead of reaching subprocess as invalid arguments.
+CONTROL_REGISTRY="$FIXTURE_ROOT/control.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"control\",\"url\":\"bad\\u0000url\",\"ref\":\"main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"THIRD_PARTY_NOTICES.md\"}" \
+  ']}' > "$CONTROL_REGISTRY"
+run_checker "$CONTROL_REGISTRY"
+assert_eq "2" "$CHECK_STATUS" "control character: invalid registry status"
+assert_contains "$CHECK_OUTPUT" "bounded string" "control character: actionable field error"
+assert_not_contains "$CHECK_OUTPUT" "Traceback" "control character: no uncaught subprocess error"
+
+# Attribution paths are part of registry validity, not passive metadata.
+MISSING_NOTICE_REGISTRY="$FIXTURE_ROOT/missing-notice.json"
+printf '%s\n' \
+  '{"version":1,"sources":[' \
+  "{\"id\":\"missing-notice\",\"url\":\"$WHOLE_REPO\",\"ref\":\"refs/heads/main\",\"baseline\":\"$WHOLE_BASELINE\",\"source_notice\":\"missing-notice.md\"}" \
+  ']}' > "$MISSING_NOTICE_REGISTRY"
+run_checker "$MISSING_NOTICE_REGISTRY"
+assert_eq "2" "$CHECK_STATUS" "missing notice: invalid registry status"
+assert_contains "$CHECK_OUTPUT" "existing file" "missing notice: actionable path error"
+
+# A standard absolute registry path resolves repository-relative notices even outside the repo.
+OUTSIDE_STDOUT="$FIXTURE_ROOT/outside-stdout"
+OUTSIDE_STDERR="$FIXTURE_ROOT/outside-stderr"
+(cd "$FIXTURE_ROOT" && python3 "$CHECKER" \
+  --registry "$REPO/.github/upstreams.json" --deadline-seconds 0.000001 \
+  >"$OUTSIDE_STDOUT" 2>"$OUTSIDE_STDERR")
+OUTSIDE_STATUS=$?
+OUTSIDE_OUTPUT="$(cat "$OUTSIDE_STDOUT"; cat "$OUTSIDE_STDERR")"
+assert_eq "1" "$OUTSIDE_STATUS" "repository root: absolute standard registry validates outside repo"
+assert_not_contains "$OUTSIDE_OUTPUT" "existing file" "repository root: notice resolves against registry repo"
+
+# An exhausted total deadline still reports every source instead of timing out in CI.
+run_checker "$AGGREGATE_REGISTRY" --deadline-seconds 0.000001
+assert_eq "1" "$CHECK_STATUS" "deadline: non-clean status"
+assert_contains "$CHECK_OUTPUT" "unavailable: scoped" "deadline: reports first source"
+assert_contains "$CHECK_OUTPUT" "unavailable: missing-remote" "deadline: reports later sources"
+
+for invalid_deadline in nan inf; do
+  run_checker "$CLEAN_REGISTRY" --deadline-seconds "$invalid_deadline"
+  assert_eq "2" "$CHECK_STATUS" "deadline: rejects $invalid_deadline"
+done
+
+finish

--- a/tests/test-verification-skill-integration.sh
+++ b/tests/test-verification-skill-integration.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Contract for the vendored pstack verification-skill authoring workflow.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+CREATOR=.agents/skills/create-verification-skill/SKILL.md
+MAINTAINER=.agents/skills/maintain-verification-skill/SKILL.md
+EXAMPLE=.agents/skills/create-verification-skill/references/feature-map-example
+NOTICE_TEXT="$(awk '/^> MIT License$/ { found=1 }
+  found && /^>/ { sub(/^> ?/, ""); print; next }
+  found { exit }' THIRD_PARTY_NOTICES.md)"
+MIT_LICENSE_BLOB=6b5400237fdf6545be0b8fae370d6f2fcff8fb25
+
+for skill in create-verification-skill maintain-verification-skill; do
+  canonical=".agents/skills/$skill/SKILL.md"
+  compat=".claude/skills/$skill/SKILL.md"
+  frontmatter="$(awk 'NR == 1 && /^---$/ { in_frontmatter=1; next }
+    in_frontmatter && /^---$/ { exit }
+    in_frontmatter { print }' "$canonical" 2>/dev/null)"
+  assert_contains "$frontmatter" "name: $skill" "$skill: valid frontmatter name"
+  assert_contains "$frontmatter" "description:" "$skill: description is present"
+  assert_contains "$frontmatter" "disable-model-invocation: false" "$skill: model invocation is enabled"
+  assert_contains "$frontmatter" "harness: universal" "$skill: harness-neutral registration"
+  assert_files_identical "$canonical" "$compat" "$skill: canonical and Claude copies match"
+  assert_file_contains ".agents/skills/$skill/LICENSE.pstack" "Copyright (c) 2026 Lauren Tan" \
+    "$skill: standalone canonical copy bundles attribution"
+  assert_file_contains ".claude/skills/$skill/LICENSE.pstack" "Permission is hereby granted" \
+    "$skill: standalone Claude copy bundles the MIT grant"
+  assert_files_identical ".agents/skills/$skill/LICENSE.pstack" ".claude/skills/$skill/LICENSE.pstack" \
+    "$skill: bundled notices match across trees"
+  assert_eq "$NOTICE_TEXT" "$(cat ".agents/skills/$skill/LICENSE.pstack")" \
+    "$skill: bundled license matches the complete repository notice"
+  assert_eq "$MIT_LICENSE_BLOB" "$(git hash-object ".agents/skills/$skill/LICENSE.pstack")" \
+    "$skill: bundled license matches the reviewed MIT text exactly"
+done
+
+for section in Launch Doctor Drive Evidence Cleanup Helpers; do
+  assert_file_contains "$CREATOR" "**$section:**" "creator: generated skill requires $section"
+done
+assert_file_contains "$CREATOR" "Surface and capability ceiling" \
+  "creator: generated skill declares its surface and capability ceiling"
+assert_file_contains "$CREATOR" 'canonical `.agents/skills/` tree' \
+  "creator: canonical generated path"
+assert_file_contains "$CREATOR" 'compatibility `.claude/skills/` tree' \
+  "creator: mirrored generated path"
+assert_file_contains "$CREATOR" "byte-identical" "creator: generated trees stay byte-identical"
+assert_file_contains "$CREATOR" "top 3-5" "creator: seeds a bounded feature map"
+assert_file_contains "$CREATOR" "evidence still exists" "creator: proof survives cleanup"
+assert_file_not_matches "$CREATOR" 'TBD|PLACEHOLDER|TODO:' \
+  "creator: contains no unfinished authoring placeholders"
+assert_file_contains "$CREATOR" "Never kill by process name" \
+  "creator: explicitly forbids process-name cleanup"
+assert_file_not_matches "$CREATOR" '(^|[[:space:]`])(pkill|killall)([[:space:]`]|$)' \
+  "creator: contains no unsafe process-name cleanup command"
+
+FEATURE_LINKS="$(sed -n '/^## Features$/,$p' "$EXAMPLE/README.md" | sed -n 's/.*](\.\/\([^)]*\.md\)).*/\1/p')"
+for feature in $FEATURE_LINKS; do
+  headings="$(grep '^## ' "$EXAMPLE/$feature" 2>/dev/null)"
+  assert_eq "4" "$(printf '%s\n' "$headings" | grep -c '^## ')" \
+    "feature example: $feature has exactly four H2 sections"
+  assert_eq "## Sub-features" "$(printf '%s\n' "$headings" | sed -n '1p')" \
+    "feature example: $feature starts with Sub-features"
+  assert_eq "## How to get to it (user POV)" "$(printf '%s\n' "$headings" | sed -n '2p')" \
+    "feature example: $feature next documents user entry points"
+  assert_contains "$(printf '%s\n' "$headings" | sed -n '3p')" "## Driving it with " \
+    "feature example: $feature next documents its driving harness"
+  assert_eq "## Gotchas" "$(printf '%s\n' "$headings" | sed -n '4p')" \
+    "feature example: $feature ends with Gotchas"
+done
+assert_file_contains "$EXAMPLE/README.md" "## Features" "feature example: indexed map"
+assert_file_contains "$EXAMPLE/README.md" "every user entry point" \
+  "feature example: every entry point is independently accounted for"
+FEATURE_COUNT="$(printf '%s\n' "$FEATURE_LINKS" | sed '/^$/d' | wc -l)"
+if [ "$FEATURE_COUNT" -ge 3 ] && [ "$FEATURE_COUNT" -le 5 ]; then
+  assert_eq "bounded" "bounded" "feature example: contains 3-5 indexed entries"
+else
+  assert_eq "3-5" "$FEATURE_COUNT" "feature example: contains 3-5 indexed entries"
+fi
+for feature in $FEATURE_LINKS; do
+  if [ -f "$EXAMPLE/$feature" ]; then
+    assert_eq "exists" "exists" "feature example: indexed target $feature exists"
+  else
+    assert_eq "exists" "missing" "feature example: indexed target $feature exists"
+  fi
+done
+assert_eq "$(find "$EXAMPLE" -maxdepth 1 -type f -name '*.md' ! -name README.md -printf '%f\n' | sort)" \
+  "$(printf '%s\n' "$FEATURE_LINKS" | sort)" \
+  "feature example: every feature file is indexed exactly once"
+
+assert_file_contains "$MAINTAINER" "--scope changed" "maintainer: changed-scope mode"
+assert_file_contains "$MAINTAINER" "session intent" "maintainer: changed mode consumes session intent"
+assert_file_contains "$MAINTAINER" "base-to-HEAD diff" "maintainer: changed mode consumes the diff"
+assert_file_contains "$MAINTAINER" "internal-only" "maintainer: changed mode skips internal-only work"
+assert_file_contains "$MAINTAINER" "active branch" "maintainer: changed mode edits the active branch"
+assert_file_contains "$MAINTAINER" "idempotent" "maintainer: changed mode is idempotent"
+assert_file_contains "$MAINTAINER" "count candidates before validating their contents" \
+  "maintainer: counts every verify-* candidate before target validation"
+assert_file_contains "$MAINTAINER" 'candidate set as `/verify --scope e2e`' \
+  "maintainer: shares verify's ambiguity boundary"
+assert_file_contains "$MAINTAINER" "one read-only subagent per feature" \
+  "maintainer: full mode has independent source coverage"
+assert_file_contains "$MAINTAINER" "Exercise every feature" \
+  "maintainer: full mode drives every feature"
+for outcome in clean changed blocked; do
+  assert_file_matches "$MAINTAINER" "^- \\*\\*$outcome\\*\\*" \
+    "maintainer: declares exact $outcome outcome"
+done
+OUTCOMES="$(awk '/^## Outcomes$/ { found=1; next } found && /^## / { exit } found { print }' "$MAINTAINER" \
+  | sed -n 's/^- \*\*\([^*]*\)\*\*.*/\1/p')"
+assert_eq "$(printf '%s\n' clean changed blocked)" "$OUTCOMES" \
+  "maintainer: clean, changed, and blocked are the only outcomes"
+assert_file_contains "$MAINTAINER" "Only edit" "maintainer: confines edits to verification skill"
+assert_file_contains "$MAINTAINER" "does not open a separate PR" \
+  "maintainer: changed-scope mode does not own a PR"
+assert_file_contains "$MAINTAINER" "at most one PR" \
+  "maintainer: full mode owns at most one correction PR"
+
+assert_file_contains THIRD_PARTY_NOTICES.md "MIT License" "provenance: full MIT notice"
+assert_file_contains THIRD_PARTY_NOTICES.md "does not declare a license for the repository as a whole" \
+  "provenance: MIT scope is limited to derived material"
+assert_file_contains THIRD_PARTY_NOTICES.md "Copyright (c) 2026 Lauren Tan" \
+  "provenance: upstream copyright"
+assert_file_contains THIRD_PARTY_NOTICES.md "https://github.com/cursor/plugins" \
+  "provenance: upstream repository"
+assert_file_contains THIRD_PARTY_NOTICES.md "pstack/skills/create-verification-skill/SKILL.md" \
+  "provenance: creator source path"
+assert_file_contains THIRD_PARTY_NOTICES.md "pstack/skills/maintain-verification-skill/SKILL.md" \
+  "provenance: maintainer source path"
+assert_file_contains THIRD_PARTY_NOTICES.md "68836ddaf5697224520f1847d90cdb90ca8babaa" \
+  "provenance: pinned revision"
+assert_file_contains README.md "cursor/plugins" "README: pstack source credit"
+
+finish


### PR DESCRIPTION
## Summary

- add harness-neutral `/create-verification-skill` and `/maintain-verification-skill` adaptations with byte-identical Claude mirrors, grounded feature-map references, and preserved pstack MIT attribution
- route changed user-facing behavior through verification-map maintenance before E2E while preserving fail-closed backend/capability selection
- add a general upstream registry, resource-bounded Git drift checker, and least-privilege weekly/manual workflow pinned to immutable actions

## Verification

- `bash tests/run.sh` — all 25 test files passed after rebasing onto current `master`
- `tests/test-verification-skill-integration.sh` — 82 assertions passed
- `tests/test-upstream-drift.sh` — 64 assertions passed
- `tests/test-task-registry.sh` — 277 assertions passed alongside the pstack changes
- `tests/test-skill-invocation-chain.sh` — 64 assertions passed
- `tests/test-skill-parity.sh` — 69 assertions passed
- live `python3 scripts/check-upstream-drift.py` — exit 0, silent clean result
- security recheck — Python/shell syntax, secret/dangerous-execution scan, workflow permissions, and `git diff --check` clean

## Review

Three independently dispatched review lenses plus one inline adversarial pass found 13 issues; all were resolved. Notable corrections aligned raw `verify-*` candidate discovery, closed false-green contract tests, validated Git refs before network access, bounded fetch resources and diagnostics, terminated hung helper process trees, protected workflow-summary integrity, and pinned `actions/checkout` by commit.

## Merge resolution

Rebased onto `master` at `5bdb464`. The sole content conflict was the append-only `tasks/todo.md` register; it was resolved by retaining both task-registry plan blocks followed by the complete pstack plan. The auto-merged skill lifecycle and invocation chains were verified together. The rebase also exposed a pre-existing task-registry canonical/Claude reference mismatch from `master`; commit `f06f1d8` restores byte parity and records the investigation.

## Provenance

Adapted from cursor/plugins pstack at `68836ddaf5697224520f1847d90cdb90ca8babaa`; the full upstream MIT notice is preserved in `THIRD_PARTY_NOTICES.md` and bundled with both imported skills.
