### PR TITLE
chore(tidy): fix flaky task-registry doctor test, reconcile skill/agent tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,7 @@ authorization unless the project's configuration enables them.
 | `/prd` | Greenfield project interview → PRD + backlog + context file |
 | `/brainstorm` | Divergent design exploration before `/plan` |
 | `/plan` | Interview → spec → task breakdown in `tasks/todo.md` |
+| `/visual-plan` | Turn an existing text spec into a rich, self-contained HTML visual plan for review before implementation |
 | `/build` | Autonomous TDD orchestrator with sub-agent delegation |
 | `/auto-push` | One approval gate at `/plan`, then `/build` + `/wrap-up-session` run autonomously through commit and push |
 | `/yolo` | Ralph-style full-auto loop: `/plan` (auto-confirmed) → `/build` → `/wrap-up-session`, iterating until backlog empty or circuit breaker |
@@ -444,6 +445,7 @@ authorization unless the project's configuration enables them.
 | `/quality-gate` | 3-phase post-build review: structural quality, AI anti-patterns, APOSD design |
 | `/software-design-expert-review` | APOSD structural design gate — depth, leakage, error design; GO/HOLD/STOP verdict |
 | `/software-design-expert-learn` | APOSD design tutorial — end-of-session learning review based on Ousterhout |
+| `/html-presentation` | Generate a polished, self-contained HTML presentation (report or slide-deck) from structured content |
 | `/receive-review` | Process code review feedback with pushback protocol |
 | `/learn` | Extract session learnings → typed documents in `tasks/solutions/` |
 | `/memory-maintain` | Sweep the typed learning store — resolve, merge, prune — every 5 sessions |
@@ -452,6 +454,7 @@ authorization unless the project's configuration enables them.
 | `/security-scan` | OWASP-focused audit on recently changed files |
 | `/start-qa` | Restart app + health check + browser with log monitoring |
 | `/wrap-up-session` | Learnings, tests, reviews, commit, push |
+| `/visual-recap` | Turn a completed branch's git diff into a self-contained HTML visual recap for review |
 | `/writing-skills` | Author new skills with proper structure |
 | `/task-registry` | Sync `tasks/todo.md` with GitHub Issues, Jira, or a local Markdown store; reconcile stale plans; dependency-aware frontier |
 | `/eval` | Blinded A/B eval of a skill or prompt change before promoting it |

--- a/README.md
+++ b/README.md
@@ -261,21 +261,32 @@ Invoke with `/skill-name` in any Claude Code session:
 
 | Skill | What It Does |
 |-------|-------------|
+| `/prd` | Greenfield project interview → PRD + backlog + context file |
 | `/brainstorm` | Divergent design exploration: 2-3 approaches with trade-offs, design approval before `/plan` |
 | `/plan` | Interviews you, writes spec to `specs/`, creates TDD task plan in `tasks/todo.md` |
+| `/visual-plan` | Turn an existing text spec into a rich, self-contained HTML visual plan for review before implementation |
 | `/build` | Autonomous orchestrator: TDD + sub-agents + 2-stage review + parallel dispatch + quality-gate + spec validation |
+| `/auto-push` | One approval gate at `/plan`, then `/build` + `/wrap-up-session` run autonomously through commit and push |
+| `/yolo` | Ralph-style full-auto loop: `/plan` (auto-confirmed) → `/build` → `/wrap-up-session`, iterating until backlog empty or circuit breaker |
+| `/auto-improve` | Unattended discover→fix loop: survey backlog/tech-debt/tests/perf/design, ship one high-value improvement as a PR. Built for daily cloud runs |
 | `/tdd` | Manual TDD loop with user checkpoints: failing test → code → pass → refactor → `[x]` |
 | `/debug` | Root cause analysis with architecture questioning after 3 fails, bug-track store documents |
 | `/verify` | Evidence-based verification gate — no completion claims without fresh command output |
 | `/create-verification-skill` | Discover an app's real user surface, generate its `verify-<app>` recipe and feature map, then prove one feature live |
 | `/maintain-verification-skill` | Reconcile changed user behavior with `--scope changed`, or run a full audit of the complete feature map |
 | `/quality-gate` | 3-phase post-build review: structural quality, AI anti-patterns, APOSD design |
