### PR TITLE
tidy: fix doctor crash when gh is missing; reconcile skill/agent tables

### DIFF
--- a/.agents/skills/task-registry/scripts/registry/providers/github.py
+++ b/.agents/skills/task-registry/scripts/registry/providers/github.py
@@ -71,7 +71,10 @@ class GitHubProvider(TrackerProvider):
 
     # ---------------------------------------------------------------- discovery
     def discover(self) -> ProviderStatus:
-        code, output = self._run(["gh", "auth", "status"], check=False)
+        try:
+            code, output = self._run(["gh", "auth", "status"], check=False)
+        except ProviderUnavailable as exc:
+            return ProviderStatus(False, str(exc))
         if code != 0:
             return ProviderStatus(
                 False,
@@ -79,10 +82,13 @@ class GitHubProvider(TrackerProvider):
                 f"({self.redact(output.strip().splitlines()[-1]) if output.strip() else 'no output'})",
             )
         if not self.repository:
-            code, output = self._run(
-                ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-                check=False,
-            )
+            try:
+                code, output = self._run(
+                    ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+                    check=False,
+                )
+            except ProviderUnavailable as exc:
+                return ProviderStatus(False, str(exc))
             if code != 0:
                 return ProviderStatus(False, "no repository configured and `gh repo view` failed")
             self.repository = output.strip()

--- a/.claude/skills/task-registry/scripts/registry/providers/github.py
+++ b/.claude/skills/task-registry/scripts/registry/providers/github.py
@@ -71,7 +71,10 @@ class GitHubProvider(TrackerProvider):
 
     # ---------------------------------------------------------------- discovery
     def discover(self) -> ProviderStatus:
-        code, output = self._run(["gh", "auth", "status"], check=False)
+        try:
+            code, output = self._run(["gh", "auth", "status"], check=False)
+        except ProviderUnavailable as exc:
+            return ProviderStatus(False, str(exc))
         if code != 0:
             return ProviderStatus(
                 False,
@@ -79,10 +82,13 @@ class GitHubProvider(TrackerProvider):
                 f"({self.redact(output.strip().splitlines()[-1]) if output.strip() else 'no output'})",
             )
         if not self.repository:
-            code, output = self._run(
-                ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-                check=False,
-            )
+            try:
+                code, output = self._run(
+                    ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+                    check=False,
+                )
+            except ProviderUnavailable as exc:
+                return ProviderStatus(False, str(exc))
             if code != 0:
                 return ProviderStatus(False, "no repository configured and `gh repo view` failed")
             self.repository = output.strip()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,4 +457,7 @@ authorization unless the project's configuration enables them.
 | `/eval` | Blinded A/B eval of a skill or prompt change before promoting it |
 | `/sync` | Pull latest skills, hooks, agents from template repo |
 | `/folder-context-optimization` | Sweep folder for legacy/unused files |
+| `/visual-plan` | Turn a text spec into a rich, self-contained HTML visual plan for review before implementation |
+| `/visual-recap` | Turn a completed branch's git diff into a self-contained HTML visual recap |
+| `/html-presentation` | Generate a polished, self-contained HTML presentation (report or slide-deck) from structured content |
 | `/graphify` | Build a navigable code knowledge graph (clustered communities, HTML + JSON + report) |

--- a/README.md
+++ b/README.md
@@ -261,22 +261,33 @@ Invoke with `/skill-name` in any Claude Code session:
 
 | Skill | What It Does |
 |-------|-------------|
+| `/prd` | Greenfield project interview → PRD + backlog + context file |
 | `/brainstorm` | Divergent design exploration: 2-3 approaches with trade-offs, design approval before `/plan` |
 | `/plan` | Interviews you, writes spec to `specs/`, creates TDD task plan in `tasks/todo.md` |
 | `/build` | Autonomous orchestrator: TDD + sub-agents + 2-stage review + parallel dispatch + quality-gate + spec validation |
