### PR TITLE
fix(task-registry): degrade when gh lacks an optional issue field

### DIFF
--- a/.agents/skills/task-registry/scripts/registry/providers/github.py
+++ b/.agents/skills/task-registry/scripts/registry/providers/github.py
@@ -35,7 +35,18 @@ from .base import (
     preserve_labels,
 )
 
-ISSUE_FIELDS = "number,title,body,labels,state,url,createdAt,updatedAt,assignees,closedByPullRequestsReferences"
+REQUIRED_ISSUE_FIELDS = (
+    "number", "title", "body", "labels", "state", "url",
+    "createdAt", "updatedAt", "assignees",
+)
+#: Fields a recent `gh` exposes and an older one does not.
+#: `closedByPullRequestsReferences` arrived in gh 2.73.0, and `gh` validates
+#: `--json` names client-side — so asking an older one for it fails the whole
+#: query rather than omitting the field. Absent it, `_linked_pr_state` already
+#: reports linked-PR state as unknown, which routing reads as a downgrade. That
+#: is the correct degradation; dying is not.
+OPTIONAL_ISSUE_FIELDS = ("closedByPullRequestsReferences",)
+UNKNOWN_FIELD_RE = re.compile(r'Unknown JSON field: "([^"]+)"')
 #: `gh` paginates internally up to this many issues. Reaching it exactly is
 #: indistinguishable from "there were more", so it is treated as truncation.
 LIST_LIMIT = 500
@@ -69,6 +80,7 @@ class GitHubProvider(TrackerProvider):
         self.repository = config.repository
         self.redact = redactor_for(config)
         self._known_labels: Optional[Sequence[str]] = None
+        self._unsupported_fields: set = set()
 
     # ---------------------------------------------------------------- discovery
     def discover(self) -> ProviderStatus:
@@ -97,13 +109,13 @@ class GitHubProvider(TrackerProvider):
 
     # -------------------------------------------------------------------- reads
     def list_tasks(self) -> List[Task]:
