### PR TITLE
fix(docs): correct task registry provider precedence

### DIFF
--- a/.agents/skills/task-registry/references/configuration.md
+++ b/.agents/skills/task-registry/references/configuration.md
@@ -15,7 +15,8 @@ The registry looks for its configuration in this order:
    wins. Project-owned files come first because `CLAUDE.md` is template-managed
    and `/sync` overwrites it;
 2. `docs/task-tracking.md`;
-3. nothing — defaults apply, and the local provider is used.
+3. nothing — configuration defaults apply; provider auto-selection still follows
+   the table below.
 
 Every path the configuration names — the pointer target, the index, the detail
 directory — must resolve inside the project root. One that escapes is refused,

--- a/.agents/skills/task-registry/templates/task-tracking.md
+++ b/.agents/skills/task-registry/templates/task-tracking.md
@@ -5,8 +5,9 @@
 > `Task tracking instructions: <path>` to `AGENTS.md`, `CLAUDE.md`, or
 > `.claude/project.md`.
 >
-> Read by `/task-registry`. Everything is optional — a project with no
-> configuration at all gets the local Markdown provider and works offline.
+> Read by `/task-registry`. Everything is optional — without configuration,
+> selection still prefers GitHub when a GitHub remote and an authenticated `gh`
+> both exist, then falls back to local Markdown.
 
 ```ini
 [tracker]

--- a/.claude/skills/task-registry/references/configuration.md
+++ b/.claude/skills/task-registry/references/configuration.md
@@ -15,7 +15,8 @@ The registry looks for its configuration in this order:
    wins. Project-owned files come first because `CLAUDE.md` is template-managed
    and `/sync` overwrites it;
 2. `docs/task-tracking.md`;
-3. nothing — defaults apply, and the local provider is used.
+3. nothing — configuration defaults apply; provider auto-selection still follows
+   the table below.
 
 Every path the configuration names — the pointer target, the index, the detail
 directory — must resolve inside the project root. One that escapes is refused,

--- a/.claude/skills/task-registry/templates/task-tracking.md
+++ b/.claude/skills/task-registry/templates/task-tracking.md
@@ -5,8 +5,9 @@
 > `Task tracking instructions: <path>` to `AGENTS.md`, `CLAUDE.md`, or
 > `.claude/project.md`.
 >
-> Read by `/task-registry`. Everything is optional — a project with no
-> configuration at all gets the local Markdown provider and works offline.
+> Read by `/task-registry`. Everything is optional — without configuration,
+> selection still prefers GitHub when a GitHub remote and an authenticated `gh`
+> both exist, then falls back to local Markdown.
 
 ```ini
 [tracker]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,8 +420,9 @@ Task tracking instructions: docs/task-tracking.md
 That file is the project's configuration contract: provider (`github`, `jira`, or
 `local`), repository/project identifier, label and status mappings, local detail
 directory, dependency strategy, whether external writes need approval, migration
-policy, and offline behaviour. It is optional — a project without one gets the
-local Markdown provider and works offline. Start from
+policy, and offline behaviour. It is optional — without one, provider selection
+still prefers GitHub when a GitHub remote and an authenticated `gh` both exist,
+then falls back to local Markdown. Start from
 `.agents/skills/task-registry/templates/task-tracking.md`.
 
 **No skill talks to a tracker directly.** `/plan`, `/build`, `/verify`,

--- a/specs/wrap-up-gate-and-tdd-fold.md
+++ b/specs/wrap-up-gate-and-tdd-fold.md
@@ -70,9 +70,9 @@ Two constraints, both verified, forbid the hook from reaching a tracker:
    self-authorizing an outward-facing write on every push, which is what the
    floor exists to prevent — and `CLAUDE.md` § *Task Tracking* states external
    creation requires explicit authorization.