+| `/auto-push` | One approval gate at `/plan`, then `/build` + `/wrap-up-session` run autonomously through commit and push |
+| `/yolo` | Ralph-style full-auto loop: `/plan` (auto-confirmed) → `/build` → `/wrap-up-session`, iterating until backlog empty or circuit breaker |
+| `/auto-improve` | Unattended discover→fix loop: survey backlog/tech-debt/tests/perf/design, ship one high-value improvement as a PR |
 | `/tdd` | Manual TDD loop with user checkpoints: failing test → code → pass → refactor → `[x]` |
 | `/debug` | Root cause analysis with architecture questioning after 3 fails, bug-track store documents |
 | `/verify` | Evidence-based verification gate — no completion claims without fresh command output |
 | `/create-verification-skill` | Discover an app's real user surface, generate its `verify-<app>` recipe and feature map, then prove one feature live |
 | `/maintain-verification-skill` | Reconcile changed user behavior with `--scope changed`, or run a full audit of the complete feature map |
 | `/quality-gate` | 3-phase post-build review: structural quality, AI anti-patterns, APOSD design |
+| `/software-design-expert-review` | APOSD structural design gate — depth, leakage, error design; GO/HOLD/STOP verdict |
+| `/software-design-expert-learn` | APOSD design tutorial — end-of-session learning review based on Ousterhout |
 | `/receive-review` | Process code review feedback: technical evaluation, pushback protocol, no performative agreement |
 | `/learn` | Extracts session learnings into typed documents under `tasks/solutions/` |
+| `/memory-maintain` | Sweep the typed learning store — resolve, merge, prune — every 5 sessions |
 | `/checkpoint` | Saves progress snapshot to `tasks/checkpoint.md` for handoff or pause |
+| `/refresh` | Context reset — snapshot state to disk, then rebuild from a clean context (backstop for long tasks) |
 | `/security-scan` | Audits changed files against OWASP top 10; blocks commit on HIGH/MEDIUM |
 | `/start-qa` | Discover project config, restart app, launch browser, background smoke tests |
 | `/wrap-up-session` | Parallel code review → verify → merge worktree → sync learnings → run tests → push |
 | `/writing-skills` | Author new skills with proper structure, iron laws, and reference docs |
+| `/visual-plan` | Turn a text spec into a rich, self-contained HTML visual plan for review before implementation |
+| `/visual-recap` | Turn a completed branch's git diff into a self-contained HTML visual recap |
+| `/html-presentation` | Generate a polished, self-contained HTML presentation (report or slide-deck) from structured content |
 | `/eval` | Blinded A/B eval of a skill, prompt, or workflow change: sanitized worktrees, organic prompts, transcript-based grading |
 | `/sync` | Pull latest skills, hooks, agents from template repo into current project |
 | `/task-registry` | Sync `tasks/todo.md` with GitHub Issues, Jira, or a local Markdown store |