+| `/software-design-expert-review` | APOSD structural design gate — depth, leakage, error design; GO/HOLD/STOP verdict |
+| `/software-design-expert-learn` | APOSD design tutorial — end-of-session learning review based on Ousterhout |
+| `/html-presentation` | Generate a polished, self-contained HTML presentation (report or slide-deck) from structured content |
 | `/receive-review` | Process code review feedback: technical evaluation, pushback protocol, no performative agreement |
 | `/learn` | Extracts session learnings into typed documents under `tasks/solutions/` |
+| `/memory-maintain` | Sweep the typed learning store — resolve, merge, prune — every 5 sessions |
 | `/checkpoint` | Saves progress snapshot to `tasks/checkpoint.md` for handoff or pause |
+| `/refresh` | Context reset — snapshot state to disk, then rebuild from a clean context (backstop for long tasks) |
 | `/security-scan` | Audits changed files against OWASP top 10; blocks commit on HIGH/MEDIUM |
 | `/start-qa` | Discover project config, restart app, launch browser, background smoke tests |
 | `/wrap-up-session` | Parallel code review → verify → merge worktree → sync learnings → run tests → push |
+| `/visual-recap` | Turn a completed branch's git diff into a self-contained HTML visual recap for review |
 | `/writing-skills` | Author new skills with proper structure, iron laws, and reference docs |
 | `/eval` | Blinded A/B eval of a skill, prompt, or workflow change: sanitized worktrees, organic prompts, transcript-based grading |
 | `/sync` | Pull latest skills, hooks, agents from template repo into current project |