-2. **A hook must not do network I/O.** It runs on every push, including offline
-   and in CI. This repository has no `docs/task-tracking.md`, so the registry
-   resolves to the offline local provider regardless.
+2. **The hook never invokes `/task-registry`.** It runs on every push, including
+   offline and in CI, but its path only detects and records wrap-up debt. With no
+   registry invocation, it cannot reach any provider.
 
 So the hook does the part that must be immediate and offline (detect, warn,
 record), and the part needing judgement and authorization (file the issue)

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -242,3 +242,13 @@
 
 ## 2026-09-02 — qwen spend investigation + guardrails (yolo)
 Investigated a $26.53/24h OpenRouter burn: pi session logs traced it to 6,006 qwen3-coder-next requests from one autonomous /build in PROJECT-pix-receipt-tracker (22 backend-developer spawns; 95% cache-read at $0.07/M). Root cause: `subagents.defaultModel` blanket-enforced qwen on all unscoped agents. Applied: defaultModel → deepseek-v4-flash, 80-turn caps on builder agents, key-limit deferred (needs management key). Verified via live smoke spawn. Docs: tasks/solutions/patterns/cheap-per-token-is-not-cheap-per-task-cap-subagent-turns.md
+
+### [2026-09-04] — Provider documentation drift
+
+- Key changes: Corrected task-registry provider precedence in `CLAUDE.md` and both
+  shipped configuration templates, replaced the wrap-up hook's false local-provider
+  rationale with its actual no-registry-call boundary, and added focused regression
+  assertions.
+- Verification: `tests/test-doc-conventions.sh` passed 439 assertions after
+  review-driven coverage fixes; all 32 test files passed in the debug suite.
+- Learnings captured: `tasks/solutions/bugs/task-registry-provider-selection-docs-drift.md`

--- a/tasks/route-decision.md
+++ b/tasks/route-decision.md
@@ -1,0 +1,78 @@
+# Route Decision
+
+```json
+{
+  "author_association": "unknown",
+  "auto_confirm": false,
+  "autonomy": "gated-at-plan-and-pre-push",
+  "baseline_revision": "c3809a1642f328dc286fa5266529e4d80fa43237",
+  "baseline_worktree": {},
+  "ceiling": {
+    "channel_grant": "gated-at-plan",
+    "content_ceiling": "autonomous",
+    "label_grant": "gated-at-plan"
+  },
+  "decision_id": "9c8d05546da24bdaad8aaaa6371da9b1",
+  "declared_paths": [
+    "specs/wrap-up-gate-and-tdd-fold.md"
+  ],
+  "declared_radius": 1,
+  "downgrades": [
+    {
+      "reason": "actual diff exceeded the declared scope",
+      "signal": "runtime_tripwire"
+    },
+    {
+      "reason": "actual diff exceeded the declared scope",
+      "signal": "runtime_tripwire"
+    },
+    {
+      "reason": "runtime tripwire did not pass before reviewer finalization",
+      "signal": "runtime-tripwire"
+    }
+  ],
+  "human_verification": {
+    "judges": [],
+    "needed": false
+  },
+  "ignored_directives": [],
+  "independently_dispatched_reviews": true,
+  "lane": "gated-at-plan-and-pre-push",
+  "prelude": "/debug",
+  "review_outcomes": {
+    "code-reviewer": "completed"
+  },
+  "reviewers": [
+    "code-reviewer"
+  ],
+  "runtime_tripwire": {
+    "actual_radius": 7,
+    "changed_paths": [
+      ".agents/skills/task-registry/references/configuration.md",
+      ".agents/skills/task-registry/templates/task-tracking.md",
+      ".claude/skills/task-registry/references/configuration.md",
+      ".claude/skills/task-registry/templates/task-tracking.md",
+      "CLAUDE.md",
+      "specs/wrap-up-gate-and-tdd-fold.md",
+      "tasks/history.md",
+      "tasks/solutions/bugs/task-registry-provider-selection-docs-drift.md",
+      "tests/test-doc-conventions.sh"
+    ],
+    "outside_declared_paths": [
+      ".agents/skills/task-registry/references/configuration.md",
+      ".agents/skills/task-registry/templates/task-tracking.md",
+      ".claude/skills/task-registry/references/configuration.md",
+      ".claude/skills/task-registry/templates/task-tracking.md",
+      "CLAUDE.md",
+      "tasks/history.md",
+      "tasks/solutions/bugs/task-registry-provider-selection-docs-drift.md",
+      "tests/test-doc-conventions.sh"
+    ],
+    "overflow": true,
+    "status": "failed"
+  },
+  "task_reference": "https://github.com/Joaovsales/jplugin-agentic-development/issues/95",
+  "unresolved_review_findings": [],
+  "verification_method": "link-check"
+}
+```