@@ -316,7 +327,9 @@ Claude delegates to these automatically (or you can invoke them via the Agent to
 | `code-reviewer` | Post-implementation quality review (invoked proactively) |
 | `code-debugger` | Debugging failing tests and runtime errors |
 | `security-reviewer` | OWASP checks, auth flows, injection vectors |
+| `critic` | Adversarial quality gate for plans, code, specs |
 | `context-document-optimizer` | Compress large docs for token efficiency |
+| `software-design-expert-review` | Read-only APOSD design audit — depth, leakage, error design |
 
 ---
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -1,0 +1,11 @@
+# Backlog
+
+Judgment-call proposals surfaced by `/tidy` (repo-hygiene routine) that were not
+mechanically fixable. One line each; promote to a real task when picked up.
+
+- [ ] CLAUDE.md's Skills table (`## Skills — .agents/skills/`) lists `/graphify`
+  alongside real `.agents/skills/` entries, but `graphify` is an external
+  pip-installed CLI (see README.md § "Optional — graphify code graph"), not a
+  file under `.agents/skills/`. Decide whether to drop the row, move it out of
+  the table into prose, or add a footnote marking it as an optional external
+  integration.


### PR DESCRIPTION
Automated repo-hygiene run (`/tidy`). Findings and fixes below.

## Checks run

- [x] **SUITE** — `bash tests/run.sh`. Found one real failure (below), fixed it, then re-ran the full suite twice more (once green, once after the doc edits) — both clean: `all 26 test files passed`.
- [x] **TABLES** — compared `.agents/skills/` and `.claude/agents/` against the skill/agent tables in `CLAUDE.md` and `README.md`. Found and fixed several gaps (below). `AGENTS.md` has no skill/agent table (by design — it only carries Pi-specific rules), so nothing to check there.
- [x] **REFS** — every backtick-quoted path in `CLAUDE.md`, `README.md`, `AGENTS.md`, `PI_SETUP.md`, `.claude/project.md`. All resolve (two, `session-start.sh` and `auto-test-runner.sh`, resolve by basename under `.claude/hooks/`; the intentionally-absent list — `CLAUDE.local.md`, `tasks/backlog.md`, `graphify-out/graph.json`, `models.json`, `tasks/deploy-state.json` — was skipped as instructed). No fixes needed.
- [x] **DOC FAN-OUT** — reconciled the skill/agent tables across `CLAUDE.md` and `README.md` (see below).
- [x] **PARITY** — `diff -rq .agents/skills .claude/skills`, allowing the documented Claude-only extras (`README.md`, `setup-deployment/`, `verify-deployment/`). Clean — the only other diff was a gitignored `__pycache__` directory left over from running the tests, not a real divergence.

## Fixes

- [ ] **Bug**: `github.py`'s `discover()` let a missing `gh` binary raise `ProviderUnavailable` straight out of `doctor`, crashing it with exit 1 instead of reporting reachability (every other code path, and the sibling `jira.py` provider, catches this and returns `ProviderStatus(False, ...)`). This is what `tests/test-task-registry.sh`'s "Doctor: the refused relaxation is visible to the user" assertion caught. Fixed in both `.agents/skills/task-registry/scripts/registry/providers/github.py` and its `.claude/skills/` mirror, matching the existing jira.py pattern.
- [ ] **Docs**: `CLAUDE.md`'s Skills table was missing `/visual-plan`, `/visual-recap`, `/html-presentation` (all present under `.agents/skills/`). Added.
- [ ] **Docs**: `README.md`'s Skills table was missing 11 rows for skills that exist on disk: `/prd`, `/auto-push`, `/yolo`, `/auto-improve`, `/software-design-expert-review`, `/software-design-expert-learn`, `/memory-maintain`, `/refresh`, `/visual-plan`, `/visual-recap`, `/html-presentation`. Added, using the same wording as `CLAUDE.md` / each skill's own description where available.
- [ ] **Docs**: `README.md`'s Agents table was missing `critic` and `software-design-expert-review` (both present under `.claude/agents/` and already listed in `CLAUDE.md`'s agent table). Added.

## Not fixed — filed to `tasks/backlog.md` (judgment call)

- `CLAUDE.md`'s Skills table (header: `## Skills — .agents/skills/`) lists `/graphify` alongside real skill entries, but `graphify` is an external pip-installed CLI (see `README.md` § "Optional — graphify code graph"), not a file under `.agents/skills/`. Fixing this means deciding how to present it (drop the row / move it to prose / footnote it), which is a wording judgment call rather than a mechanical fix, so it's left as a one-line backlog proposal rather than edited directly.

## Not checked / out of scope

Per the routine's instructions, this run only checked repo content — local-machine artifacts (`.claude/worktrees/`, installed `~/.claude/` copies) don't exist in this fresh cloud checkout and were correctly not looked for.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M6wLd7bA2me4a8joTjTWDF)_