-        payload = self._json(
-            [
+        payload = self._issue_json(
+            lambda fields: [
                 "gh", "issue", "list",
                 "--repo", self._repo(),
                 "--state", "all",
                 "--limit", str(LIST_LIMIT),
-                "--json", ISSUE_FIELDS,
+                "--json", fields,
             ]
         )
         if len(payload) >= LIST_LIMIT:
@@ -116,9 +128,9 @@ class GitHubProvider(TrackerProvider):
         return [self._to_task(issue) for issue in payload]
 
     def get_task(self, ref: ExternalRef) -> Task:
-        payload = self._json(
-            ["gh", "issue", "view", "--repo", self._repo(), "--json", ISSUE_FIELDS,
-             "--", self._number(ref)]
+        payload = self._issue_json(
+            lambda fields: ["gh", "issue", "view", "--repo", self._repo(), "--json", fields,
+                            "--", self._number(ref)]
         )
         return self._to_task(payload)
 
@@ -440,6 +452,32 @@ class GitHubProvider(TrackerProvider):
                 f"{self.redact(output.strip()) or 'no output'}"
             )
         return completed.returncode, output
+
+    def _issue_fields(self) -> str:
+        optional = [f for f in OPTIONAL_ISSUE_FIELDS if f not in self._unsupported_fields]
+        return ",".join(list(REQUIRED_ISSUE_FIELDS) + optional)
+
+    def _issue_json(self, build):
+        """Read issues, degrading once if this `gh` predates an optional field.
+
+        `build(fields)` returns the argv for the read. A required field that `gh`
+        rejects is still a hard failure: dropping it would hand the caller a task
+        with a silently missing identity, which is worse than the refusal.
+        """
+        try:
+            return self._json(build(self._issue_fields()))
+        except ProviderError as exc:
+            match = UNKNOWN_FIELD_RE.search(str(exc))
+            field = match.group(1) if match else ""
+            if field not in OPTIONAL_ISSUE_FIELDS or field in self._unsupported_fields:
+                raise
+            self._unsupported_fields.add(field)
+            self._note(
+                f"this gh does not support the `{field}` issue field, so linked pull "
+                "request state is unknown for every issue this run; upgrade to gh 2.73.0 "
+                "or newer to restore it"
+            )
+            return self._json(build(self._issue_fields()))
 
     def _json(self, command: Sequence[str]):
         _, output = self._run(command)

--- a/.claude/skills/task-registry/scripts/registry/providers/github.py
+++ b/.claude/skills/task-registry/scripts/registry/providers/github.py
@@ -35,7 +35,18 @@ from .base import (
     preserve_labels,
 )
 
-ISSUE_FIELDS = "number,title,body,labels,state,url,createdAt,updatedAt,assignees,closedByPullRequestsReferences"
+REQUIRED_ISSUE_FIELDS = (
+    "number", "title", "body", "labels", "state", "url",
+    "createdAt", "updatedAt", "assignees",
+)
+#: Fields a recent `gh` exposes and an older one does not.
+#: `closedByPullRequestsReferences` arrived in gh 2.73.0, and `gh` validates
+#: `--json` names client-side — so asking an older one for it fails the whole
+#: query rather than omitting the field. Absent it, `_linked_pr_state` already
+#: reports linked-PR state as unknown, which routing reads as a downgrade. That
+#: is the correct degradation; dying is not.
+OPTIONAL_ISSUE_FIELDS = ("closedByPullRequestsReferences",)
+UNKNOWN_FIELD_RE = re.compile(r'Unknown JSON field: "([^"]+)"')
 #: `gh` paginates internally up to this many issues. Reaching it exactly is
 #: indistinguishable from "there were more", so it is treated as truncation.
 LIST_LIMIT = 500
@@ -69,6 +80,7 @@ class GitHubProvider(TrackerProvider):
         self.repository = config.repository
         self.redact = redactor_for(config)
         self._known_labels: Optional[Sequence[str]] = None
+        self._unsupported_fields: set = set()
 
     # ---------------------------------------------------------------- discovery
     def discover(self) -> ProviderStatus:
@@ -97,13 +109,13 @@ class GitHubProvider(TrackerProvider):
 
     # -------------------------------------------------------------------- reads
     def list_tasks(self) -> List[Task]:
-        payload = self._json(
-            [
+        payload = self._issue_json(
+            lambda fields: [
                 "gh", "issue", "list",
                 "--repo", self._repo(),
                 "--state", "all",
                 "--limit", str(LIST_LIMIT),
-                "--json", ISSUE_FIELDS,
+                "--json", fields,
             ]
         )
         if len(payload) >= LIST_LIMIT:
@@ -116,9 +128,9 @@ class GitHubProvider(TrackerProvider):
         return [self._to_task(issue) for issue in payload]
 
     def get_task(self, ref: ExternalRef) -> Task:
-        payload = self._json(
-            ["gh", "issue", "view", "--repo", self._repo(), "--json", ISSUE_FIELDS,
-             "--", self._number(ref)]
+        payload = self._issue_json(
+            lambda fields: ["gh", "issue", "view", "--repo", self._repo(), "--json", fields,
+                            "--", self._number(ref)]
         )
         return self._to_task(payload)
 
@@ -440,6 +452,32 @@ class GitHubProvider(TrackerProvider):
                 f"{self.redact(output.strip()) or 'no output'}"
             )
         return completed.returncode, output
+
+    def _issue_fields(self) -> str:
+        optional = [f for f in OPTIONAL_ISSUE_FIELDS if f not in self._unsupported_fields]
+        return ",".join(list(REQUIRED_ISSUE_FIELDS) + optional)
+
+    def _issue_json(self, build):
+        """Read issues, degrading once if this `gh` predates an optional field.
+
+        `build(fields)` returns the argv for the read. A required field that `gh`
+        rejects is still a hard failure: dropping it would hand the caller a task
+        with a silently missing identity, which is worse than the refusal.
+        """
+        try:
+            return self._json(build(self._issue_fields()))
+        except ProviderError as exc:
+            match = UNKNOWN_FIELD_RE.search(str(exc))
+            field = match.group(1) if match else ""
+            if field not in OPTIONAL_ISSUE_FIELDS or field in self._unsupported_fields:
+                raise
+            self._unsupported_fields.add(field)
+            self._note(
+                f"this gh does not support the `{field}` issue field, so linked pull "
+                "request state is unknown for every issue this run; upgrade to gh 2.73.0 "
+                "or newer to restore it"
+            )
+            return self._json(build(self._issue_fields()))
 
     def _json(self, command: Sequence[str]):
         _, output = self._run(command)

--- a/tests/test-task-registry.sh
+++ b/tests/test-task-registry.sh
@@ -544,6 +544,58 @@ assert_contains "$github_reference_out" "open-pr=true" \
 assert_contains "$github_reference_out" "identity=provisional-title-slug" \
   "GitHub: an unmanaged issue exposes its provisional identity"
 
+# A `gh` older than the release that added an optional issue field rejects the
+# whole query client-side, so asking for it unconditionally turns every read into
+# a hard failure. The field is optional to us; the run must degrade, not die.
+github_old_gh_out="$(pyreg <<'EOF'
+from registry.config import Config
+from registry.providers.base import ProviderError
+from registry.providers.github import GitHubProvider
+
+class OldGh(GitHubProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.attempts = []
+
+    def _run(self, command, check=True):
+        fields = command[command.index("--json") + 1]
+        self.attempts.append(fields)
+        if "closedByPullRequestsReferences" in fields:
+            raise ProviderError(
+                "github: `gh issue list` exited 1 — Unknown JSON field: "
+                '"closedByPullRequestsReferences"'
+            )
+        return 0, '[{"number": 7, "title": "old gh", "state": "OPEN", "url": "", "labels": []}]'
+
+provider = OldGh(Config(root=".", repository="owner/repo"))
+tasks = provider.list_tasks()
+print("count=%d" % len(tasks))
+print("linked=" + tasks[0].extra.get("unresolved_linked_pr", "unset"))
+print("attempts=%d" % len(provider.attempts))
+print("degraded=" + ("yes" if any("closedByPullRequestsReferences" in n for n in provider.limitations) else "no"))
+
+strict = OldGh(Config(root=".", repository="owner/repo"))
+strict.__class__._run = lambda self, command, check=True: (_ for _ in ()).throw(
+    ProviderError('github: `gh issue list` exited 1 — Unknown JSON field: "title"')
+)
+try:
+    strict.list_tasks()
+    print("required=dropped")
+except ProviderError:
+    print("required=refused")
+EOF
+)"
+assert_contains "$github_old_gh_out" "count=1" \
+  "GitHub: an unsupported optional field degrades the read instead of failing it"
+assert_contains "$github_old_gh_out" "linked=unset" \
+  "GitHub: a degraded read reports linked-PR state as unknown, never as clean"
+assert_contains "$github_old_gh_out" "attempts=2" \
+  "GitHub: the field is dropped and the read retried exactly once"
+assert_contains "$github_old_gh_out" "degraded=yes" \
+  "GitHub: the dropped field is recorded as a limitation, not silently swallowed"
+assert_contains "$github_old_gh_out" "required=refused" \
+  "GitHub: an unknown *required* field still fails — only optional ones are dropped"
+
 # =============================================================================
 # 6. Local provider — the full lifecycle, entirely offline
 # =============================================================================


### PR DESCRIPTION
## Problem

`ISSUE_FIELDS` requested `closedByPullRequestsReferences` unconditionally. `gh` validates `--json` field names client-side, so any `gh` older than **2.73.0** — the release that added the field (cli/cli `ee281fd9`, PR #10941, 2025-05-19) — rejects the entire query:

```
Unknown JSON field: "closedByPullRequestsReferences"
```

Every issue read became a hard failure. Found in production: a scheduled `/route` automation halted at task selection on `gh 2.68.1` and could not pick an issue at all.

The provider already had the right fallback, but it was unreachable:

```python
if "closedByPullRequestsReferences" not in issue:
    return {}          # handles an absent field in a response
```

`gh` refused before returning a response, so that branch was dead code on exactly the versions that needed it.

## Fix

- Split `ISSUE_FIELDS` into `REQUIRED_ISSUE_FIELDS` and `OPTIONAL_ISSUE_FIELDS`.
- `_issue_json(build)` catches `Unknown JSON field: "<name>"` and, **only when the name is optional**, drops it, records the loss via `_note`, and retries once.
- An unknown **required** field still fails hard. Dropping `number` or `title` would hand callers a task with a silently missing identity — worse than a refusal.

Detection is behavioural rather than a `gh --version` comparison: it keys on the actual capability, needs no version table to maintain, and self-heals if the field is renamed again.

## Degraded behaviour is safe

Without the field, `unresolved_linked_pr` is unset. `route_issue.py:235` reads unknown as a downgrade to `gated-at-plan` — which is deny-by-default, consistent with `specs/issue-lane-routing.md`'s *"Unknown counts as fail"*. The loss surfaces in `doctor` and every command preamble rather than being swallowed, per **No Silent Failures**.

## Test plan

Five new assertions in `tests/test-task-registry.sh`, written red-first against a `GitHubProvider` subclass that simulates an old `gh`:

- an unsupported optional field degrades the read instead of failing it
- a degraded read reports linked-PR state as `unknown`, never as clean
- the field is dropped and the read retried **exactly once**
- the dropped field is recorded as a limitation
- an unknown **required** field still fails

```
bash tests/run.sh  →  RESULT: all 32 test files passed
```

Both skill trees updated and verified byte-identical (`.agents/` canonical, `.claude/` copy).

## After merge

Downstream projects need `/sync` to pick this up. Any project whose host runs `gh < 2.73.0` is currently unable to use `/task-registry` or `/route` against GitHub at all.