--- a/tasks/solutions/bugs/task-registry-provider-selection-docs-drift.md
+++ b/tasks/solutions/bugs/task-registry-provider-selection-docs-drift.md
@@ -1,0 +1,31 @@
+---
+title: Keep provider-selection documentation aligned with runtime precedence
+date: 2026-09-04
+problem_type: bug
+module: CLAUDE.md, specs/wrap-up-gate-and-tdd-fold.md, task-registry documentation
+tags: [task-registry, documentation, provider-selection, regression-test]
+symptoms: Documentation claimed that absent task-tracking configuration always selects the offline local provider
+root_cause: Documentation collapsed an absent explicit provider into the final local fallback and omitted GitHub auto-selection
+resolution: Documented the complete precedence in every affected guide and template, replaced the hook rationale with its actual no-registry-invocation boundary, and added positive regression assertions
+---
+
+**Status**: fixed — 2026-09-04
+**Regression test**: `tests/test-doc-conventions.sh`
+
+Issue #95 exposed documentation semantic drift rather than a selector defect. The
+runtime checks an explicit provider first, then a GitHub remote with authenticated
+`gh`, and only then chooses local Markdown
+(`.agents/skills/task-registry/scripts/registry/config.py:363-373`).
+
+The corrected task-tracking overview, both shipped configuration templates, and
+the dedicated configuration guide now keep configuration discovery separate from
+provider selection (`CLAUDE.md:423-425`,
+`.agents/skills/task-registry/templates/task-tracking.md:8-11`, and
+`.agents/skills/task-registry/references/configuration.md:16-26`). The wrap-up
+gate specification no longer infers provider selection from a missing
+configuration file; it records the stronger boundary that the pre-push hook never
+invokes `/task-registry` and therefore cannot reach any provider
+(`specs/wrap-up-gate-and-tdd-fold.md:73-75`). Regression assertions positively pin
+the corrected contract (`tests/test-doc-conventions.sh:331-377`).
+
+Related pattern: [Consume structured records before rendering human summaries](../patterns/consume-structured-records-before-rendering-human-summaries.md).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -336,3 +336,20 @@ assertions, and 51 parity assertions. Initial quality gate: APOSD GO.
   contract stands. Shipped as c000b04, PR #88. The gate defect the finding
   exposed is filed as `review-gate.define-finding-resolution`.
 - [ ] Define finding resolution per owner, and remove the owner carve-out from every gate <!-- task-id: review-gate.define-finding-resolution --> — The word "unresolved" is load-bearing in four commit gates and defined nowhere, so each gate re-derives it and two deri… ([review-gate.define-finding-resolution](tasks/details/review-gate.define-finding-resolution.md))
+
+## Session Summary — 2026-09-04 [c3809a1..HEAD]
+- Completed: issue #95 via `/debug`; corrected five documentation surfaces and added regression coverage.
+- Pending: 0 tasks for issue #95.
+- Carry-forward: none; the route radius prediction miss remains recorded in `tasks/route-decision.md`.
+
+<!-- route-lane:begin -->
+## Routed lane — gated-at-plan-and-pre-push
+
+[x] prelude: /debug
+[x] /plan — skip: user explicitly directed the bug through `/debug` without a separate plan
+[x] /build — skip: direct `/debug` fix used its reproduction, fix, and full-suite loop
+[x] route radius tripwire: finalized; declared-path overflow recorded and user authorized wrap-up
+[x] /verify (evidence: link-check) — 439 doc assertions, 79 parity assertions, doctor and stale-claim scan passed
+[x] reviewers: code-reviewer — completed independently; all findings resolved
+[x] /wrap-up-session — user authorized the pre-push gate; all gates passed
+<!-- route-lane:end -->