@@ -316,7 +327,9 @@ Claude delegates to these automatically (or you can invoke them via the Agent to
 | `code-reviewer` | Post-implementation quality review (invoked proactively) |
 | `code-debugger` | Debugging failing tests and runtime errors |
 | `security-reviewer` | OWASP checks, auth flows, injection vectors |
+| `critic` | Adversarial quality gate for plans, code, and specs |
 | `context-document-optimizer` | Compress large docs for token efficiency |
+| `software-design-expert-review` | Read-only APOSD design audit — depth, leakage, error design (dispatched by `/quality-gate`) |
 
 ---
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -1,0 +1,10 @@
+# Backlog
+
+Ordered work items. Judgment-call proposals from automated hygiene runs land here rather
+than being auto-applied.
+
+- [ ] `/tidy` (2026-08-31): `CLAUDE.md`'s skill table (§ Skills) lists `` `/graphify` `` as if it
+      were a repo skill, but no such skill exists under `.agents/skills/` or `.claude/skills/` —
+      `graphify` is an external `pip`-installed CLI tool documented separately in README.md
+      § "Optional — graphify code graph". Decide whether to remove the row, or reformat it to
+      make clear it is an external tool rather than a `/`-invocable skill.

--- a/tests/test-task-registry.sh
+++ b/tests/test-task-registry.sh
@@ -1264,6 +1264,7 @@ provider = github
 require_write_approval = false
 EOF
 printf '```\n' >> "$F_FLOOR/docs/task-tracking.md"
+install_gh_mock "$F_FLOOR"
 floor_out="$(cd "$F_FLOOR" && pyreg <<'EOF'
 from registry.config import load_config
 plain = load_config(".", env={})
@@ -1279,7 +1280,8 @@ assert_contains "$floor_out" "ignored-flag=True" \
   "Config: the ignored relaxation is recorded so doctor can say so"
 assert_contains "$floor_out" "trusted=False" \
   "Config: an operator who trusts the repository can lower the floor"
-floor_doctor="$(run doctor --repo "$F_FLOOR" 2>&1)"
+floor_doctor="$(cd "$F_FLOOR" && PATH="$F_FLOOR/bin:$PATH" GH_MOCK_DIR="$F_FLOOR/ghdata" \
+  run doctor --repo "$F_FLOOR" 2>&1)"
 assert_contains "$floor_doctor" "approval is a floor" \
   "Doctor: the refused relaxation is visible to the user"
 


### PR DESCRIPTION
Automated repo-hygiene run (`/tidy`), unattended in a fresh cloud checkout.

## Checks run

- [x] **SUITE** — `bash tests/run.sh`. First run found 1 failing assertion (see below); fixed it, then re-ran twice more to confirm. **All 26 test files, 277+ assertions green** on the final run.
- [x] **TABLES** — compared `.agents/skills/` and `.claude/agents/` on disk against the skill/agent tables in `CLAUDE.md` and `README.md` (`AGENTS.md` carries no skill/agent table of its own — it only imports `CLAUDE.md`, so nothing to reconcile there). Found and fixed several gaps (below).
- [x] **REFS** — every backtick-quoted file path in `CLAUDE.md`, `README.md`, `AGENTS.md`, `PI_SETUP.md`, `.claude/project.md` resolves. Delegated to a sub-agent for a careful pass (exact path, then basename fallback); nothing broken found. (One plain-prose, non-backtick reference — `docs/task-tracking.md` in `CLAUDE.md` — is intentionally absent, same pattern as the `Deployment Targets` placeholder: this is the template repo itself, with no project-specific tracker configured.)
- [x] **DOC FAN-OUT** — reconciled the skill/agent tables that had drifted between `CLAUDE.md` and `README.md` (see below). `PI_SETUP.md` and `project-template/` carry no skill/agent tables, so nothing to reconcile there.
- [x] **PARITY** — `.agents/skills/` vs `.claude/skills/`: byte-identical except the allowlisted Claude-only extras (`README.md`, `setup-deployment/`, `verify-deployment/`). The one incidental divergence found (`.agents/skills/task-registry/scripts/__pycache__/`) was a `.gitignore`d bytecode cache generated by my own investigation commands, not a repo defect — removed it before committing (nothing to commit there, it was never tracked).

## Fixes made

1. **`tests/test-task-registry.sh`** — the assertion `Doctor: the refused relaxation is visible to the user` invoked `task-registry.py doctor --repo <fixture>` against a fixture configured with `provider = github`, but — unlike every other GitHub-provider case in this file — never set up the `gh` mock (`install_gh_mock` + scoped `PATH`/`GH_MOCK_DIR`). On a host without a real `gh` CLI installed (this sandbox included), `doctor` fails at `registry.provider.discover()` with `github: the \`gh\` CLI is not installed` before it ever reaches the approval-floor message the assertion is checking for — so the assertion was environment-dependent and could silently never exercise its real intent. Wired up the mock the same way the rest of the file does. Verified: `bash tests/test-task-registry.sh` now passes all 277 assertions; reproduced the original failure first by running the untouched test standalone.
2. **`CLAUDE.md`** — added the three skill-table rows missing for skills that exist under `.agents/skills/` but weren't listed: `/visual-plan`, `/html-presentation`, `/visual-recap`.
3. **`README.md`** — brought the `## Skills` table in sync with `CLAUDE.md`'s (added `/prd`, `/auto-push`, `/yolo`, `/auto-improve`, `/software-design-expert-review`, `/software-design-expert-learn`, `/html-presentation`, `/memory-maintain`, `/refresh`, `/visual-plan`, `/visual-recap`, all copied verbatim from `CLAUDE.md`'s existing one-liners where available), and added the two missing rows to `## Agents` (`critic`, `software-design-expert-review`).
4. **`tasks/backlog.md`** (new) — recorded one judgment-call proposal, not auto-applied: `CLAUDE.md`'s skill table lists `` `/graphify` `` as if it were a `.agents/skills/` skill, but `graphify` is actually an external `pip`-installed CLI tool (documented separately in `README.md` § "Optional — graphify code graph") with no entry under `.agents/skills/` or `.claude/skills/`. Whether to remove the row or reformat it to mark it as an external tool is a call for a human, not this run.

## Not verified / out of scope

- Local-machine artifacts (git worktrees under `.claude/worktrees/`, the installed `~/.claude/` copy) — this run executes in a fresh cloud checkout where those don't exist by construction, per the routine's own scoping instructions. A separate local hook covers those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUMmey76VKvvMLVnpWYFL8)_