### PR TITLE
test(task-registry): pin the approval-floor doctor test to the gh mock

### DIFF
--- a/tests/test-task-registry.sh
+++ b/tests/test-task-registry.sh
@@ -1264,6 +1264,7 @@ provider = github
 require_write_approval = false
 EOF
 printf '```\n' >> "$F_FLOOR/docs/task-tracking.md"
+install_gh_mock "$F_FLOOR"
 floor_out="$(cd "$F_FLOOR" && pyreg <<'EOF'
 from registry.config import load_config
 plain = load_config(".", env={})
@@ -1279,7 +1280,8 @@ assert_contains "$floor_out" "ignored-flag=True" \
   "Config: the ignored relaxation is recorded so doctor can say so"
 assert_contains "$floor_out" "trusted=False" \
   "Config: an operator who trusts the repository can lower the floor"
-floor_doctor="$(run doctor --repo "$F_FLOOR" 2>&1)"
+floor_doctor="$(cd "$F_FLOOR" && PATH="$F_FLOOR/bin:$PATH" GH_MOCK_DIR="$F_FLOOR/ghdata" \
+  run doctor --repo "$F_FLOOR" 2>&1)"
 assert_contains "$floor_doctor" "approval is a floor" \
   "Doctor: the refused relaxation is visible to the user"
 


### PR DESCRIPTION
Salvages the one change from #80 that #83 did not supersede. #80 is closed in favour of this.

## What

`tests/test-task-registry.sh` — the approval-floor fixture (`F_FLOOR`) now installs the `gh` mock, and `doctor` runs against it.

## Why

The fixture is `provider = github`, and `doctor` shells out for real:

```
code, output = self._run(["gh", "auth", "status"], check=False)
```
`.agents/skills/task-registry/scripts/registry/providers/github.py:75`

`F_FLOOR` was the only `provider = github` fixture in the file with no mock installed — `F_SEL_GH`, `F_GH`, and `F_GHFAIL` all call `install_gh_mock`. So this assertion resolved the host's real `gh` and the developer's real account.

#83 fixed the crash: `discover()` now returns `ProviderStatus(False, ...)` rather than raising when `gh` is absent. That is the right production fix and it is not this. With #83 in, a gh-less host passes the assertion through the *provider-unavailable* path — so the test named "the refused relaxation is visible to the user" stops exercising the reachable provider whose relaxation is being refused. It passes either way, for two different reasons, depending on the host.

## Verification

`bash tests/test-task-registry.sh` — `39/277` failing before the change, `39/277` after, and `Doctor: the refused relaxation is visible to the user` green in both. No regression; no production code touched.

Those 39 are pre-existing on `master` on Windows (CI is `ubuntu-latest` only) and are tracked separately — not in scope here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