--- a/tests/test-doc-conventions.sh
+++ b/tests/test-doc-conventions.sh
@@ -328,6 +328,18 @@ assert_file_contains "CLAUDE.md" "Task tracking instructions: docs/task-tracking
   "task-registry: CLAUDE.md carries the configuration pointer the loader looks for"
 assert_prose_contains "CLAUDE.md" "is an **index**, not the detailed source of truth" \
   "task-registry: CLAUDE.md states that tasks/todo.md is an index"
+assert_not_contains "$(flatten CLAUDE.md)" \
+  "a project without one gets the local Markdown provider and works offline" \
+  "task-registry: absent configuration does not erase GitHub auto-selection"
+assert_prose_contains "CLAUDE.md" \
+  "without one, provider selection still prefers GitHub when a GitHub remote and an authenticated \`gh\` both exist, then falls back to local Markdown" \
+  "task-registry: CLAUDE.md pins GitHub-before-local auto-selection"
+wrap_up_gate_spec="$(flatten specs/wrap-up-gate-and-tdd-fold.md)"
+assert_not_contains "$wrap_up_gate_spec" \
+  "no \`docs/task-tracking.md\`, so the registry resolves to the offline local provider regardless" \
+  "task-registry: wrap-up spec does not claim absent configuration forces local"
+assert_contains "$wrap_up_gate_spec" "hook never invokes \`/task-registry\`" \
+  "task-registry: wrap-up spec gives the real reason the hook cannot reach a tracker"
 assert_file_contains ".claude/hooks/session-start.sh" "/task-registry" \
   "task-registry: the session-start banner lists the skill"
 
@@ -343,6 +355,13 @@ for tree in .agents .claude; do
     "task-registry: $f states the no-silent-deletion rule"
   assert_file_contains "$f" "Jira is never selected implicitly" \
     "task-registry: $f states that Jira is never implicit"
+  template="$tree/skills/task-registry/templates/task-tracking.md"
+  assert_file_contains "$template" \
+    "selection still prefers GitHub when a GitHub remote and an authenticated \`gh\`" \
+    "task-registry: $template pins GitHub auto-selection"
+  assert_file_contains "$template" \
+    "both exist, then falls back to local Markdown" \
+    "task-registry: $template pins the local fallback"
   # The three companion documents the skill points at must exist, or the
   # progressive-disclosure promise ("detail on demand") has nowhere to land.
   for ref in configuration migration progressive-disclosure; do
@@ -353,6 +372,9 @@ for tree in .agents .claude; do
   assert_eq "present" \
     "$([ -f "$tree/skills/task-registry/templates/task-tracking.md" ] && echo present || echo missing)" \
     "task-registry: $tree ships the docs/task-tracking.md template"
+  assert_prose_contains "$tree/skills/task-registry/references/configuration.md" \
+    "nothing — configuration defaults apply; provider auto-selection still follows the table below" \
+    "task-registry: $tree configuration guide separates discovery from provider selection"
 done
 
 # The five workflow skills reach tracking only through the registry.


### PR DESCRIPTION
## Summary

- correct provider-selection precedence in `CLAUDE.md`, both shipped task-tracking templates, and both configuration references
- replace the wrap-up hook's false local-provider rationale with the actual boundary: the hook never invokes `/task-registry`
- add positive regression assertions and record the debug investigation

## Verification

- `bash tests/test-doc-conventions.sh` — 439 assertions passed
- `bash tests/test-skill-parity.sh` — 79 assertions passed
- `bash tests/run.sh` — all 32 test files passed
- `task-registry doctor` — selected GitHub from the repository remote plus authenticated `gh`
- repository stale-claim scan — no false provider-selection wording remains
- security scan — PASS; documentation and constant-string test changes only

## Route decision

- lane: `gated-at-plan-and-pre-push`
- autonomy: `gated-at-plan-and-pre-push`
- human verification: not required by content policy
- verification method: `link-check`
- reviewers: `code-reviewer`
- runtime tripwire: declared scope overflowed from one path to seven subsystems/paths after mandatory debug records, regression coverage, and review-driven mirrored-doc fixes; demotion was preserved and the user explicitly authorized `/debug` followed by `/wrap-up-session`
- review outcome: four independently dispatched lenses completed; all findings resolved

Fixes #95
