### PR TITLE
feat(sync): deterministic retirement — replace the per-run judgement with a record

### DIFF
--- a/.agents/skills/memory-maintain/SKILL.md
+++ b/.agents/skills/memory-maintain/SKILL.md
@@ -23,7 +23,7 @@ cheap light pass every session, and the heavy consolidation only every 5.
 ### Light pass — every session (cheap, continuous decay)
 
 Runs on **every** invocation (session start + wrap-up). Bounded work only:
-- Count documents and `needs_review` flags (`grep -rl 'needs_review: true' tasks/solutions/*/` — category dirs only, so the README's literal mention of the flag is not counted).
+- Count documents and `needs_review` flags (`grep -rlE '^needs_review: true' tasks/solutions/*/`). Anchored to column 0 because the flag is a frontmatter field: scoping to category dirs excludes the store README, but not a document that quotes the flag in its own prose.
 - Check `tasks/concepts.md` for a `> Sweep: pending` marker line (cheap grep).
   If present, run **Phase 0** now — the bootstrap sweep fires on the first
   invocation that sees the marker, never waiting for the heavy-pass gate.

--- a/.agents/skills/sync/SKILL.md
+++ b/.agents/skills/sync/SKILL.md
@@ -85,7 +85,15 @@ rm .claude/.sync-check-cache
 
 ## Syncable Paths
 
-These are the files/directories managed by the workflow template:
+These are the files/directories managed by the workflow template.
+
+> **This block is machine-parsed** — by `scripts/sync-retire.py`, which reads it
+> for the roots it scans, and by `tests/test-syncable-paths.sh`, which pins the
+> other six copies of this list against it. Both parsers split each line on the
+> arrow glyph, so keep the two-column shape, and keep the trailing slash on
+> every directory: an entry without one is read as a file and excluded from
+> retirement. Do not use that glyph in prose anywhere between this heading and
+> the next one — the parsers are fence-unaware and would read the line as a root.
 
 ```
 CLAUDE.md             → Shared rules: workflow, principles, skills index (both harnesses)
@@ -120,6 +128,11 @@ Skipping it is how a gate ends up present in the tree and wired nowhere.
 - `CLAUDE.local.md` — personal per-project overrides (gitignored)
 - `tasks/` — project-specific task state
 - `specs/` — project-specific feature specs
+- `.claude/sync-keep` — the project's retirement allowlist (see Step 6.4). It
+  needs no exclusion mechanism, and the reason is structural rather than a list
+  to keep in step: every syncable root under `.claude/` is a *subdirectory*,
+  while `sync-keep` is a file directly under `.claude/`, so it lies outside all
+  of them by shape. Listed here anyway, because this is where people look.
 
 ## Procedure
 
@@ -139,7 +152,23 @@ git remote get-url workflow 2>/dev/null
 | **Add git remote** | `git remote add workflow https://github.com/Joaovsales/coding-agent-workflow.git` |
 | **Manual diff** | Skip git, do a file-by-file comparison using a local clone in `/tmp` |
 
-If user chooses manual diff, clone to `/tmp/coding-agent-workflow` (or reuse if already there with `git -C /tmp/coding-agent-workflow pull`).
+If user chooses manual diff, clone to a **fresh private directory** and remember it:
+
+```bash
+WORKFLOW_CLONE="$(mktemp -d)"
+git clone --filter=blob:none https://github.com/Joaovsales/coding-agent-workflow.git "$WORKFLOW_CLONE"
+```
+
+`--filter=blob:none`, not `--depth 1`: Step 6.4 asks the template what it *used
+to* carry, and a shallow clone's history is just its current state — under which
+every retired skill looks project-specific and is kept forever. The filter keeps
+the clone cheap (commits and trees only; file contents are fetched on demand)
+while leaving that question answerable.
+
+Do not reuse a fixed path such as `/tmp/coding-agent-workflow`, and do not trust
+one that already exists. Step 6.4 points a **file-deleting** tool at this
+directory and reads the syncable-root list out of it, so anything that can
+pre-create that path chooses what gets deleted.
 
 ### Step 2 — Detect Remote Default Branch & Fetch Latest
 
@@ -161,7 +190,7 @@ git fetch workflow "$WORKFLOW_BRANCH"
 
 Store the detected branch name — use `workflow/$WORKFLOW_BRANCH` in all subsequent steps (Steps 3, 4, 5) instead of the hardcoded `workflow/main`.
 
-If using manual diff mode, use the `/tmp/coding-agent-workflow` clone as the source.
+If using manual diff mode, use the `"$WORKFLOW_CLONE"` checkout from Step 1 as the source.
 
 ### Step 2.5 — Legacy Directory Migration
 
@@ -270,7 +299,38 @@ git diff workflow/$WORKFLOW_BRANCH -- .agents/skills/ .agents/agents/ .agents/gi
 ```
 
 **If manual diff mode:**
-For each syncable path, compare using `diff -rq` between the project and `/tmp/coding-agent-workflow`.
+For each syncable path, compare using `diff -rq` between the project and `"$WORKFLOW_CLONE"`.
+
+**Retirement preview (both modes):** the diff above covers additions and
+modifications. Deletions come from the retirement pass, which is a dry run here
+so its output is part of the summary the user approves — nothing is written
+until Step 6.4:
+
+```bash
+set -o pipefail
+git show "workflow/$WORKFLOW_BRANCH:.agents/skills/sync/scripts/sync-retire.py" \
+  | python3 - --from-ref "workflow/$WORKFLOW_BRANCH"
+```
+
+In manual-diff mode run
+`python3 "$WORKFLOW_CLONE/.agents/skills/sync/scripts/sync-retire.py"` with
+`--from-dir "$WORKFLOW_CLONE"` instead. Show every line it prints; the retire
+list is never abbreviated.
+
+**Set the variables in the same command that uses them.** `$WORKFLOW_BRANCH` and
+`$WORKFLOW_CLONE` are assigned in Step 1, and shell state does not survive
+between separate tool calls — so re-derive or re-state them here rather than
+assuming they are still set. `set -o pipefail` is not decoration either: without
+it a failed `git show` feeds `python3 -` an empty program, which exits **0**
+having printed nothing, and the retirement gate silently does not run. The
+script rejects an empty `--from-dir` with exit 2 for the same reason.
+
+**Both forms run the template's copy of the script, never the project's.** The
+project may not have one: Step 5 is what checks `.agents/skills/` out, so on the
+sync that first delivers this script the project's path does not exist yet —
+which is every downstream project's first sync. Reading it from the template
+also settles the version question Step 6.4 raises, since the preview and the
+deletion then come from the same revision.
 
 ### Step 4 — Present Changes to User
 
@@ -292,6 +352,12 @@ Then ask the user:
 > 3. **Preview only** — just show the diffs, don't apply anything
 > 4. **Abort** — cancel sync
 
+Retirement is **not** part of this menu. It applies in full for both *all
+changes* and *pick files*, and not at all for *preview only* or *abort*. The
+retirement set is defined by `.claude/sync-keep`, not by picking — a user who
+wants to keep a path adds it to `sync-keep`, which is the entire point of the
+mechanism.
+
 ### Step 5 — Apply Changes
 
 **If git remote mode (recommended for "all changes"):**
@@ -311,7 +377,7 @@ For each applied file, briefly note what changed.
    - Suggested message: `chore: sync workflow updates from coding-agent-workflow`
 3. Remind the user to review `CLAUDE.md` if it was updated — they may need to merge project-specific customizations back in
 
-### Step 6.4 — Retired Skill Removal
+### Step 6.4 — Retired Path Removal
 
 A sync copies files in; it never deletes. A project that installed a skill the
 template has since retired keeps running the stale copy indefinitely, and the
@@ -321,17 +387,151 @@ for `/wrap-up-session` — the only written authorization in the workflow to com
 code without wrapping up,
 which is exactly what the pre-push wrap-up gate exists to catch.
 
-Remove retired skills from both trees when present:
+Which paths are retired is **recorded, not judged**. A path that exists in the
+project but not in the template is either retired upstream or project-specific;
+nothing in either repository used to answer which, so the answer was re-derived
+on every run and two syncs from one template commit could produce different
+trees. The project now owns `.claude/sync-keep` — newline-delimited glob
+patterns naming the paths under syncable roots that belong to it — and the
+retirement set is set arithmetic over that file:
+
+    retire = project paths under syncable roots
+           - template paths under the same roots
+           - paths matching a sync-keep pattern
+
+Apply it. This is the same command Step 3 already ran as a dry run, plus
+`--apply`:
 
 ```bash
-for retired in tdd deslop simplify verify-e2e; do
-  rm -rf ".agents/skills/$retired" ".claude/skills/$retired"
-done
+set -o pipefail
+git show "workflow/$WORKFLOW_BRANCH:.agents/skills/sync/scripts/sync-retire.py" \
+  | python3 - --from-ref "workflow/$WORKFLOW_BRANCH" --apply
 ```
 
-Their content was folded into surviving skills, not dropped: `tdd` → `/build`
+In manual-diff mode run
+`python3 "$WORKFLOW_CLONE/.agents/skills/sync/scripts/sync-retire.py"` with
+`--from-dir "$WORKFLOW_CLONE"`; the two modes produce the same retirement set
+for the same template content. The `set -o pipefail` and same-command variable
+rules from Step 3 apply here unchanged — more so, because this run deletes. Report every line the script prints — the retire list is the
+record of what was destroyed, so it is never abbreviated.
+
+**Re-read the list here, do not rely on the Step 3 preview.** The tree changed
+underneath it: Step 5 checked out `.agents/skills/`, so paths that were retire
+candidates at Step 3 may no longer be. The list printed here is the
+authoritative one, and it is printed before anything is deleted. Running the
+template's copy in both steps — rather than the project's, which Step 5
+overwrites midway — is what keeps the two runs the same version of the script.
+
+**Pattern syntax.** Each non-blank, non-`#` line in `.claude/sync-keep` is one
+glob, matched against the whole path, case-sensitively:
+
+```
+*   any run of characters except /       .claude/hooks/*.sh
+?   exactly one character except /       .claude/hooks/ru?.sh
+**  any run of characters including /    .agents/skills/sync/**
+```
+
+Those three tokens are the whole language. Character classes, brace expansion
+and negation are rejected, as are absolute paths, `..`, and backslashes. A
+pattern must name a path under a syncable root.
+
+A trailing `/` is refused: a directory name matches no file and would protect
+nothing, so write the `**` form above rather than `.agents/skills/sync/`. A
+pattern that matches nothing in a given run is reported as `unmatched:` — not an
+error, but usually a stale entry that has stopped protecting what it names.
+
+**Project-local content under a syncable root belongs in `sync-keep`.** Other
+skills write there — `/create-verification-skill` generates a `verify-<app>`
+skill into `.agents/skills/` and mirrors it into `.claude/skills/` — and nothing
+registers those paths automatically. Once a project has promoted its candidate,
+anything generated afterwards is a retire candidate on the next sync. It is
+always reported before deletion, so nothing is lost silently, but the operator
+is the only thing standing between a generated skill and removal. When this run
+reports a retire path the project deliberately created, add it to
+`.claude/sync-keep` rather than re-creating it after every sync.
+
+**A non-zero exit means one of three different things.** They need different
+responses, so read the message rather than the code:
+
+| Exit | Meaning | Response |
+|------|---------|----------|
+| `2` | usage — no source, both sources, or an empty one | fix the invocation; nothing was read |
+| `1` + `sync-keep line N:` | the allowlist has an unusable pattern | fix that line; nothing was deleted |
+| `1` + `candidate already exists` | a previous bootstrap run left `.claude/sync-keep.candidate` | review and promote it, or delete it; nothing was deleted |
+| `1` + `refusing to retire a root` | the template source is wrong, or a declared root is genuinely empty upstream | check the ref before anything else |
+| `1` + `FAILED:`/`UNPRUNED:` | deletion ran and part of it did not land | the `deleted:` lines are the record; re-run after fixing permissions |
+
+Only the last one has deleted anything. **Do not treat a non-zero exit as
+permission to skip the step** — retirement not running is the state this feature
+exists to end.
+
+**A project with no `.claude/sync-keep` is in bootstrap.** It still loses what
+the template retired: a file byte-identical to something the template once
+shipped at that path was template content, not this project's, and the
+template's git history is the record that says so — no hand-maintained list of
+retired names, and no model asked to classify. Those are reported as
+`retire: <path> (was template content, retired upstream)` and deleted under
+`--apply`.
+
+Provenance is per **content**, not per path and not per skill name. Three cases
+that look retirable and are not:
+
+- a synced file this project **edited** afterwards — the edit makes it the
+  project's, and the edit may not even be committed yet
+- a file this project **wrote itself** at a path the template happens to have
+  used once (`.claude/hooks/pre-commit.sh` is a name both reach for)
+- a retired skill sitting at a path the template never used — an older sync that
+  wrote it elsewhere, or a hand copy
+
+All three stay candidates. The script deletes a file only when its bytes match
+something the template actually shipped there, so nothing is removed that
+`git checkout` could not have restored anyway.
+
+Only paths the template **never** carried are held back for a human. For those
+the script retires nothing, reports `bootstrap: required`, and under `--apply` writes
+`.claude/sync-keep.candidate` — never `.claude/sync-keep` itself. Promoting the
+candidate is the human's confirming act; until that file exists, this step
+deletes nothing *of unknown origin*, and additions and modifications still sync
+normally.
+
+If the template's history cannot be read, the script says
+`provenance: unavailable (<reason>)` and retires nothing at all, rather than
+treating "I cannot tell" as "project-specific". **Read the reason**: a truncated
+clone, a ref that does not resolve, and an unreadable object are different
+problems, and only the first is fixed by deepening the clone — the advice is
+attached to the reason that warrants it, not to all of them. Step 1's
+`--filter=blob:none` is what keeps that from being the normal case.
+
+Truncation is detected at **any** depth, by whether the revision's root commit
+records a parent git does not have. A `--depth 5` clone is as unreadable as a
+`--depth 1` one for this purpose, and reporting only the latter meant the same
+template commit could yield two different retirement sets.
+
+The depth that matters is the **template revision's**, not the project's. A
+project that is itself a `--depth 1` checkout — what CI does by default — still
+gets full provenance, as long as the ref it syncs from carries its history. A
+second
+`--apply` while the candidate is still sitting there exits 1 rather than
+overwriting it, so the routine "I have not promoted it yet" case is an error by
+design — promote the file or delete it.
+
+**A declared root the template has no files under is skipped, not fatal.** It is
+reported as `skipped: <root>` and nothing under it is retired — upstream may have
+emptied it legitimately, and two roots here hold a single file each, so one
+commit removing that file must not disable retirement everywhere. More than one
+empty root is refused outright: upstream retires roots one release at a time,
+while a truncated checkout empties several at once, and retiring against that
+would delete the project's copy of each.
+
+The script scans only what the § Syncable Paths block above declares, reading it
+from the template rather than the project so a stale branch cannot narrow the
+scan. It never deletes an untracked file, and it fails loudly — deleting
+nothing — on an invalid `sync-keep` pattern or a syncable root the template
+cannot vouch for.
+
+Retired content was folded into surviving skills, not dropped: `tdd` → `/build`
 Phase 1 § *TDD Discipline*; `simplify` and `deslop` → `/quality-gate` Phase 1
-and Phase 2; `verify-e2e` → `/verify --scope e2e`. Report what was removed.
+and Phase 2; `verify-e2e` → `/verify --scope e2e`.
 
 ### Step 6.5 — Unmigrated Learning Store Check
 

--- a/.agents/skills/sync/scripts/sync-retire.py
+++ b/.agents/skills/sync/scripts/sync-retire.py
@@ -304,8 +304,15 @@ def _history_is_truncated(where: str, revision: str) -> bool:
     `--depth 5` clone silently produced a *different* retirement set from the
     same commit SHA — the non-determinism this whole feature exists to remove.
     """
-    for commit in _git(where, "rev-list", "--max-parents=0", revision).split():
-        if re.search(r"^parent ", _git(where, "cat-file", "commit", commit), re.M):
+    for commit in _git(
+        where, "rev-list", "--max-parents=0", "--end-of-options", revision
+    ).split():
+        # Headers only. `cat-file commit` emits headers, a blank line, then the
+        # free-text message -- so a commit message containing a line that begins
+        # `parent ` was read as a graft, and one such message upstream would
+        # report `provenance: unavailable` for every downstream project forever.
+        header = _git(where, "cat-file", "commit", commit).split("\n\n", 1)[0]
+        if re.search(r"^parent ", header, re.M):
             return True
     return False
 
@@ -336,24 +343,39 @@ def template_history_blobs(
 
     `--raw` carries the pre- and post-image blob of every change, so one walk
     yields the full content history without re-reading a tree per commit.
+
+    `-z` is load-bearing, not a parsing convenience. Without it git C-quotes
+    paths holding non-ASCII bytes, and whether it does is decided by
+    `core.quotePath` — read from the repository being inspected, which in
+    `--from-dir` mode is the untrusted template checkout. This map is keyed on
+    those strings while the project side uses raw bytes, so one line in someone
+    else's `.git/config` moved a file between "held for a human" and "deleted",
+    and made the two source modes disagree for identical content.
     """
     stream = _git(
-        where, "log", "--pretty=format:", "--raw", "--no-abbrev",
-        "--diff-filter=AMRD", revision, "--", *roots,
+        where, "log", "--pretty=format:", "--raw", "--no-abbrev", "-z",
+        "--diff-filter=AMRD", "--end-of-options", revision, "--", *roots,
     )
     blobs: Dict[str, Set[str]] = {}
-    for line in stream.splitlines():
-        if not line.startswith(":"):
+    fields = stream.split("\0")
+    index = 0
+    while index < len(fields):
+        record = fields[index]
+        if not record.startswith(":"):
+            index += 1
             continue
-        fields = line.split("\t")
-        columns = fields[0].split()
-        if len(columns) < 5 or len(fields) < 2:
+        columns = record.split()
+        if len(columns) < 5:
+            index += 1
             continue
-        # A rename names both the old and the new path; the blob belongs to each.
-        for path in fields[1:]:
+        # A rename or copy names both the old path and the new one, and the
+        # blob belongs to each; everything else names one.
+        wanted = 2 if columns[4][:1] in ("R", "C") else 1
+        for path in (p for p in fields[index + 1 : index + 1 + wanted] if p):
             for sha in columns[2:4]:
                 if sha and set(sha) != {"0"}:
                     blobs.setdefault(path, set()).add(sha)
+        index += 1 + wanted
     return blobs
 
 
@@ -406,12 +428,18 @@ def project_paths(repo: str, roots: Sequence[str]) -> List[str]:
     to delete. It also keeps the two template modes agreeing — a walk would see
     build residue such as `__pycache__` that `git ls-tree` can never report.
 
-    `isfile` also excludes broken symlinks, symlinks to directories, and
-    submodule gitlinks, so none of those is ever retired. That is the safe
+    `isfile` excludes broken symlinks, symlinks to directories, and submodule
+    gitlinks *at the leaf*, so none of those is ever retired. That is the safe
     direction — the tool leaves them rather than guessing whether `os.remove` is
     the right verb — but it does mean a retired-upstream symlink of those shapes
     needs manual removal. A tracked symlink to a *file* is retired normally, and
     removes the link, never its target.
+
+    It says nothing about the **directories above** the leaf: `isfile` follows
+    every component, so a symlinked directory inside a syncable root resolves
+    this path somewhere else entirely. `_confined_target` is what refuses that,
+    at the deletion itself — this filter is not a containment check and must not
+    be read as one.
 
     Filtered to what is actually on disk, because `ls-files` reports the *index*.
     A path this script deleted on an earlier run stays in the index until the
@@ -428,7 +456,10 @@ def project_paths(repo: str, roots: Sequence[str]) -> List[str]:
 
 
 def template_paths_from_ref(repo: str, ref: str, roots: Sequence[str]) -> List[str]:
-    stream = _git(repo, "ls-tree", "-r", "--name-only", "-z", ref, "--", *roots)
+    stream = _git(
+        repo, "ls-tree", "-r", "--name-only", "-z", "--end-of-options", ref,
+        "--", *roots,
+    )
     return sorted(p for p in stream.split("\0") if p)
 
 
@@ -467,7 +498,11 @@ def read_template_doc(repo: str, ref: Optional[str], directory: Optional[str]) -
         if not os.path.isfile(path):
             raise RetireError(f"template checkout has no {SKILL_DOC}: {directory}")
         return _read_text(path)
-    return _git(repo, "show", f"{ref}:{SKILL_DOC}")
+    # --end-of-options at the sink: `main` rejects a ref starting with `-`, but
+    # that guard is 400 lines away and the tests already import this module and
+    # call in directly, so it is one refactor from being bypassed. Without it
+    # `git show "--output=...:path"` is read as an option.
+    return _git(repo, "show", "--end-of-options", f"{ref}:{SKILL_DOC}")
 
 
 def usable_roots(
@@ -627,6 +662,19 @@ def compute_plan(repo: str, ref: Optional[str], directory: Optional[str]) -> Pla
     )
 
 
+def _field(path: str) -> str:
+    """A path, rendered so it can only ever occupy one line of the report.
+
+    The report is the sole record of what a file-deleting tool destroyed, and
+    SKILL.md tells the operator to read it in full. A path containing a newline
+    would otherwise emit lines indistinguishable from real ones — a file can be
+    named so that the run claims to have kept what it deleted. `repr` also
+    escapes carriage returns, which repaint a terminal line, and surrogates
+    from `errors="surrogateescape"`, which would raise on print.
+    """
+    return path if path.isprintable() else repr(path)
+
+
 def render(plan: Plan) -> str:
     """Render what this run proposes, printed before anything is written.
 
@@ -651,28 +699,52 @@ def render(plan: Plan) -> str:
                 f"is retired"
             )
         for path in plan.retire:
-            lines.append(f"  retire: {path} (was template content, retired upstream)")
+            lines.append(f"  retire: {_field(path)} (was template content, retired upstream)")
         for path in plan.candidates:
-            lines.append(f"  candidate: {path}")
+            lines.append(f"  candidate: {_field(path)}")
         lines.append(
             f"  next:   re-run with --apply to write {CANDIDATE_FILE}, review it, "
             f"then rename it to {KEEP_FILE}"
         )
         return "\n".join(lines)
     for path in plan.retire:
-        lines.append(f"  retire: {path}")
+        lines.append(f"  retire: {_field(path)}")
     if not plan.retire:
         lines.append("  retire: (none)")
     for path, pattern in plan.kept:
-        lines.append(f"  kept:   {path} (matched {pattern})")
+        lines.append(f"  kept:   {_field(path)} (matched {_field(pattern)})")
     for pattern in plan.dormant:
         lines.append(
-            f"  dormant: {pattern} — under a skipped root; it protects again "
+            f"  dormant: {_field(pattern)} — under a skipped root; it protects again "
             f"when the template restores that root. Keep it"
         )
     for pattern in plan.unmatched:
-        lines.append(f"  unmatched: {pattern} — matched nothing this run")
+        lines.append(f"  unmatched: {_field(pattern)} — matched nothing this run")
     return "\n".join(lines)
+
+
+def _confined_target(repo_real: str, relative: str) -> Optional[str]:
+    """The path to delete, or None when a directory on the way is a symlink.
+
+    `project_paths` reads the *index* and confirms the leaf with
+    `os.path.isfile`, which follows every component. So a symlinked directory
+    inside a syncable root — a developer sharing a skill tree across worktrees
+    is enough, no hostile template required — makes `os.remove` delete a file
+    somewhere else entirely. That file was never in this repository, so
+    `git restore` cannot bring it back, which is the whole loss this tool is
+    built to avoid.
+
+    The leaf itself needs no check: `os.remove` never follows a final symlink,
+    so a symlinked *file* costs only the link.
+    """
+    parent = os.path.dirname(relative)
+    declared = os.path.normpath(os.path.join(repo_real, parent))
+    resolved = os.path.realpath(os.path.join(repo_real, parent))
+    if resolved != declared:
+        return None
+    if os.path.commonpath([repo_real, resolved]) != repo_real:
+        return None
+    return os.path.join(resolved, os.path.basename(relative))
 
 
 def apply_plan(
@@ -693,9 +765,18 @@ def apply_plan(
     removed: List[str] = []
     failed: List[Tuple[str, str]] = []
     pruned_failed: List[Tuple[str, str]] = []
+    repo_real = os.path.realpath(repo)
     for relative in plan.retire:
+        target = _confined_target(repo_real, relative)
+        if target is None:
+            failed.append((
+                relative,
+                "a directory on this path is a symlink, so it resolves outside "
+                "the repository — refusing to delete",
+            ))
+            continue
         try:
-            os.remove(os.path.join(repo, relative))
+            os.remove(target)
         except OSError as exc:
             failed.append((relative, str(exc)))
             continue
@@ -789,7 +870,20 @@ def write_candidate(repo: str, plan: Plan) -> str:
         "",
     ]
     lines.extend(_as_pattern(path) for path in plan.candidates)
-    with open(path, "w", encoding="utf-8") as handle:
+    # O_EXCL|O_NOFOLLOW subsumes the lexists precondition and closes the window
+    # between it and this write, which the bootstrap path widens by deleting in
+    # between. A same-uid process cannot land a symlink here and be followed.
+    try:
+        descriptor = os.open(
+            path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o644
+        )
+    except FileExistsError:
+        raise RetireError(
+            f"{CANDIDATE_FILE} already exists — review it and rename it to "
+            f"{KEEP_FILE}, or delete it to regenerate. Refusing to overwrite a "
+            f"file this tool asked a human to edit"
+        )
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
     return path
 
@@ -902,12 +996,12 @@ def _deletion_outcome(
     # The docstring promises a partial run "reports every file it removed", and a
     # count is not that: the operator would have to subtract FAILED lines from an
     # earlier render they may no longer have.
-    lines.extend(f"  deleted: {path}" for path in removed)
-    lines.extend(f"  FAILED: {path} — {reason}" for path, reason in failed)
+    lines.extend(f"  deleted: {_field(path)}" for path in removed)
+    lines.extend(f"  FAILED: {_field(path)} — {reason}" for path, reason in failed)
     # A directory left behind is reported separately: the files under it are
     # gone either way, so this must not read as a deletion that did not happen.
-    lines.extend(f"  UNPRUNED: {path} — {reason}" for path, reason in pruned_failed)
-    lines.extend(f"  FAILED: cannot write {path} — {reason}" for path, reason in unwritten)
+    lines.extend(f"  UNPRUNED: {_field(path)} — {reason}" for path, reason in pruned_failed)
+    lines.extend(f"  FAILED: cannot write {_field(path)} — {reason}" for path, reason in unwritten)
     return "\n".join(lines), 1
 
 

--- a/.agents/skills/sync/scripts/sync-retire.py
+++ b/.agents/skills/sync/scripts/sync-retire.py
@@ -1,0 +1,963 @@
+#!/usr/bin/env python3
+"""Deterministic retirement for /sync.
+
+`/sync` copies files in; it never deletes. A path present in a project but
+absent from the template is either retired upstream or project-specific, and
+until now nothing recorded which — so the answer was re-derived by a model on
+every run, and two runs against one template commit could produce different
+trees.
+
+This script replaces that judgement with set arithmetic:
+
+    retire = project paths under syncable roots
+           - template paths under the same roots
+           - paths matching a .claude/sync-keep pattern
+
+Nothing is classified at run time. Given the same template revision, the same
+project tree and the same sync-keep, the retirement set is identical on every
+run and from every project branch.
+
+Stdlib only, Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import re
+import subprocess
+import sys
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+KEEP_FILE = ".claude/sync-keep"
+CANDIDATE_FILE = ".claude/sync-keep.candidate"
+SKILL_DOC = ".agents/skills/sync/SKILL.md"
+
+# `[`, `]`, `{`, `}` and `!` are the glob syntax this format does *not* accept.
+# Silently ignoring them would let an author record intent that protects
+# nothing, which is the failure mode the whole allowlist exists to prevent.
+UNSUPPORTED_GLOB_CHARS = "[]{}!"
+
+# A syncable root must be a direct subdirectory of one of the two harness trees:
+# `.agents/skills/`, `.claude/hooks/`, and so on. The doc block that names the
+# roots is read from the *template* — a remote repository, or in manual-diff mode
+# a directory under /tmp — so without this the template chooses what a
+# file-deleting tool is pointed at. A hostile or simply mistaken block naming
+# `src/` deletes the project's source; naming `.claude/` sweeps in the never-sync
+# files, including the allowlist this whole mechanism depends on. Staying inside
+# the repository is not sufficient, because every one of those paths already is.
+SYNCABLE_ROOT_PATTERN = re.compile(r"^\.(agents|claude)/[A-Za-z0-9_-]+/$")
+
+
+class PruneError(Exception):
+    """A directory that could not be removed, carrying which one it was."""
+
+    def __init__(self, directory: str, reason: str) -> None:
+        super().__init__(f"{directory}: {reason}")
+        self.directory = directory
+        self.reason = reason
+
+
+class RetireError(Exception):
+    """A failure that must stop the run before anything is deleted."""
+
+
+# ------------------------------------------------------- patterns and matching
+
+
+def _pattern_to_regex(pattern: str) -> str:
+    """Translate the three supported tokens; everything else is a literal.
+
+    Hand-written rather than `fnmatch`, whose `*` happily crosses `/` and whose
+    `[seq]` syntax this format does not accept. Borrowing it would silently
+    widen every allowlist entry.
+    """
+    # TODO(shortcut): this and `match_path` duplicate
+    # `.agents/skills/wrap-up-session/scripts/spec-reconcile.py`, which has the
+    # same three-token semantics. Not shared yet because that file's hyphenated
+    # name makes it importable only through `importlib`, and the two validators
+    # have different contracts — a sync-keep pattern must additionally name a
+    # syncable root. Upgrade path: extract the matcher into an importable module
+    # both scripts read (filed as `glob-matcher-shared-module`).
+    # Kept as a `#` comment, not docstring prose: the /wrap-up-session shortcut
+    # ledger greps for comment syntax, and a marker it cannot see is a deferral
+    # that rots silently.
+    out: List[str] = []
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        elif pattern[index] == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(pattern[index]))
+            index += 1
+    return "".join(out)
+
+
+def match_path(pattern: str, path: str) -> bool:
+    return re.fullmatch(_pattern_to_regex(pattern), path) is not None
+
+
+def validate_pattern(pattern: str, line_number: int, roots: Sequence[str]) -> str:
+    """Return `pattern` if this program will interpret it, else raise.
+
+    Every rejection is a value that would otherwise fail *silently*: an
+    unsupported token matches nothing, so the path it was meant to protect is
+    retired anyway and the author learns about it from the deletion. The line
+    number travels with the message because an allowlist is edited by hand.
+    """
+    where = f"{KEEP_FILE} line {line_number}"
+    if pattern.startswith("/") or re.match(r"^[A-Za-z]:", pattern):
+        raise RetireError(f"{where}: absolute path not allowed: `{pattern}`")
+    if "\\" in pattern:
+        raise RetireError(f"{where}: use POSIX separators, not backslashes: `{pattern}`")
+    if ".." in pattern.split("/"):
+        raise RetireError(f"{where}: `..` traversal not allowed: `{pattern}`")
+    if pattern.endswith("/"):
+        raise RetireError(
+            f"{where}: `{pattern}` ends in `/`, so it matches no file and protects "
+            f"nothing — did you mean `{pattern}**`?"
+        )
+    bad = [c for c in UNSUPPORTED_GLOB_CHARS if c in pattern]
+    if bad:
+        raise RetireError(
+            f"{where}: unsupported glob syntax {''.join(bad)!r} in `{pattern}` "
+            f"— only *, ? and ** are accepted"
+        )
+    if not _reaches_a_root(pattern, roots):
+        raise RetireError(
+            f"{where}: `{pattern}` is outside every syncable root "
+            f"({', '.join(roots)}) — it can never protect anything"
+        )
+    return pattern
+
+
+def _reaches_a_root(pattern: str, roots: Sequence[str]) -> bool:
+    """Can this pattern match any path under any root?
+
+    Tested on the pattern's literal head — everything before its first glob
+    token — because a prefix test alone contradicts the matcher: `**` crosses
+    `/`, so `.claude/**` does reach `.claude/hooks/`, and rejecting it with
+    "it can never protect anything" told the author the opposite of the truth.
+    A head that is a prefix of a root, or prefixed by one, reaches it.
+    """
+    cut = min((i for i in (pattern.find("*"), pattern.find("?")) if i != -1), default=len(pattern))
+    head = pattern[:cut]
+    return any(head.startswith(root) or root.startswith(head) for root in roots)
+
+
+def read_keep_patterns(repo: str, roots: Sequence[str]) -> Optional[List[str]]:
+    """Read `.claude/sync-keep`, or return None when the project has no file.
+
+    None is *bootstrap*, an empty list is a recorded "nothing here is
+    project-specific". Collapsing the two would make an unconfigured project
+    look like one that had opted into deletion.
+    """
+    path = os.path.join(repo, KEEP_FILE)
+    if not os.path.isfile(path):
+        # S7: absent and unreadable are different states. A dangling symlink or a
+        # directory here is not "no allowlist" -- reporting bootstrap for it would
+        # claim the project never configured one, and write a candidate over the
+        # top of whatever is actually there.
+        if os.path.lexists(path):
+            raise RetireError(
+                f"{KEEP_FILE} exists but is not a regular file — refusing to treat "
+                f"it as an absent allowlist"
+            )
+        return None
+    patterns: List[str] = []
+    text = _read_text(path)
+    for line_number, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        patterns.append(validate_pattern(stripped, line_number, roots))
+    return patterns
+
+
+# ------------------------------------------------------------- syncable roots
+
+
+def _validate_root(entry: str, origin: str) -> str:
+    """Refuse a root that is not one of the directories `/sync` manages.
+
+    Errs toward scanning less: a legitimate new root that does not fit the shape
+    is simply not retired from, which leaves stale files behind. The opposite
+    failure deletes files the tool was never meant to touch.
+    """
+    if not SYNCABLE_ROOT_PATTERN.match(entry):
+        raise RetireError(
+            f"{origin}: `{entry}` is not a syncable root — a root must be a direct "
+            f"subdirectory of .agents/ or .claude/ (for example .agents/skills/). "
+            f"Refusing to point a file-deleting tool at it"
+        )
+    return entry
+
+
+def parse_syncable_roots(text: str, origin: str) -> List[str]:
+    """Read the directory roots out of the `## Syncable Paths` doc block.
+
+    The block is parsed rather than copied so this script becomes a *consumer*
+    of the one list `tests/test-syncable-paths.sh` already pins, instead of an
+    eighth hand-maintained duplicate of it.
+
+    The block's file entries (`CLAUDE.md`, `.claude/settings.json`) are dropped:
+    retirement is undefined for a file — it has no project-only paths inside it
+    — and the checkout step already handles them.
+    """
+    directories: List[str] = []
+    in_block = False
+    for line in text.splitlines():
+        if line.startswith("## Syncable Paths"):
+            in_block = True
+            continue
+        if in_block and re.match(r"^#{2,} ", line):
+            break
+        if in_block and "→" in line:
+            entry = line.split("→", 1)[0].strip()
+            if entry.endswith("/"):
+                directories.append(_validate_root(entry, origin))
+    if not directories:
+        raise RetireError(
+            f"{origin}: no `## Syncable Paths` doc block with directory roots — "
+            f"cannot determine what to scan"
+        )
+    return sorted(set(directories))
+
+
+# ---------------------------------------------------------------- inventories
+
+
+def _read_text(path: str) -> str:
+    """Read a file the operator controls, reporting failures on our own channel.
+
+    `open` raises OSError and UnicodeDecodeError, and `main` only catches
+    RetireError -- so an unreadable or non-UTF-8 allowlist escaped as a
+    traceback, while SKILL.md promises this tool "fails loudly" in the sense of
+    a controlled stop.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RetireError(f"cannot read {path}: {exc}")
+
+
+def _git(repo: str, *args: str) -> str:
+    """Run git against a tree whose configuration is untrusted input.
+
+    `--from-dir` points this at a template checkout the project did not write,
+    and git reads that repository's own `.git/config` — where `core.fsmonitor`
+    names a command git executes on `ls-files`. The checkout is same-uid, so
+    `safe.directory` never fires, and the read happens during the Step 3 dry
+    run, before the user has approved anything. Pinning the exec-capable knobs
+    off on the command line beats them: `-c` outranks repository config.
+    """
+    env = dict(os.environ, GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL=os.devnull)
+    result = subprocess.run(
+        ("git", "-C", repo, "-c", "core.fsmonitor=", "-c", "core.hooksPath=" + os.devnull)
+        + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        # surrogateescape, not replace: this string is fed back to os.remove, and
+        # a replacement character produces a path that can never round-trip.
+        errors="surrogateescape",
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RetireError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def _one_line(exc: Exception) -> str:
+    """Collapse a multi-line git error into a single report line.
+
+    `render` emits one line per item and its readers grep it, while git's
+    fatals routinely run to three lines with a usage hint appended.
+    """
+    return " ".join(
+        "".join(char for char in token if char.isprintable())
+        for token in str(exc).split()
+    )
+
+
+def _history_is_truncated(where: str, revision: str) -> bool:
+    """True when this revision's history stops at a shallow graft.
+
+    A shallow clone makes git treat its boundary commits as roots, but the
+    commit *objects* still record the parents that were never fetched. So a
+    root whose object names a parent is a graft — at any clone depth.
+
+    Both earlier probes were wrong in opposite directions.
+    `--is-shallow-repository` describes the repository, and in `--from-ref` the
+    revision lives in the *project*, so a shallow project suppressed provenance
+    for a complete template ref. Counting commits caught only depth 1, so a
+    `--depth 5` clone silently produced a *different* retirement set from the
+    same commit SHA — the non-determinism this whole feature exists to remove.
+    """
+    for commit in _git(where, "rev-list", "--max-parents=0", revision).split():
+        if re.search(r"^parent ", _git(where, "cat-file", "commit", commit), re.M):
+            return True
+    return False
+
+
+def _project_blobs(repo: str, paths: Sequence[str]) -> Dict[str, str]:
+    """Hash each project file as it exists **on disk**, not as it is indexed.
+
+    On disk is the load-bearing part. A file with uncommitted local edits hashes
+    to something no template commit ever produced, so it falls out of the
+    retirement set and is held for a human — which is the only way to avoid
+    destroying work that `git checkout` cannot bring back.
+    """
+    if not paths:
+        return {}
+    hashed = _git(repo, "hash-object", "--", *paths).split()
+    return dict(zip(paths, hashed))
+
+
+def template_history_blobs(
+    where: str, revision: str, roots: Sequence[str]
+) -> Dict[str, Set[str]]:
+    """Every blob the template has ever held at each path under these roots.
+
+    Paths alone cannot answer "is this the template's file?". `.claude/hooks/`
+    is a syncable root and `pre-commit.sh` is a name both a template and a
+    project reach for, so path membership would delete a file this project
+    wrote itself and never synced. The blob is what distinguishes them.
+
+    `--raw` carries the pre- and post-image blob of every change, so one walk
+    yields the full content history without re-reading a tree per commit.
+    """
+    stream = _git(
+        where, "log", "--pretty=format:", "--raw", "--no-abbrev",
+        "--diff-filter=AMRD", revision, "--", *roots,
+    )
+    blobs: Dict[str, Set[str]] = {}
+    for line in stream.splitlines():
+        if not line.startswith(":"):
+            continue
+        fields = line.split("\t")
+        columns = fields[0].split()
+        if len(columns) < 5 or len(fields) < 2:
+            continue
+        # A rename names both the old and the new path; the blob belongs to each.
+        for path in fields[1:]:
+            for sha in columns[2:4]:
+                if sha and set(sha) != {"0"}:
+                    blobs.setdefault(path, set()).add(sha)
+    return blobs
+
+
+def template_history_paths(
+    repo: str, ref: Optional[str], directory: Optional[str], roots: Sequence[str]
+) -> Tuple[Optional[Dict[str, Set[str]]], str]:
+    """Every path the template has *ever* carried under these roots.
+
+    This is the record that answers "is this project-specific?" without asking a
+    model. A path the template once shipped and no longer does was retired
+    upstream; a path the template never carried is the project's own. Before
+    this, only the template's current state was consulted, so the two were
+    indistinguishable and a project without a sync-keep had to keep both.
+
+    Returns `(None, reason)` when the history is not available -- a truncated
+    clone has one commit, and its "history" is just its current state, which
+    would silently classify every retired path as project-specific. The reason
+    travels with it because every git failure here used to be reported as
+    "shallow template history": a missing ref, an unreadable object and a
+    genuinely shallow clone are three different problems with three different
+    fixes, and the operator was shown only the third.
+
+    The probe measures the **revision**, not the repository. `--is-shallow-
+    repository` is a property of the whole repo, and in `--from-ref` mode the
+    revision lives in the *project* -- so a project that is itself a `--depth 1`
+    checkout (what CI does by default) reported "shallow template history" and
+    retired nothing, however complete the fetched template ref was. Counting
+    commits reachable from the revision asks the question actually being asked,
+    in both modes, and needs no branch.
+    """
+    where = directory or repo
+    revision = "HEAD" if directory else str(ref)
+    try:
+        if _history_is_truncated(where, revision):
+            return None, (
+                f"{revision} has truncated history — a shallow clone carries no "
+                f"record of what the template used to ship. Re-clone without "
+                f"--depth (--filter=blob:none keeps it cheap)"
+            )
+        return template_history_blobs(where, revision, roots), ""
+    except RetireError as exc:
+        return None, _one_line(exc)
+
+
+def project_paths(repo: str, roots: Sequence[str]) -> List[str]:
+    """Tracked files under the syncable roots.
+
+    Tracked, not walked: `/sync` delivers files through `git checkout`, so an
+    untracked file under a root was never synced in and is not this program's
+    to delete. It also keeps the two template modes agreeing — a walk would see
+    build residue such as `__pycache__` that `git ls-tree` can never report.
+
+    `isfile` also excludes broken symlinks, symlinks to directories, and
+    submodule gitlinks, so none of those is ever retired. That is the safe
+    direction — the tool leaves them rather than guessing whether `os.remove` is
+    the right verb — but it does mean a retired-upstream symlink of those shapes
+    needs manual removal. A tracked symlink to a *file* is retired normally, and
+    removes the link, never its target.
+
+    Filtered to what is actually on disk, because `ls-files` reports the *index*.
+    A path this script deleted on an earlier run stays in the index until the
+    removal is staged, so an unfiltered read would list it again, compute it as
+    project-only a second time, and fail on `os.remove` — making a second
+    `--apply` before the user commits crash rather than report nothing to do.
+    """
+    stream = _git(repo, "ls-files", "-z", "--", *roots)
+    return sorted(
+        path
+        for path in stream.split("\0")
+        if path and os.path.isfile(os.path.join(repo, path))
+    )
+
+
+def template_paths_from_ref(repo: str, ref: str, roots: Sequence[str]) -> List[str]:
+    stream = _git(repo, "ls-tree", "-r", "--name-only", "-z", ref, "--", *roots)
+    return sorted(p for p in stream.split("\0") if p)
+
+
+def template_paths_from_dir(directory: str, roots: Sequence[str]) -> List[str]:
+    """Template inventory from a checkout on disk.
+
+    Read through git when the checkout is a repository — which is how `/sync`
+    obtains it — so all three inventories mean the same thing by "the paths
+    under a root". A bare walk counts gitignored residue as template content,
+    which both breaks the `--from-ref`/`--from-dir` equivalence and lets
+    `assert_roots_present` be satisfied by files the committed tree lacks,
+    masking the wrong checkout in the one guard that exists to catch it.
+    """
+    if os.path.isdir(os.path.join(directory, ".git")):
+        stream = _git(directory, "ls-files", "-z", "--", *roots)
+        return sorted(p for p in stream.split("\0") if p)
+    found: List[str] = []
+    for root in roots:
+        base = os.path.join(directory, root)
+        for current, _dirs, names in os.walk(base):
+            for name in names:
+                absolute = os.path.join(current, name)
+                found.append(os.path.relpath(absolute, directory).replace(os.sep, "/"))
+    return sorted(found)
+
+
+def read_template_doc(repo: str, ref: Optional[str], directory: Optional[str]) -> str:
+    """Read the roots doc block from the *template*, never from the project.
+
+    The template is the authority on what the roots contain. Reading the
+    project's copy would let a project on a stale branch scan yesterday's root
+    list, which is the non-determinism this feature removes.
+    """
+    if directory:
+        path = os.path.join(directory, SKILL_DOC)
+        if not os.path.isfile(path):
+            raise RetireError(f"template checkout has no {SKILL_DOC}: {directory}")
+        return _read_text(path)
+    return _git(repo, "show", f"{ref}:{SKILL_DOC}")
+
+
+def usable_roots(
+    template: Sequence[str], roots: Sequence[str], source: str
+) -> Tuple[List[str], List[str]]:
+    """Split declared roots into those the template can vouch for, and those it cannot.
+
+    A root the template has no files under is ambiguous. Retiring from it would
+    compute `everything the project has` minus `nothing` and delete the
+    project's entire copy — the one mistake this script must never make quietly.
+
+    **One** empty root is read as an ordinary upstream deletion and skipped, so
+    that a single commit cannot disable retirement everywhere: two roots in this
+    template hold a single file each, and removing either used to exit 1 for
+    every downstream project and retire nothing at all.
+
+    **Several** empty roots are read as a wrong or partial source and refused.
+    That distinction is what keeps the catastrophe guard: a truncated checkout
+    empties many roots at once, while upstream retires them one release at a
+    time. The threshold matters because the doc block itself lives under
+    `.agents/skills/`, so that root is non-empty in *any* template this script
+    can read — an all-empty test would never fire for it, and a broken clone
+    carrying only the sync skill would otherwise retire every other skill the
+    project has.
+    """
+    present = [r for r in roots if any(p.startswith(r) for p in template)]
+    empty = [r for r in roots if r not in present]
+    if len(empty) > 1:
+        raise RetireError(
+            f"template source {source} contains no files under {len(empty)} of "
+            f"{len(roots)} syncable roots ({', '.join(empty)}) — refusing a "
+            f"source this incomplete; retiring against it would delete the "
+            f"project's copy of each"
+        )
+    if not present:
+        raise RetireError(
+            f"template source {source} contains no files under any syncable root "
+            f"({', '.join(roots)}) — refusing to treat an empty template as a "
+            f"complete one"
+        )
+    return present, empty
+
+
+# ------------------------------------------------------------- the retirement
+
+
+@dataclasses.dataclass
+class Plan:
+    roots: List[str]
+    source: str
+    retire: List[str] = dataclasses.field(default_factory=list)
+    kept: List[Tuple[str, str]] = dataclasses.field(default_factory=list)
+    # `bootstrap` discriminates: it selects whether `candidates` or
+    # `retire`/`kept` carry meaning, and both consumers branch on it. Modelled
+    # as one type with a flag rather than two types, which keeps the invalid
+    # combinations representable — see the `glob-matcher-shared-module` sibling
+    # follow-up for the split this wants eventually.
+    candidates: List[str] = dataclasses.field(default_factory=list)
+    unmatched: List[str] = dataclasses.field(default_factory=list)
+    # Patterns that reach only a skipped root: inactive this run, but the only
+    # thing that will protect the file when the template restores that root.
+    # Reporting them as `unmatched` invited the operator to delete them.
+    dormant: List[str] = dataclasses.field(default_factory=list)
+    bootstrap: bool = False
+    # Declared in the doc block but empty in the template: reported, never
+    # scanned. Retirement is undefined for a root the template cannot vouch for.
+    skipped_roots: List[str] = dataclasses.field(default_factory=list)
+    # Empty means provenance was read -- distinct from "read it, nothing was
+    # ever retired". Non-empty is why it could not be, quoted to the operator.
+    provenance_reason: str = ""
+
+
+def split_by_allowlist(
+    project_only: Sequence[str], patterns: Sequence[str]
+) -> Tuple[List[str], List[Tuple[str, str]], List[str]]:
+    """Split project-only paths into those to retire and those a pattern saved.
+
+    Each kept path carries the pattern that matched it, so a survivor is
+    traceable to the line that saved it — "kept" alone would make a sync-keep
+    entry that silently stopped matching look like one still doing its job.
+
+    Also returns the patterns that matched nothing. That is not an error — a
+    path may legitimately not exist yet — but it is the state a stale allowlist
+    is in just before it stops protecting something, and it is invisible unless
+    reported.
+    """
+    retire: List[str] = []
+    kept: List[Tuple[str, str]] = []
+    for path in project_only:
+        matched = next((pat for pat in patterns if match_path(pat, path)), None)
+        if matched is None:
+            retire.append(path)
+        else:
+            kept.append((path, matched))
+    used = {pattern for _, pattern in kept}
+    return retire, kept, [pattern for pattern in patterns if pattern not in used]
+
+
+def compute_plan(repo: str, ref: Optional[str], directory: Optional[str]) -> Plan:
+    """Resolve both inventories and reduce them to what this run would delete."""
+    source = ref or directory or ""
+    roots = parse_syncable_roots(read_template_doc(repo, ref, directory), source)
+    template = (
+        template_paths_from_dir(directory, roots)
+        if directory
+        else template_paths_from_ref(repo, str(ref), roots)
+    )
+    scanned, skipped = usable_roots(template, roots, source)
+    known = set(template)
+    project_only = [p for p in project_paths(repo, scanned) if p not in known]
+    patterns = read_keep_patterns(repo, roots)
+    if patterns is None:
+        # Bootstrap. A project with no recorded allowlist still knows one thing
+        # for certain: a path the template *used to* carry was retired upstream,
+        # not written by this project. Deleting those needs no human
+        # classification, which is the whole premise of the feature -- and
+        # without it a project that never promotes a candidate keeps every
+        # retired skill forever.
+        history, reason = template_history_paths(repo, ref, directory, scanned)
+        if history is None:
+            return Plan(
+                roots=scanned, source=source, bootstrap=True,
+                candidates=project_only, skipped_roots=skipped,
+                provenance_reason=reason,
+            )
+        # Content, not path. A path the template once used proves nothing about
+        # the file sitting there now: `.claude/hooks/pre-commit.sh` is a name
+        # both a template and a project reach for, and a project that edited a
+        # synced file has made it its own. Retire only a byte-identical copy of
+        # something the template actually shipped at that path -- anything else
+        # goes to the human, including a file with uncommitted edits, which
+        # `git checkout` could never bring back.
+        blobs = _project_blobs(repo, project_only)
+        retired_upstream = [
+            p for p in project_only if blobs.get(p) in history.get(p, set())
+        ]
+        unproven = set(project_only) - set(retired_upstream)
+        return Plan(
+            roots=scanned, source=source, bootstrap=True,
+            retire=retired_upstream,
+            candidates=[p for p in project_only if p in unproven],
+            skipped_roots=skipped,
+        )
+    retire, kept, unmatched = split_by_allowlist(project_only, patterns)
+    # A pattern under a skipped root matched nothing because nothing under that
+    # root was scanned -- not because it went stale. The two need different
+    # words: `unmatched` is documented as "about to stop protecting something",
+    # which is the opposite of the truth here.
+    dormant = [
+        pattern for pattern in unmatched
+        if not _reaches_a_root(pattern, scanned) and _reaches_a_root(pattern, skipped)
+    ]
+    return Plan(
+        roots=scanned, source=source, retire=retire, kept=kept,
+        unmatched=[p for p in unmatched if p not in dormant],
+        dormant=dormant, skipped_roots=skipped,
+    )
+
+
+def render(plan: Plan) -> str:
+    """Render what this run proposes, printed before anything is written.
+
+    The retire list is never truncated.
+
+    The progressive-disclosure cap that bounds other reports in this repo is a
+    readability optimisation. Here the list *is* the record of what is about to
+    be destroyed, and abbreviating it would hide exactly what the report exists
+    to show.
+    """
+    lines = [f"sync retirement — source: {plan.source}, roots: {len(plan.roots)}"]
+    for root in plan.skipped_roots:
+        lines.append(
+            f"  skipped: {root} — declared but empty in the template; "
+            f"nothing under it is retired this run"
+        )
+    if plan.bootstrap:
+        lines.append(f"  bootstrap: required (no {KEEP_FILE})")
+        if plan.provenance_reason:
+            lines.append(
+                f"  provenance: unavailable ({plan.provenance_reason}) — nothing "
+                f"is retired"
+            )
+        for path in plan.retire:
+            lines.append(f"  retire: {path} (was template content, retired upstream)")
+        for path in plan.candidates:
+            lines.append(f"  candidate: {path}")
+        lines.append(
+            f"  next:   re-run with --apply to write {CANDIDATE_FILE}, review it, "
+            f"then rename it to {KEEP_FILE}"
+        )
+        return "\n".join(lines)
+    for path in plan.retire:
+        lines.append(f"  retire: {path}")
+    if not plan.retire:
+        lines.append("  retire: (none)")
+    for path, pattern in plan.kept:
+        lines.append(f"  kept:   {path} (matched {pattern})")
+    for pattern in plan.dormant:
+        lines.append(
+            f"  dormant: {pattern} — under a skipped root; it protects again "
+            f"when the template restores that root. Keep it"
+        )
+    for pattern in plan.unmatched:
+        lines.append(f"  unmatched: {pattern} — matched nothing this run")
+    return "\n".join(lines)
+
+
+def apply_plan(
+    repo: str, plan: Plan
+) -> Tuple[List[str], List[Tuple[str, str]], List[Tuple[str, str]]]:
+    """Delete the retirement set, prune the emptied directories, report removals.
+
+    Returns what it actually removed and what it could not, rather than what it
+    intended to. A mid-loop failure that propagated would abandon the record of
+    the files already gone, leaving the operator to discover them with
+    `git status` — for a tool whose list is the record of what was destroyed,
+    that is the one hole that matters.
+
+    Pruning stops at the syncable root: an absent root and an empty one are
+    different states to every other reader of the tree, and only the deletions
+    below it were authorised.
+    """
+    removed: List[str] = []
+    failed: List[Tuple[str, str]] = []
+    pruned_failed: List[Tuple[str, str]] = []
+    for relative in plan.retire:
+        try:
+            os.remove(os.path.join(repo, relative))
+        except OSError as exc:
+            failed.append((relative, str(exc)))
+            continue
+        removed.append(relative)
+    for relative in removed:
+        try:
+            _prune_upwards(repo, os.path.dirname(relative), plan.roots)
+        except PruneError as exc:
+            # The file is already gone; only the empty directory above it
+            # survives. Propagating here would discard `removed` -- the record
+            # of what was destroyed -- which is the one hole this function
+            # exists to close. A leftover directory is cosmetic; a lost record
+            # is not.
+            entry = (exc.directory, exc.reason)
+            if entry not in pruned_failed:
+                pruned_failed.append(entry)
+    return removed, failed, pruned_failed
+
+
+# Every character validate_pattern rejects outright, plus the glob tokens this
+# language has no escape for. Restating this set by hand is what let backslash
+# drift out of it: `validate_pattern` refuses `\`, but `_as_pattern` happily
+# wrote one, so the tool emitted a line that made every later sync exit 1.
+UNEXPRESSIBLE_CHARS = UNSUPPORTED_GLOB_CHARS + "*?" + "\\" + "\n\r"
+
+
+def _is_unexpressible(path: str) -> bool:
+    """A path no sync-keep line can name, for any reason the reader would trip on."""
+    return path != path.strip() or bool(set(path) & set(UNEXPRESSIBLE_CHARS))
+
+
+def _as_pattern(path: str) -> str:
+    """Emit a project path as an allowlist pattern, or comment it out.
+
+    Candidate lines are read back as globs, and this language has no escape
+    syntax. A path containing `*` would become an over-broad rule that silently
+    protects unrelated siblings from retirement; one containing `[` would make
+    every later sync exit 1 on a line this tool wrote itself. Neither is
+    something a human asked for, so an unexpressible path is written as a
+    comment naming the problem.
+    """
+    if _is_unexpressible(path):
+        return (
+            "# UNEXPRESSIBLE — this path contains glob metacharacters, surrounding\n"
+            "# whitespace, or a line break, and no exact pattern can name it: the\n"
+            "# reader strips each line, so such a rule would silently protect\n"
+            "# nothing and the file would be retired anyway. Widen it\n"
+            "# deliberately, or rename the file:\n"
+            + "\n".join(f"#   {line}" for line in path.splitlines() or [path])
+        )
+    return path
+
+
+def assert_candidate_writable(repo: str) -> None:
+    """Raise if the candidate file cannot be written, touching nothing.
+
+    Separated from the write so the bootstrap apply path can check it *before*
+    deleting: a precondition that only fires after the destruction it guards
+    reports nothing about what was destroyed.
+    """
+    path = os.path.join(repo, CANDIDATE_FILE)
+    # lexists, not exists: a dangling symlink is invisible to `exists`, and
+    # `open(path, "w")` then follows it and writes through to whatever it
+    # names. `read_keep_patterns` already refuses this for the allowlist; the
+    # candidate is the file this tool writes, which makes it the better target.
+    if os.path.lexists(path):
+        raise RetireError(
+            f"{CANDIDATE_FILE} already exists — review it and rename it to "
+            f"{KEEP_FILE}, or delete it to regenerate. Refusing to overwrite a "
+            f"file this tool asked a human to edit"
+        )
+
+
+def write_candidate(repo: str, plan: Plan) -> str:
+    """Write the reviewable candidate allowlist, never the allowlist itself.
+
+    Promoting the candidate is the human's confirming act. A script that wrote
+    `.claude/sync-keep` directly would record an intent nobody expressed, and
+    every later run would treat that guess as data.
+    """
+    assert_candidate_writable(repo)
+    path = os.path.join(repo, CANDIDATE_FILE)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    lines = [
+        "# Candidate sync-keep, written by /sync in bootstrap mode.",
+        "#",
+        "# Every path below exists in this project but not in the template. Delete",
+        "# the lines naming paths that were retired upstream, keep the ones that are",
+        f"# genuinely project-specific, then rename this file to {os.path.basename(KEEP_FILE)}.",
+        "# Until that file exists, /sync retires nothing.",
+        "",
+    ]
+    lines.extend(_as_pattern(path) for path in plan.candidates)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+    return path
+
+
+def _prune_upwards(repo: str, relative_dir: str, roots: Sequence[str]) -> None:
+    """Remove directories emptied by the deletion, stopping at the syncable root.
+
+    An OSError carries the directory it was raised for, because pruning walks
+    upward: the directory this was *called* with has usually been removed
+    successfully by the time a parent fails, so reporting the starting point
+    names a path that no longer exists.
+    """
+    boundaries = {root.rstrip("/") for root in roots}
+    while relative_dir and relative_dir not in boundaries:
+        absolute = os.path.join(repo, relative_dir)
+        if not os.path.isdir(absolute):
+            return
+        try:
+            if os.listdir(absolute):
+                return
+            os.rmdir(absolute)
+        except OSError as exc:
+            raise PruneError(relative_dir, str(exc))
+        relative_dir = os.path.dirname(relative_dir)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sync-retire",
+        description="Compute and apply the deterministic /sync retirement set.",
+    )
+    parser.add_argument("--from-ref", help="template inventory read from a git ref")
+    parser.add_argument("--from-dir", help="template inventory read from a checkout")
+    parser.add_argument("--repo", default=".", help="project root (default: cwd)")
+    parser.add_argument("--apply", action="store_true", help="perform the deletions")
+    return parser
+
+
+def apply_requested_writes(repo: str, plan: Plan) -> Tuple[str, int]:
+    """Carry out what `--apply` means in this mode, and report what happened.
+
+    Bootstrap writes a candidate for review and deletes nothing; a configured
+    project deletes the retirement set. Both return their outcome line and an
+    exit code rather than printing, so `render`'s format stays owned in one
+    place and a partial deletion still reports every file it removed.
+    """
+    if plan.bootstrap:
+        # Bootstrap deletes only what provenance proves was template content.
+        # Everything of unknown origin goes to the candidate file for a human,
+        # exactly as before -- the confirming act is still theirs, it just no
+        # longer stands between the project and a skill the template retired.
+        #
+        # Precondition first: write_candidate refuses an existing candidate, and
+        # that raise used to happen *after* the deletions, so `removed` -- the
+        # record of what was destroyed -- was discarded on the routine
+        # "candidate not promoted yet" path. Nothing may fail between the
+        # deletion and its report.
+        assert_candidate_writable(repo)
+        removed, failed, pruned_failed = apply_plan(repo, plan)
+        # The existence check above is a courtesy, not the guarantee. Every
+        # other way this write fails -- unwritable `.claude/`, read-only mount,
+        # ENOSPC -- can only be discovered by attempting it, which is *after*
+        # the deletions. So the failure is folded into the report rather than
+        # raised through it: propagating here would unwind past `removed`, the
+        # only record that those files ever existed.
+        unwritten: List[Tuple[str, str]] = []
+        try:
+            write_candidate(repo, plan)
+        except (OSError, RetireError) as exc:
+            unwritten.append((CANDIDATE_FILE, _one_line(exc)))
+        if not plan.retire and not failed and not pruned_failed and not unwritten:
+            return (
+                f"  wrote:  {CANDIDATE_FILE} "
+                f"({len(plan.candidates)} candidates to review)"
+            ), 0
+        outcome, code = _deletion_outcome(removed, failed, pruned_failed, unwritten)
+        if unwritten:
+            return outcome, code
+        return (
+            f"{outcome}\n  wrote:  {CANDIDATE_FILE} "
+            f"({len(plan.candidates)} candidates to review)"
+        ), code
+    removed, failed, pruned_failed = apply_plan(repo, plan)
+    return _deletion_outcome(removed, failed, pruned_failed)
+
+
+def _deletion_outcome(
+    removed: List[str],
+    failed: List[Tuple[str, str]],
+    pruned_failed: List[Tuple[str, str]],
+    unwritten: Sequence[Tuple[str, str]] = (),
+) -> Tuple[str, int]:
+    """One format for what a deletion did, shared by both apply paths.
+
+    `unwritten` is a fourth category because a run can delete successfully and
+    still fail afterwards — the bootstrap candidate write is the case. It has
+    to make the run *partial*, or the deletion record collapses back to a count
+    at exactly the moment the operator most needs the paths.
+    """
+    if not failed and not pruned_failed and not unwritten:
+        return f"  mode:   applied ({len(removed)} deleted)", 0
+    headline = f"  mode:   applied ({len(removed)} deleted"
+    if failed:
+        headline += f", {len(failed)} failed"
+    if pruned_failed:
+        headline += f", {len(pruned_failed)} not pruned"
+    if unwritten:
+        headline += f", {len(unwritten)} not written"
+    lines = [headline + ")"]
+    # The docstring promises a partial run "reports every file it removed", and a
+    # count is not that: the operator would have to subtract FAILED lines from an
+    # earlier render they may no longer have.
+    lines.extend(f"  deleted: {path}" for path in removed)
+    lines.extend(f"  FAILED: {path} — {reason}" for path, reason in failed)
+    # A directory left behind is reported separately: the files under it are
+    # gone either way, so this must not read as a deletion that did not happen.
+    lines.extend(f"  UNPRUNED: {path} — {reason}" for path, reason in pruned_failed)
+    lines.extend(f"  FAILED: cannot write {path} — {reason}" for path, reason in unwritten)
+    return "\n".join(lines), 1
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    # An option supplied but empty means the caller's variable was unset -- the
+    # shape `--from-dir "$WORKFLOW_CLONE"` takes when that assignment did not
+    # survive. Treating it as "not supplied" would silently sync against the
+    # wrong source, so it is a usage error rather than a default.
+    for flag, value in (("--from-ref", args.from_ref), ("--from-dir", args.from_dir)):
+        if value is not None and not value.strip():
+            print(f"sync-retire: {flag} was given an empty value", file=sys.stderr)
+            return 2
+    # Truthiness, consistently: an empty --from-dir used to pass this guard, then
+    # take the directory branch for the roots doc and the ref branch for the file
+    # inventory -- reading roots from the *project* working tree. That is exactly
+    # the branch-dependent scan this feature exists to remove, at exit 0.
+    if bool(args.from_ref) == bool(args.from_dir):
+        print(
+            "sync-retire: pass exactly one of --from-ref or --from-dir, "
+            "and neither may be empty",
+            file=sys.stderr,
+        )
+        return 2
+    if args.from_ref and args.from_ref.startswith("-"):
+        print("sync-retire: --from-ref may not begin with '-'", file=sys.stderr)
+        return 2
+    repo = os.path.abspath(args.repo)
+    if not os.path.isdir(repo):
+        print(f"sync-retire: no such directory: {args.repo}", file=sys.stderr)
+        return 2
+
+    try:
+        plan = compute_plan(repo, args.from_ref, args.from_dir)
+    except RetireError as exc:
+        print(f"sync-retire: {exc}", file=sys.stderr)
+        return 1
+
+    print(render(plan))
+    if not args.apply:
+        print("  mode:   dry-run (no changes written)")
+        return 0
+    try:
+        outcome, code = apply_requested_writes(repo, plan)
+    except (OSError, RetireError) as exc:
+        print(f"sync-retire: {exc}", file=sys.stderr)
+        return 1
+    print(outcome)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -81,6 +81,12 @@ Run `/memory-maintain` (it self-gates on the session count — runs every 5 sess
   external task on its own. With no tracker configured this reconciles the local
   index alone and still reports stale and superseded entries.
 - Append session summary with idempotency fingerprint (commit range short-SHAs)
+  - **Resolve both endpoints to real short SHAs.** The pre-push wrap-up gate
+    validates them as bare hex, so `HEAD` — the obvious thing to write in this
+    step, since Step 7 has not committed yet — is rejected, and every commit in
+    the push is recorded as uncovered debt. Write the base and the last existing
+    commit; the bookkeeping commit that lands this summary touches only
+    `tasks/`, which the gate does not count as code.
 
 ```markdown
 ## Session Summary — [YYYY-MM-DD] [a1b2c3f..d4e5f6a]

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -153,7 +153,11 @@ if [ -d "tasks/solutions" ]; then
   # Category docs only (the store README mentions the flag as documentation),
   # and `|| true` because grep exits 1 on zero matches — under `set -eo
   # pipefail` that would kill the whole banner.
-  REVIEW_COUNT=$(grep -rl 'needs_review: true' tasks/solutions/*/ 2>/dev/null | wc -l | tr -d ' ' || true)
+  # Anchored: the flag is a frontmatter field, so it only counts at column 0.
+  # Scoping to category dirs excluded the store README but not a *document* that
+  # quotes the flag in its prose -- and one does, the bug doc about this very
+  # count. Matching the structure instead of the location is what makes it right.
+  REVIEW_COUNT=$(grep -rlE '^needs_review: true' tasks/solutions/*/ 2>/dev/null | wc -l | tr -d ' ' || true)
   echo ""
   echo "📚  LEARNING STORE  tasks/solutions — ${DOC_COUNT:-0} documents, ${REVIEW_COUNT:-0} needs_review (grep frontmatter to retrieve)"
   if [ "$UNMIGRATED" = "1" ]; then

--- a/.claude/skills/memory-maintain/SKILL.md
+++ b/.claude/skills/memory-maintain/SKILL.md
@@ -23,7 +23,7 @@ cheap light pass every session, and the heavy consolidation only every 5.
 ### Light pass — every session (cheap, continuous decay)
 
 Runs on **every** invocation (session start + wrap-up). Bounded work only:
-- Count documents and `needs_review` flags (`grep -rl 'needs_review: true' tasks/solutions/*/` — category dirs only, so the README's literal mention of the flag is not counted).
+- Count documents and `needs_review` flags (`grep -rlE '^needs_review: true' tasks/solutions/*/`). Anchored to column 0 because the flag is a frontmatter field: scoping to category dirs excludes the store README, but not a document that quotes the flag in its own prose.
 - Check `tasks/concepts.md` for a `> Sweep: pending` marker line (cheap grep).
   If present, run **Phase 0** now — the bootstrap sweep fires on the first
   invocation that sees the marker, never waiting for the heavy-pass gate.

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -85,7 +85,15 @@ rm .claude/.sync-check-cache
 
 ## Syncable Paths
 
-These are the files/directories managed by the workflow template:
+These are the files/directories managed by the workflow template.
+
+> **This block is machine-parsed** — by `scripts/sync-retire.py`, which reads it
+> for the roots it scans, and by `tests/test-syncable-paths.sh`, which pins the
+> other six copies of this list against it. Both parsers split each line on the
+> arrow glyph, so keep the two-column shape, and keep the trailing slash on
+> every directory: an entry without one is read as a file and excluded from
+> retirement. Do not use that glyph in prose anywhere between this heading and
+> the next one — the parsers are fence-unaware and would read the line as a root.
 
 ```
 CLAUDE.md             → Shared rules: workflow, principles, skills index (both harnesses)
@@ -120,6 +128,11 @@ Skipping it is how a gate ends up present in the tree and wired nowhere.
 - `CLAUDE.local.md` — personal per-project overrides (gitignored)
 - `tasks/` — project-specific task state
 - `specs/` — project-specific feature specs
+- `.claude/sync-keep` — the project's retirement allowlist (see Step 6.4). It
+  needs no exclusion mechanism, and the reason is structural rather than a list
+  to keep in step: every syncable root under `.claude/` is a *subdirectory*,
+  while `sync-keep` is a file directly under `.claude/`, so it lies outside all
+  of them by shape. Listed here anyway, because this is where people look.
 
 ## Procedure
 
@@ -139,7 +152,23 @@ git remote get-url workflow 2>/dev/null
 | **Add git remote** | `git remote add workflow https://github.com/Joaovsales/coding-agent-workflow.git` |
 | **Manual diff** | Skip git, do a file-by-file comparison using a local clone in `/tmp` |
 
-If user chooses manual diff, clone to `/tmp/coding-agent-workflow` (or reuse if already there with `git -C /tmp/coding-agent-workflow pull`).
+If user chooses manual diff, clone to a **fresh private directory** and remember it:
+
+```bash
+WORKFLOW_CLONE="$(mktemp -d)"
+git clone --filter=blob:none https://github.com/Joaovsales/coding-agent-workflow.git "$WORKFLOW_CLONE"
+```
+
+`--filter=blob:none`, not `--depth 1`: Step 6.4 asks the template what it *used
+to* carry, and a shallow clone's history is just its current state — under which
+every retired skill looks project-specific and is kept forever. The filter keeps
+the clone cheap (commits and trees only; file contents are fetched on demand)
+while leaving that question answerable.
+
+Do not reuse a fixed path such as `/tmp/coding-agent-workflow`, and do not trust
+one that already exists. Step 6.4 points a **file-deleting** tool at this
+directory and reads the syncable-root list out of it, so anything that can
+pre-create that path chooses what gets deleted.
 
 ### Step 2 — Detect Remote Default Branch & Fetch Latest
 
@@ -161,7 +190,7 @@ git fetch workflow "$WORKFLOW_BRANCH"
 
 Store the detected branch name — use `workflow/$WORKFLOW_BRANCH` in all subsequent steps (Steps 3, 4, 5) instead of the hardcoded `workflow/main`.
 
-If using manual diff mode, use the `/tmp/coding-agent-workflow` clone as the source.
+If using manual diff mode, use the `"$WORKFLOW_CLONE"` checkout from Step 1 as the source.
 
 ### Step 2.5 — Legacy Directory Migration
 
@@ -270,7 +299,38 @@ git diff workflow/$WORKFLOW_BRANCH -- .agents/skills/ .agents/agents/ .agents/gi
 ```
 
 **If manual diff mode:**
-For each syncable path, compare using `diff -rq` between the project and `/tmp/coding-agent-workflow`.
+For each syncable path, compare using `diff -rq` between the project and `"$WORKFLOW_CLONE"`.
+
+**Retirement preview (both modes):** the diff above covers additions and
+modifications. Deletions come from the retirement pass, which is a dry run here
+so its output is part of the summary the user approves — nothing is written
+until Step 6.4:
+
+```bash
+set -o pipefail
+git show "workflow/$WORKFLOW_BRANCH:.agents/skills/sync/scripts/sync-retire.py" \
+  | python3 - --from-ref "workflow/$WORKFLOW_BRANCH"
+```
+
+In manual-diff mode run
+`python3 "$WORKFLOW_CLONE/.agents/skills/sync/scripts/sync-retire.py"` with
+`--from-dir "$WORKFLOW_CLONE"` instead. Show every line it prints; the retire
+list is never abbreviated.
+
+**Set the variables in the same command that uses them.** `$WORKFLOW_BRANCH` and
+`$WORKFLOW_CLONE` are assigned in Step 1, and shell state does not survive
+between separate tool calls — so re-derive or re-state them here rather than
+assuming they are still set. `set -o pipefail` is not decoration either: without
+it a failed `git show` feeds `python3 -` an empty program, which exits **0**
+having printed nothing, and the retirement gate silently does not run. The
+script rejects an empty `--from-dir` with exit 2 for the same reason.
+
+**Both forms run the template's copy of the script, never the project's.** The
+project may not have one: Step 5 is what checks `.agents/skills/` out, so on the
+sync that first delivers this script the project's path does not exist yet —
+which is every downstream project's first sync. Reading it from the template
+also settles the version question Step 6.4 raises, since the preview and the
+deletion then come from the same revision.
 
 ### Step 4 — Present Changes to User
 
@@ -292,6 +352,12 @@ Then ask the user:
 > 3. **Preview only** — just show the diffs, don't apply anything
 > 4. **Abort** — cancel sync
 
+Retirement is **not** part of this menu. It applies in full for both *all
+changes* and *pick files*, and not at all for *preview only* or *abort*. The
+retirement set is defined by `.claude/sync-keep`, not by picking — a user who
+wants to keep a path adds it to `sync-keep`, which is the entire point of the
+mechanism.
+
 ### Step 5 — Apply Changes
 
 **If git remote mode (recommended for "all changes"):**
@@ -311,7 +377,7 @@ For each applied file, briefly note what changed.
    - Suggested message: `chore: sync workflow updates from coding-agent-workflow`
 3. Remind the user to review `CLAUDE.md` if it was updated — they may need to merge project-specific customizations back in
 
-### Step 6.4 — Retired Skill Removal
+### Step 6.4 — Retired Path Removal
 
 A sync copies files in; it never deletes. A project that installed a skill the
 template has since retired keeps running the stale copy indefinitely, and the
@@ -321,17 +387,151 @@ for `/wrap-up-session` — the only written authorization in the workflow to com
 code without wrapping up,
 which is exactly what the pre-push wrap-up gate exists to catch.
 
-Remove retired skills from both trees when present:
+Which paths are retired is **recorded, not judged**. A path that exists in the
+project but not in the template is either retired upstream or project-specific;
+nothing in either repository used to answer which, so the answer was re-derived
+on every run and two syncs from one template commit could produce different
+trees. The project now owns `.claude/sync-keep` — newline-delimited glob
+patterns naming the paths under syncable roots that belong to it — and the
+retirement set is set arithmetic over that file:
+
+    retire = project paths under syncable roots
+           - template paths under the same roots
+           - paths matching a sync-keep pattern
+
+Apply it. This is the same command Step 3 already ran as a dry run, plus
+`--apply`:
 
 ```bash
-for retired in tdd deslop simplify verify-e2e; do
-  rm -rf ".agents/skills/$retired" ".claude/skills/$retired"
-done
+set -o pipefail
+git show "workflow/$WORKFLOW_BRANCH:.agents/skills/sync/scripts/sync-retire.py" \
+  | python3 - --from-ref "workflow/$WORKFLOW_BRANCH" --apply
 ```
 
-Their content was folded into surviving skills, not dropped: `tdd` → `/build`
+In manual-diff mode run
+`python3 "$WORKFLOW_CLONE/.agents/skills/sync/scripts/sync-retire.py"` with
+`--from-dir "$WORKFLOW_CLONE"`; the two modes produce the same retirement set
+for the same template content. The `set -o pipefail` and same-command variable
+rules from Step 3 apply here unchanged — more so, because this run deletes. Report every line the script prints — the retire list is the
+record of what was destroyed, so it is never abbreviated.
+
+**Re-read the list here, do not rely on the Step 3 preview.** The tree changed
+underneath it: Step 5 checked out `.agents/skills/`, so paths that were retire
+candidates at Step 3 may no longer be. The list printed here is the
+authoritative one, and it is printed before anything is deleted. Running the
+template's copy in both steps — rather than the project's, which Step 5
+overwrites midway — is what keeps the two runs the same version of the script.
+
+**Pattern syntax.** Each non-blank, non-`#` line in `.claude/sync-keep` is one
+glob, matched against the whole path, case-sensitively:
+
+```
+*   any run of characters except /       .claude/hooks/*.sh
+?   exactly one character except /       .claude/hooks/ru?.sh
+**  any run of characters including /    .agents/skills/sync/**
+```
+
+Those three tokens are the whole language. Character classes, brace expansion
+and negation are rejected, as are absolute paths, `..`, and backslashes. A
+pattern must name a path under a syncable root.
+
+A trailing `/` is refused: a directory name matches no file and would protect
+nothing, so write the `**` form above rather than `.agents/skills/sync/`. A
+pattern that matches nothing in a given run is reported as `unmatched:` — not an
+error, but usually a stale entry that has stopped protecting what it names.
+
+**Project-local content under a syncable root belongs in `sync-keep`.** Other
+skills write there — `/create-verification-skill` generates a `verify-<app>`
+skill into `.agents/skills/` and mirrors it into `.claude/skills/` — and nothing
+registers those paths automatically. Once a project has promoted its candidate,
+anything generated afterwards is a retire candidate on the next sync. It is
+always reported before deletion, so nothing is lost silently, but the operator
+is the only thing standing between a generated skill and removal. When this run
+reports a retire path the project deliberately created, add it to
+`.claude/sync-keep` rather than re-creating it after every sync.
+
+**A non-zero exit means one of three different things.** They need different
+responses, so read the message rather than the code:
+
+| Exit | Meaning | Response |
+|------|---------|----------|
+| `2` | usage — no source, both sources, or an empty one | fix the invocation; nothing was read |
+| `1` + `sync-keep line N:` | the allowlist has an unusable pattern | fix that line; nothing was deleted |
+| `1` + `candidate already exists` | a previous bootstrap run left `.claude/sync-keep.candidate` | review and promote it, or delete it; nothing was deleted |
+| `1` + `refusing to retire a root` | the template source is wrong, or a declared root is genuinely empty upstream | check the ref before anything else |
+| `1` + `FAILED:`/`UNPRUNED:` | deletion ran and part of it did not land | the `deleted:` lines are the record; re-run after fixing permissions |
+
+Only the last one has deleted anything. **Do not treat a non-zero exit as
+permission to skip the step** — retirement not running is the state this feature
+exists to end.
+
+**A project with no `.claude/sync-keep` is in bootstrap.** It still loses what
+the template retired: a file byte-identical to something the template once
+shipped at that path was template content, not this project's, and the
+template's git history is the record that says so — no hand-maintained list of
+retired names, and no model asked to classify. Those are reported as
+`retire: <path> (was template content, retired upstream)` and deleted under
+`--apply`.
+
+Provenance is per **content**, not per path and not per skill name. Three cases
+that look retirable and are not:
+
+- a synced file this project **edited** afterwards — the edit makes it the
+  project's, and the edit may not even be committed yet
+- a file this project **wrote itself** at a path the template happens to have
+  used once (`.claude/hooks/pre-commit.sh` is a name both reach for)
+- a retired skill sitting at a path the template never used — an older sync that
+  wrote it elsewhere, or a hand copy
+
+All three stay candidates. The script deletes a file only when its bytes match
+something the template actually shipped there, so nothing is removed that
+`git checkout` could not have restored anyway.
+
+Only paths the template **never** carried are held back for a human. For those
+the script retires nothing, reports `bootstrap: required`, and under `--apply` writes
+`.claude/sync-keep.candidate` — never `.claude/sync-keep` itself. Promoting the
+candidate is the human's confirming act; until that file exists, this step
+deletes nothing *of unknown origin*, and additions and modifications still sync
+normally.
+
+If the template's history cannot be read, the script says
+`provenance: unavailable (<reason>)` and retires nothing at all, rather than
+treating "I cannot tell" as "project-specific". **Read the reason**: a truncated
+clone, a ref that does not resolve, and an unreadable object are different
+problems, and only the first is fixed by deepening the clone — the advice is
+attached to the reason that warrants it, not to all of them. Step 1's
+`--filter=blob:none` is what keeps that from being the normal case.
+
+Truncation is detected at **any** depth, by whether the revision's root commit
+records a parent git does not have. A `--depth 5` clone is as unreadable as a
+`--depth 1` one for this purpose, and reporting only the latter meant the same
+template commit could yield two different retirement sets.
+
+The depth that matters is the **template revision's**, not the project's. A
+project that is itself a `--depth 1` checkout — what CI does by default — still
+gets full provenance, as long as the ref it syncs from carries its history. A
+second
+`--apply` while the candidate is still sitting there exits 1 rather than
+overwriting it, so the routine "I have not promoted it yet" case is an error by
+design — promote the file or delete it.
+
+**A declared root the template has no files under is skipped, not fatal.** It is
+reported as `skipped: <root>` and nothing under it is retired — upstream may have
+emptied it legitimately, and two roots here hold a single file each, so one
+commit removing that file must not disable retirement everywhere. More than one
+empty root is refused outright: upstream retires roots one release at a time,
+while a truncated checkout empties several at once, and retiring against that
+would delete the project's copy of each.
+
+The script scans only what the § Syncable Paths block above declares, reading it
+from the template rather than the project so a stale branch cannot narrow the
+scan. It never deletes an untracked file, and it fails loudly — deleting
+nothing — on an invalid `sync-keep` pattern or a syncable root the template
+cannot vouch for.
+
+Retired content was folded into surviving skills, not dropped: `tdd` → `/build`
 Phase 1 § *TDD Discipline*; `simplify` and `deslop` → `/quality-gate` Phase 1
-and Phase 2; `verify-e2e` → `/verify --scope e2e`. Report what was removed.
+and Phase 2; `verify-e2e` → `/verify --scope e2e`.
 
 ### Step 6.5 — Unmigrated Learning Store Check
 

--- a/.claude/skills/sync/scripts/sync-retire.py
+++ b/.claude/skills/sync/scripts/sync-retire.py
@@ -304,8 +304,15 @@ def _history_is_truncated(where: str, revision: str) -> bool:
     `--depth 5` clone silently produced a *different* retirement set from the
     same commit SHA — the non-determinism this whole feature exists to remove.
     """
-    for commit in _git(where, "rev-list", "--max-parents=0", revision).split():
-        if re.search(r"^parent ", _git(where, "cat-file", "commit", commit), re.M):
+    for commit in _git(
+        where, "rev-list", "--max-parents=0", "--end-of-options", revision
+    ).split():
+        # Headers only. `cat-file commit` emits headers, a blank line, then the
+        # free-text message -- so a commit message containing a line that begins
+        # `parent ` was read as a graft, and one such message upstream would
+        # report `provenance: unavailable` for every downstream project forever.
+        header = _git(where, "cat-file", "commit", commit).split("\n\n", 1)[0]
+        if re.search(r"^parent ", header, re.M):
             return True
     return False
 
@@ -336,24 +343,39 @@ def template_history_blobs(
 
     `--raw` carries the pre- and post-image blob of every change, so one walk
     yields the full content history without re-reading a tree per commit.
+
+    `-z` is load-bearing, not a parsing convenience. Without it git C-quotes
+    paths holding non-ASCII bytes, and whether it does is decided by
+    `core.quotePath` — read from the repository being inspected, which in
+    `--from-dir` mode is the untrusted template checkout. This map is keyed on
+    those strings while the project side uses raw bytes, so one line in someone
+    else's `.git/config` moved a file between "held for a human" and "deleted",
+    and made the two source modes disagree for identical content.
     """
     stream = _git(
-        where, "log", "--pretty=format:", "--raw", "--no-abbrev",
-        "--diff-filter=AMRD", revision, "--", *roots,
+        where, "log", "--pretty=format:", "--raw", "--no-abbrev", "-z",
+        "--diff-filter=AMRD", "--end-of-options", revision, "--", *roots,
     )
     blobs: Dict[str, Set[str]] = {}
-    for line in stream.splitlines():
-        if not line.startswith(":"):
+    fields = stream.split("\0")
+    index = 0
+    while index < len(fields):
+        record = fields[index]
+        if not record.startswith(":"):
+            index += 1
             continue
-        fields = line.split("\t")
-        columns = fields[0].split()
-        if len(columns) < 5 or len(fields) < 2:
+        columns = record.split()
+        if len(columns) < 5:
+            index += 1
             continue
-        # A rename names both the old and the new path; the blob belongs to each.
-        for path in fields[1:]:
+        # A rename or copy names both the old path and the new one, and the
+        # blob belongs to each; everything else names one.
+        wanted = 2 if columns[4][:1] in ("R", "C") else 1
+        for path in (p for p in fields[index + 1 : index + 1 + wanted] if p):
             for sha in columns[2:4]:
                 if sha and set(sha) != {"0"}:
                     blobs.setdefault(path, set()).add(sha)
+        index += 1 + wanted
     return blobs
 
 
@@ -406,12 +428,18 @@ def project_paths(repo: str, roots: Sequence[str]) -> List[str]:
     to delete. It also keeps the two template modes agreeing — a walk would see
     build residue such as `__pycache__` that `git ls-tree` can never report.
 
-    `isfile` also excludes broken symlinks, symlinks to directories, and
-    submodule gitlinks, so none of those is ever retired. That is the safe
+    `isfile` excludes broken symlinks, symlinks to directories, and submodule
+    gitlinks *at the leaf*, so none of those is ever retired. That is the safe
     direction — the tool leaves them rather than guessing whether `os.remove` is
     the right verb — but it does mean a retired-upstream symlink of those shapes
     needs manual removal. A tracked symlink to a *file* is retired normally, and
     removes the link, never its target.
+
+    It says nothing about the **directories above** the leaf: `isfile` follows
+    every component, so a symlinked directory inside a syncable root resolves
+    this path somewhere else entirely. `_confined_target` is what refuses that,
+    at the deletion itself — this filter is not a containment check and must not
+    be read as one.
 
     Filtered to what is actually on disk, because `ls-files` reports the *index*.
     A path this script deleted on an earlier run stays in the index until the
@@ -428,7 +456,10 @@ def project_paths(repo: str, roots: Sequence[str]) -> List[str]:
 
 
 def template_paths_from_ref(repo: str, ref: str, roots: Sequence[str]) -> List[str]:
-    stream = _git(repo, "ls-tree", "-r", "--name-only", "-z", ref, "--", *roots)
+    stream = _git(
+        repo, "ls-tree", "-r", "--name-only", "-z", "--end-of-options", ref,
+        "--", *roots,
+    )
     return sorted(p for p in stream.split("\0") if p)
 
 
@@ -467,7 +498,11 @@ def read_template_doc(repo: str, ref: Optional[str], directory: Optional[str]) -
         if not os.path.isfile(path):
             raise RetireError(f"template checkout has no {SKILL_DOC}: {directory}")
         return _read_text(path)
-    return _git(repo, "show", f"{ref}:{SKILL_DOC}")
+    # --end-of-options at the sink: `main` rejects a ref starting with `-`, but
+    # that guard is 400 lines away and the tests already import this module and
+    # call in directly, so it is one refactor from being bypassed. Without it
+    # `git show "--output=...:path"` is read as an option.
+    return _git(repo, "show", "--end-of-options", f"{ref}:{SKILL_DOC}")
 
 
 def usable_roots(
@@ -627,6 +662,19 @@ def compute_plan(repo: str, ref: Optional[str], directory: Optional[str]) -> Pla
     )
 
 
+def _field(path: str) -> str:
+    """A path, rendered so it can only ever occupy one line of the report.
+
+    The report is the sole record of what a file-deleting tool destroyed, and
+    SKILL.md tells the operator to read it in full. A path containing a newline
+    would otherwise emit lines indistinguishable from real ones — a file can be
+    named so that the run claims to have kept what it deleted. `repr` also
+    escapes carriage returns, which repaint a terminal line, and surrogates
+    from `errors="surrogateescape"`, which would raise on print.
+    """
+    return path if path.isprintable() else repr(path)
+
+
 def render(plan: Plan) -> str:
     """Render what this run proposes, printed before anything is written.
 
@@ -651,28 +699,52 @@ def render(plan: Plan) -> str:
                 f"is retired"
             )
         for path in plan.retire:
-            lines.append(f"  retire: {path} (was template content, retired upstream)")
+            lines.append(f"  retire: {_field(path)} (was template content, retired upstream)")
         for path in plan.candidates:
-            lines.append(f"  candidate: {path}")
+            lines.append(f"  candidate: {_field(path)}")
         lines.append(
             f"  next:   re-run with --apply to write {CANDIDATE_FILE}, review it, "
             f"then rename it to {KEEP_FILE}"
         )
         return "\n".join(lines)
     for path in plan.retire:
-        lines.append(f"  retire: {path}")
+        lines.append(f"  retire: {_field(path)}")
     if not plan.retire:
         lines.append("  retire: (none)")
     for path, pattern in plan.kept:
-        lines.append(f"  kept:   {path} (matched {pattern})")
+        lines.append(f"  kept:   {_field(path)} (matched {_field(pattern)})")
     for pattern in plan.dormant:
         lines.append(
-            f"  dormant: {pattern} — under a skipped root; it protects again "
+            f"  dormant: {_field(pattern)} — under a skipped root; it protects again "
             f"when the template restores that root. Keep it"
         )
     for pattern in plan.unmatched:
-        lines.append(f"  unmatched: {pattern} — matched nothing this run")
+        lines.append(f"  unmatched: {_field(pattern)} — matched nothing this run")
     return "\n".join(lines)
+
+
+def _confined_target(repo_real: str, relative: str) -> Optional[str]:
+    """The path to delete, or None when a directory on the way is a symlink.
+
+    `project_paths` reads the *index* and confirms the leaf with
+    `os.path.isfile`, which follows every component. So a symlinked directory
+    inside a syncable root — a developer sharing a skill tree across worktrees
+    is enough, no hostile template required — makes `os.remove` delete a file
+    somewhere else entirely. That file was never in this repository, so
+    `git restore` cannot bring it back, which is the whole loss this tool is
+    built to avoid.
+
+    The leaf itself needs no check: `os.remove` never follows a final symlink,
+    so a symlinked *file* costs only the link.
+    """
+    parent = os.path.dirname(relative)
+    declared = os.path.normpath(os.path.join(repo_real, parent))
+    resolved = os.path.realpath(os.path.join(repo_real, parent))
+    if resolved != declared:
+        return None
+    if os.path.commonpath([repo_real, resolved]) != repo_real:
+        return None
+    return os.path.join(resolved, os.path.basename(relative))
 
 
 def apply_plan(
@@ -693,9 +765,18 @@ def apply_plan(
     removed: List[str] = []
     failed: List[Tuple[str, str]] = []
     pruned_failed: List[Tuple[str, str]] = []
+    repo_real = os.path.realpath(repo)
     for relative in plan.retire:
+        target = _confined_target(repo_real, relative)
+        if target is None:
+            failed.append((
+                relative,
+                "a directory on this path is a symlink, so it resolves outside "
+                "the repository — refusing to delete",
+            ))
+            continue
         try:
-            os.remove(os.path.join(repo, relative))
+            os.remove(target)
         except OSError as exc:
             failed.append((relative, str(exc)))
             continue
@@ -789,7 +870,20 @@ def write_candidate(repo: str, plan: Plan) -> str:
         "",
     ]
     lines.extend(_as_pattern(path) for path in plan.candidates)
-    with open(path, "w", encoding="utf-8") as handle:
+    # O_EXCL|O_NOFOLLOW subsumes the lexists precondition and closes the window
+    # between it and this write, which the bootstrap path widens by deleting in
+    # between. A same-uid process cannot land a symlink here and be followed.
+    try:
+        descriptor = os.open(
+            path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o644
+        )
+    except FileExistsError:
+        raise RetireError(
+            f"{CANDIDATE_FILE} already exists — review it and rename it to "
+            f"{KEEP_FILE}, or delete it to regenerate. Refusing to overwrite a "
+            f"file this tool asked a human to edit"
+        )
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
     return path
 
@@ -902,12 +996,12 @@ def _deletion_outcome(
     # The docstring promises a partial run "reports every file it removed", and a
     # count is not that: the operator would have to subtract FAILED lines from an
     # earlier render they may no longer have.
-    lines.extend(f"  deleted: {path}" for path in removed)
-    lines.extend(f"  FAILED: {path} — {reason}" for path, reason in failed)
+    lines.extend(f"  deleted: {_field(path)}" for path in removed)
+    lines.extend(f"  FAILED: {_field(path)} — {reason}" for path, reason in failed)
     # A directory left behind is reported separately: the files under it are
     # gone either way, so this must not read as a deletion that did not happen.
-    lines.extend(f"  UNPRUNED: {path} — {reason}" for path, reason in pruned_failed)
-    lines.extend(f"  FAILED: cannot write {path} — {reason}" for path, reason in unwritten)
+    lines.extend(f"  UNPRUNED: {_field(path)} — {reason}" for path, reason in pruned_failed)
+    lines.extend(f"  FAILED: cannot write {_field(path)} — {reason}" for path, reason in unwritten)
     return "\n".join(lines), 1
 
 

--- a/.claude/skills/sync/scripts/sync-retire.py
+++ b/.claude/skills/sync/scripts/sync-retire.py
@@ -1,0 +1,963 @@
+#!/usr/bin/env python3
+"""Deterministic retirement for /sync.
+
+`/sync` copies files in; it never deletes. A path present in a project but
+absent from the template is either retired upstream or project-specific, and
+until now nothing recorded which — so the answer was re-derived by a model on
+every run, and two runs against one template commit could produce different
+trees.
+
+This script replaces that judgement with set arithmetic:
+
+    retire = project paths under syncable roots
+           - template paths under the same roots
+           - paths matching a .claude/sync-keep pattern
+
+Nothing is classified at run time. Given the same template revision, the same
+project tree and the same sync-keep, the retirement set is identical on every
+run and from every project branch.
+
+Stdlib only, Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import re
+import subprocess
+import sys
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+KEEP_FILE = ".claude/sync-keep"
+CANDIDATE_FILE = ".claude/sync-keep.candidate"
+SKILL_DOC = ".agents/skills/sync/SKILL.md"
+
+# `[`, `]`, `{`, `}` and `!` are the glob syntax this format does *not* accept.
+# Silently ignoring them would let an author record intent that protects
+# nothing, which is the failure mode the whole allowlist exists to prevent.
+UNSUPPORTED_GLOB_CHARS = "[]{}!"
+
+# A syncable root must be a direct subdirectory of one of the two harness trees:
+# `.agents/skills/`, `.claude/hooks/`, and so on. The doc block that names the
+# roots is read from the *template* — a remote repository, or in manual-diff mode
+# a directory under /tmp — so without this the template chooses what a
+# file-deleting tool is pointed at. A hostile or simply mistaken block naming
+# `src/` deletes the project's source; naming `.claude/` sweeps in the never-sync
+# files, including the allowlist this whole mechanism depends on. Staying inside
+# the repository is not sufficient, because every one of those paths already is.
+SYNCABLE_ROOT_PATTERN = re.compile(r"^\.(agents|claude)/[A-Za-z0-9_-]+/$")
+
+
+class PruneError(Exception):
+    """A directory that could not be removed, carrying which one it was."""
+
+    def __init__(self, directory: str, reason: str) -> None:
+        super().__init__(f"{directory}: {reason}")
+        self.directory = directory
+        self.reason = reason
+
+
+class RetireError(Exception):
+    """A failure that must stop the run before anything is deleted."""
+
+
+# ------------------------------------------------------- patterns and matching
+
+
+def _pattern_to_regex(pattern: str) -> str:
+    """Translate the three supported tokens; everything else is a literal.
+
+    Hand-written rather than `fnmatch`, whose `*` happily crosses `/` and whose
+    `[seq]` syntax this format does not accept. Borrowing it would silently
+    widen every allowlist entry.
+    """
+    # TODO(shortcut): this and `match_path` duplicate
+    # `.agents/skills/wrap-up-session/scripts/spec-reconcile.py`, which has the
+    # same three-token semantics. Not shared yet because that file's hyphenated
+    # name makes it importable only through `importlib`, and the two validators
+    # have different contracts — a sync-keep pattern must additionally name a
+    # syncable root. Upgrade path: extract the matcher into an importable module
+    # both scripts read (filed as `glob-matcher-shared-module`).
+    # Kept as a `#` comment, not docstring prose: the /wrap-up-session shortcut
+    # ledger greps for comment syntax, and a marker it cannot see is a deferral
+    # that rots silently.
+    out: List[str] = []
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        elif pattern[index] == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(pattern[index]))
+            index += 1
+    return "".join(out)
+
+
+def match_path(pattern: str, path: str) -> bool:
+    return re.fullmatch(_pattern_to_regex(pattern), path) is not None
+
+
+def validate_pattern(pattern: str, line_number: int, roots: Sequence[str]) -> str:
+    """Return `pattern` if this program will interpret it, else raise.
+
+    Every rejection is a value that would otherwise fail *silently*: an
+    unsupported token matches nothing, so the path it was meant to protect is
+    retired anyway and the author learns about it from the deletion. The line
+    number travels with the message because an allowlist is edited by hand.
+    """
+    where = f"{KEEP_FILE} line {line_number}"
+    if pattern.startswith("/") or re.match(r"^[A-Za-z]:", pattern):
+        raise RetireError(f"{where}: absolute path not allowed: `{pattern}`")
+    if "\\" in pattern:
+        raise RetireError(f"{where}: use POSIX separators, not backslashes: `{pattern}`")
+    if ".." in pattern.split("/"):
+        raise RetireError(f"{where}: `..` traversal not allowed: `{pattern}`")
+    if pattern.endswith("/"):
+        raise RetireError(
+            f"{where}: `{pattern}` ends in `/`, so it matches no file and protects "
+            f"nothing — did you mean `{pattern}**`?"
+        )
+    bad = [c for c in UNSUPPORTED_GLOB_CHARS if c in pattern]
+    if bad:
+        raise RetireError(
+            f"{where}: unsupported glob syntax {''.join(bad)!r} in `{pattern}` "
+            f"— only *, ? and ** are accepted"
+        )
+    if not _reaches_a_root(pattern, roots):
+        raise RetireError(
+            f"{where}: `{pattern}` is outside every syncable root "
+            f"({', '.join(roots)}) — it can never protect anything"
+        )
+    return pattern
+
+
+def _reaches_a_root(pattern: str, roots: Sequence[str]) -> bool:
+    """Can this pattern match any path under any root?
+
+    Tested on the pattern's literal head — everything before its first glob
+    token — because a prefix test alone contradicts the matcher: `**` crosses
+    `/`, so `.claude/**` does reach `.claude/hooks/`, and rejecting it with
+    "it can never protect anything" told the author the opposite of the truth.
+    A head that is a prefix of a root, or prefixed by one, reaches it.
+    """
+    cut = min((i for i in (pattern.find("*"), pattern.find("?")) if i != -1), default=len(pattern))
+    head = pattern[:cut]
+    return any(head.startswith(root) or root.startswith(head) for root in roots)
+
+
+def read_keep_patterns(repo: str, roots: Sequence[str]) -> Optional[List[str]]:
+    """Read `.claude/sync-keep`, or return None when the project has no file.
+
+    None is *bootstrap*, an empty list is a recorded "nothing here is
+    project-specific". Collapsing the two would make an unconfigured project
+    look like one that had opted into deletion.
+    """
+    path = os.path.join(repo, KEEP_FILE)
+    if not os.path.isfile(path):
+        # S7: absent and unreadable are different states. A dangling symlink or a
+        # directory here is not "no allowlist" -- reporting bootstrap for it would
+        # claim the project never configured one, and write a candidate over the
+        # top of whatever is actually there.
+        if os.path.lexists(path):
+            raise RetireError(
+                f"{KEEP_FILE} exists but is not a regular file — refusing to treat "
+                f"it as an absent allowlist"
+            )
+        return None
+    patterns: List[str] = []
+    text = _read_text(path)
+    for line_number, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        patterns.append(validate_pattern(stripped, line_number, roots))
+    return patterns
+
+
+# ------------------------------------------------------------- syncable roots
+
+
+def _validate_root(entry: str, origin: str) -> str:
+    """Refuse a root that is not one of the directories `/sync` manages.
+
+    Errs toward scanning less: a legitimate new root that does not fit the shape
+    is simply not retired from, which leaves stale files behind. The opposite
+    failure deletes files the tool was never meant to touch.
+    """
+    if not SYNCABLE_ROOT_PATTERN.match(entry):
+        raise RetireError(
+            f"{origin}: `{entry}` is not a syncable root — a root must be a direct "
+            f"subdirectory of .agents/ or .claude/ (for example .agents/skills/). "
+            f"Refusing to point a file-deleting tool at it"
+        )
+    return entry
+
+
+def parse_syncable_roots(text: str, origin: str) -> List[str]:
+    """Read the directory roots out of the `## Syncable Paths` doc block.
+
+    The block is parsed rather than copied so this script becomes a *consumer*
+    of the one list `tests/test-syncable-paths.sh` already pins, instead of an
+    eighth hand-maintained duplicate of it.
+
+    The block's file entries (`CLAUDE.md`, `.claude/settings.json`) are dropped:
+    retirement is undefined for a file — it has no project-only paths inside it
+    — and the checkout step already handles them.
+    """
+    directories: List[str] = []
+    in_block = False
+    for line in text.splitlines():
+        if line.startswith("## Syncable Paths"):
+            in_block = True
+            continue
+        if in_block and re.match(r"^#{2,} ", line):
+            break
+        if in_block and "→" in line:
+            entry = line.split("→", 1)[0].strip()
+            if entry.endswith("/"):
+                directories.append(_validate_root(entry, origin))
+    if not directories:
+        raise RetireError(
+            f"{origin}: no `## Syncable Paths` doc block with directory roots — "
+            f"cannot determine what to scan"
+        )
+    return sorted(set(directories))
+
+
+# ---------------------------------------------------------------- inventories
+
+
+def _read_text(path: str) -> str:
+    """Read a file the operator controls, reporting failures on our own channel.
+
+    `open` raises OSError and UnicodeDecodeError, and `main` only catches
+    RetireError -- so an unreadable or non-UTF-8 allowlist escaped as a
+    traceback, while SKILL.md promises this tool "fails loudly" in the sense of
+    a controlled stop.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RetireError(f"cannot read {path}: {exc}")
+
+
+def _git(repo: str, *args: str) -> str:
+    """Run git against a tree whose configuration is untrusted input.
+
+    `--from-dir` points this at a template checkout the project did not write,
+    and git reads that repository's own `.git/config` — where `core.fsmonitor`
+    names a command git executes on `ls-files`. The checkout is same-uid, so
+    `safe.directory` never fires, and the read happens during the Step 3 dry
+    run, before the user has approved anything. Pinning the exec-capable knobs
+    off on the command line beats them: `-c` outranks repository config.
+    """
+    env = dict(os.environ, GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL=os.devnull)
+    result = subprocess.run(
+        ("git", "-C", repo, "-c", "core.fsmonitor=", "-c", "core.hooksPath=" + os.devnull)
+        + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        # surrogateescape, not replace: this string is fed back to os.remove, and
+        # a replacement character produces a path that can never round-trip.
+        errors="surrogateescape",
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RetireError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def _one_line(exc: Exception) -> str:
+    """Collapse a multi-line git error into a single report line.
+
+    `render` emits one line per item and its readers grep it, while git's
+    fatals routinely run to three lines with a usage hint appended.
+    """
+    return " ".join(
+        "".join(char for char in token if char.isprintable())
+        for token in str(exc).split()
+    )
+
+
+def _history_is_truncated(where: str, revision: str) -> bool:
+    """True when this revision's history stops at a shallow graft.
+
+    A shallow clone makes git treat its boundary commits as roots, but the
+    commit *objects* still record the parents that were never fetched. So a
+    root whose object names a parent is a graft — at any clone depth.
+
+    Both earlier probes were wrong in opposite directions.
+    `--is-shallow-repository` describes the repository, and in `--from-ref` the
+    revision lives in the *project*, so a shallow project suppressed provenance
+    for a complete template ref. Counting commits caught only depth 1, so a
+    `--depth 5` clone silently produced a *different* retirement set from the
+    same commit SHA — the non-determinism this whole feature exists to remove.
+    """
+    for commit in _git(where, "rev-list", "--max-parents=0", revision).split():
+        if re.search(r"^parent ", _git(where, "cat-file", "commit", commit), re.M):
+            return True
+    return False
+
+
+def _project_blobs(repo: str, paths: Sequence[str]) -> Dict[str, str]:
+    """Hash each project file as it exists **on disk**, not as it is indexed.
+
+    On disk is the load-bearing part. A file with uncommitted local edits hashes
+    to something no template commit ever produced, so it falls out of the
+    retirement set and is held for a human — which is the only way to avoid
+    destroying work that `git checkout` cannot bring back.
+    """
+    if not paths:
+        return {}
+    hashed = _git(repo, "hash-object", "--", *paths).split()
+    return dict(zip(paths, hashed))
+
+
+def template_history_blobs(
+    where: str, revision: str, roots: Sequence[str]
+) -> Dict[str, Set[str]]:
+    """Every blob the template has ever held at each path under these roots.
+
+    Paths alone cannot answer "is this the template's file?". `.claude/hooks/`
+    is a syncable root and `pre-commit.sh` is a name both a template and a
+    project reach for, so path membership would delete a file this project
+    wrote itself and never synced. The blob is what distinguishes them.
+
+    `--raw` carries the pre- and post-image blob of every change, so one walk
+    yields the full content history without re-reading a tree per commit.
+    """
+    stream = _git(
+        where, "log", "--pretty=format:", "--raw", "--no-abbrev",
+        "--diff-filter=AMRD", revision, "--", *roots,
+    )
+    blobs: Dict[str, Set[str]] = {}
+    for line in stream.splitlines():
+        if not line.startswith(":"):
+            continue
+        fields = line.split("\t")
+        columns = fields[0].split()
+        if len(columns) < 5 or len(fields) < 2:
+            continue
+        # A rename names both the old and the new path; the blob belongs to each.
+        for path in fields[1:]:
+            for sha in columns[2:4]:
+                if sha and set(sha) != {"0"}:
+                    blobs.setdefault(path, set()).add(sha)
+    return blobs
+
+
+def template_history_paths(
+    repo: str, ref: Optional[str], directory: Optional[str], roots: Sequence[str]
+) -> Tuple[Optional[Dict[str, Set[str]]], str]:
+    """Every path the template has *ever* carried under these roots.
+
+    This is the record that answers "is this project-specific?" without asking a
+    model. A path the template once shipped and no longer does was retired
+    upstream; a path the template never carried is the project's own. Before
+    this, only the template's current state was consulted, so the two were
+    indistinguishable and a project without a sync-keep had to keep both.
+
+    Returns `(None, reason)` when the history is not available -- a truncated
+    clone has one commit, and its "history" is just its current state, which
+    would silently classify every retired path as project-specific. The reason
+    travels with it because every git failure here used to be reported as
+    "shallow template history": a missing ref, an unreadable object and a
+    genuinely shallow clone are three different problems with three different
+    fixes, and the operator was shown only the third.
+
+    The probe measures the **revision**, not the repository. `--is-shallow-
+    repository` is a property of the whole repo, and in `--from-ref` mode the
+    revision lives in the *project* -- so a project that is itself a `--depth 1`
+    checkout (what CI does by default) reported "shallow template history" and
+    retired nothing, however complete the fetched template ref was. Counting
+    commits reachable from the revision asks the question actually being asked,
+    in both modes, and needs no branch.
+    """
+    where = directory or repo
+    revision = "HEAD" if directory else str(ref)
+    try:
+        if _history_is_truncated(where, revision):
+            return None, (
+                f"{revision} has truncated history — a shallow clone carries no "
+                f"record of what the template used to ship. Re-clone without "
+                f"--depth (--filter=blob:none keeps it cheap)"
+            )
+        return template_history_blobs(where, revision, roots), ""
+    except RetireError as exc:
+        return None, _one_line(exc)
+
+
+def project_paths(repo: str, roots: Sequence[str]) -> List[str]:
+    """Tracked files under the syncable roots.
+
+    Tracked, not walked: `/sync` delivers files through `git checkout`, so an
+    untracked file under a root was never synced in and is not this program's
+    to delete. It also keeps the two template modes agreeing — a walk would see
+    build residue such as `__pycache__` that `git ls-tree` can never report.
+
+    `isfile` also excludes broken symlinks, symlinks to directories, and
+    submodule gitlinks, so none of those is ever retired. That is the safe
+    direction — the tool leaves them rather than guessing whether `os.remove` is
+    the right verb — but it does mean a retired-upstream symlink of those shapes
+    needs manual removal. A tracked symlink to a *file* is retired normally, and
+    removes the link, never its target.
+
+    Filtered to what is actually on disk, because `ls-files` reports the *index*.
+    A path this script deleted on an earlier run stays in the index until the
+    removal is staged, so an unfiltered read would list it again, compute it as
+    project-only a second time, and fail on `os.remove` — making a second
+    `--apply` before the user commits crash rather than report nothing to do.
+    """
+    stream = _git(repo, "ls-files", "-z", "--", *roots)
+    return sorted(
+        path
+        for path in stream.split("\0")
+        if path and os.path.isfile(os.path.join(repo, path))
+    )
+
+
+def template_paths_from_ref(repo: str, ref: str, roots: Sequence[str]) -> List[str]:
+    stream = _git(repo, "ls-tree", "-r", "--name-only", "-z", ref, "--", *roots)
+    return sorted(p for p in stream.split("\0") if p)
+
+
+def template_paths_from_dir(directory: str, roots: Sequence[str]) -> List[str]:
+    """Template inventory from a checkout on disk.
+
+    Read through git when the checkout is a repository — which is how `/sync`
+    obtains it — so all three inventories mean the same thing by "the paths
+    under a root". A bare walk counts gitignored residue as template content,
+    which both breaks the `--from-ref`/`--from-dir` equivalence and lets
+    `assert_roots_present` be satisfied by files the committed tree lacks,
+    masking the wrong checkout in the one guard that exists to catch it.
+    """
+    if os.path.isdir(os.path.join(directory, ".git")):
+        stream = _git(directory, "ls-files", "-z", "--", *roots)
+        return sorted(p for p in stream.split("\0") if p)
+    found: List[str] = []
+    for root in roots:
+        base = os.path.join(directory, root)
+        for current, _dirs, names in os.walk(base):
+            for name in names:
+                absolute = os.path.join(current, name)
+                found.append(os.path.relpath(absolute, directory).replace(os.sep, "/"))
+    return sorted(found)
+
+
+def read_template_doc(repo: str, ref: Optional[str], directory: Optional[str]) -> str:
+    """Read the roots doc block from the *template*, never from the project.
+
+    The template is the authority on what the roots contain. Reading the
+    project's copy would let a project on a stale branch scan yesterday's root
+    list, which is the non-determinism this feature removes.
+    """
+    if directory:
+        path = os.path.join(directory, SKILL_DOC)
+        if not os.path.isfile(path):
+            raise RetireError(f"template checkout has no {SKILL_DOC}: {directory}")
+        return _read_text(path)
+    return _git(repo, "show", f"{ref}:{SKILL_DOC}")
+
+
+def usable_roots(
+    template: Sequence[str], roots: Sequence[str], source: str
+) -> Tuple[List[str], List[str]]:
+    """Split declared roots into those the template can vouch for, and those it cannot.
+
+    A root the template has no files under is ambiguous. Retiring from it would
+    compute `everything the project has` minus `nothing` and delete the
+    project's entire copy — the one mistake this script must never make quietly.
+
+    **One** empty root is read as an ordinary upstream deletion and skipped, so
+    that a single commit cannot disable retirement everywhere: two roots in this
+    template hold a single file each, and removing either used to exit 1 for
+    every downstream project and retire nothing at all.
+
+    **Several** empty roots are read as a wrong or partial source and refused.
+    That distinction is what keeps the catastrophe guard: a truncated checkout
+    empties many roots at once, while upstream retires them one release at a
+    time. The threshold matters because the doc block itself lives under
+    `.agents/skills/`, so that root is non-empty in *any* template this script
+    can read — an all-empty test would never fire for it, and a broken clone
+    carrying only the sync skill would otherwise retire every other skill the
+    project has.
+    """
+    present = [r for r in roots if any(p.startswith(r) for p in template)]
+    empty = [r for r in roots if r not in present]
+    if len(empty) > 1:
+        raise RetireError(
+            f"template source {source} contains no files under {len(empty)} of "
+            f"{len(roots)} syncable roots ({', '.join(empty)}) — refusing a "
+            f"source this incomplete; retiring against it would delete the "
+            f"project's copy of each"
+        )
+    if not present:
+        raise RetireError(
+            f"template source {source} contains no files under any syncable root "
+            f"({', '.join(roots)}) — refusing to treat an empty template as a "
+            f"complete one"
+        )
+    return present, empty
+
+
+# ------------------------------------------------------------- the retirement
+
+
+@dataclasses.dataclass
+class Plan:
+    roots: List[str]
+    source: str
+    retire: List[str] = dataclasses.field(default_factory=list)
+    kept: List[Tuple[str, str]] = dataclasses.field(default_factory=list)
+    # `bootstrap` discriminates: it selects whether `candidates` or
+    # `retire`/`kept` carry meaning, and both consumers branch on it. Modelled
+    # as one type with a flag rather than two types, which keeps the invalid
+    # combinations representable — see the `glob-matcher-shared-module` sibling
+    # follow-up for the split this wants eventually.
+    candidates: List[str] = dataclasses.field(default_factory=list)
+    unmatched: List[str] = dataclasses.field(default_factory=list)
+    # Patterns that reach only a skipped root: inactive this run, but the only
+    # thing that will protect the file when the template restores that root.
+    # Reporting them as `unmatched` invited the operator to delete them.
+    dormant: List[str] = dataclasses.field(default_factory=list)
+    bootstrap: bool = False
+    # Declared in the doc block but empty in the template: reported, never
+    # scanned. Retirement is undefined for a root the template cannot vouch for.
+    skipped_roots: List[str] = dataclasses.field(default_factory=list)
+    # Empty means provenance was read -- distinct from "read it, nothing was
+    # ever retired". Non-empty is why it could not be, quoted to the operator.
+    provenance_reason: str = ""
+
+
+def split_by_allowlist(
+    project_only: Sequence[str], patterns: Sequence[str]
+) -> Tuple[List[str], List[Tuple[str, str]], List[str]]:
+    """Split project-only paths into those to retire and those a pattern saved.
+
+    Each kept path carries the pattern that matched it, so a survivor is
+    traceable to the line that saved it — "kept" alone would make a sync-keep
+    entry that silently stopped matching look like one still doing its job.
+
+    Also returns the patterns that matched nothing. That is not an error — a
+    path may legitimately not exist yet — but it is the state a stale allowlist
+    is in just before it stops protecting something, and it is invisible unless
+    reported.
+    """
+    retire: List[str] = []
+    kept: List[Tuple[str, str]] = []
+    for path in project_only:
+        matched = next((pat for pat in patterns if match_path(pat, path)), None)
+        if matched is None:
+            retire.append(path)
+        else:
+            kept.append((path, matched))
+    used = {pattern for _, pattern in kept}
+    return retire, kept, [pattern for pattern in patterns if pattern not in used]
+
+
+def compute_plan(repo: str, ref: Optional[str], directory: Optional[str]) -> Plan:
+    """Resolve both inventories and reduce them to what this run would delete."""
+    source = ref or directory or ""
+    roots = parse_syncable_roots(read_template_doc(repo, ref, directory), source)
+    template = (
+        template_paths_from_dir(directory, roots)
+        if directory
+        else template_paths_from_ref(repo, str(ref), roots)
+    )
+    scanned, skipped = usable_roots(template, roots, source)
+    known = set(template)
+    project_only = [p for p in project_paths(repo, scanned) if p not in known]
+    patterns = read_keep_patterns(repo, roots)
+    if patterns is None:
+        # Bootstrap. A project with no recorded allowlist still knows one thing
+        # for certain: a path the template *used to* carry was retired upstream,
+        # not written by this project. Deleting those needs no human
+        # classification, which is the whole premise of the feature -- and
+        # without it a project that never promotes a candidate keeps every
+        # retired skill forever.
+        history, reason = template_history_paths(repo, ref, directory, scanned)
+        if history is None:
+            return Plan(
+                roots=scanned, source=source, bootstrap=True,
+                candidates=project_only, skipped_roots=skipped,
+                provenance_reason=reason,
+            )
+        # Content, not path. A path the template once used proves nothing about
+        # the file sitting there now: `.claude/hooks/pre-commit.sh` is a name
+        # both a template and a project reach for, and a project that edited a
+        # synced file has made it its own. Retire only a byte-identical copy of
+        # something the template actually shipped at that path -- anything else
+        # goes to the human, including a file with uncommitted edits, which
+        # `git checkout` could never bring back.
+        blobs = _project_blobs(repo, project_only)
+        retired_upstream = [
+            p for p in project_only if blobs.get(p) in history.get(p, set())
+        ]
+        unproven = set(project_only) - set(retired_upstream)
+        return Plan(
+            roots=scanned, source=source, bootstrap=True,
+            retire=retired_upstream,
+            candidates=[p for p in project_only if p in unproven],
+            skipped_roots=skipped,
+        )
+    retire, kept, unmatched = split_by_allowlist(project_only, patterns)
+    # A pattern under a skipped root matched nothing because nothing under that
+    # root was scanned -- not because it went stale. The two need different
+    # words: `unmatched` is documented as "about to stop protecting something",
+    # which is the opposite of the truth here.
+    dormant = [
+        pattern for pattern in unmatched
+        if not _reaches_a_root(pattern, scanned) and _reaches_a_root(pattern, skipped)
+    ]
+    return Plan(
+        roots=scanned, source=source, retire=retire, kept=kept,
+        unmatched=[p for p in unmatched if p not in dormant],
+        dormant=dormant, skipped_roots=skipped,
+    )
+
+
+def render(plan: Plan) -> str:
+    """Render what this run proposes, printed before anything is written.
+
+    The retire list is never truncated.
+
+    The progressive-disclosure cap that bounds other reports in this repo is a
+    readability optimisation. Here the list *is* the record of what is about to
+    be destroyed, and abbreviating it would hide exactly what the report exists
+    to show.
+    """
+    lines = [f"sync retirement — source: {plan.source}, roots: {len(plan.roots)}"]
+    for root in plan.skipped_roots:
+        lines.append(
+            f"  skipped: {root} — declared but empty in the template; "
+            f"nothing under it is retired this run"
+        )
+    if plan.bootstrap:
+        lines.append(f"  bootstrap: required (no {KEEP_FILE})")
+        if plan.provenance_reason:
+            lines.append(
+                f"  provenance: unavailable ({plan.provenance_reason}) — nothing "
+                f"is retired"
+            )
+        for path in plan.retire:
+            lines.append(f"  retire: {path} (was template content, retired upstream)")
+        for path in plan.candidates:
+            lines.append(f"  candidate: {path}")
+        lines.append(
+            f"  next:   re-run with --apply to write {CANDIDATE_FILE}, review it, "
+            f"then rename it to {KEEP_FILE}"
+        )
+        return "\n".join(lines)
+    for path in plan.retire:
+        lines.append(f"  retire: {path}")
+    if not plan.retire:
+        lines.append("  retire: (none)")
+    for path, pattern in plan.kept:
+        lines.append(f"  kept:   {path} (matched {pattern})")
+    for pattern in plan.dormant:
+        lines.append(
+            f"  dormant: {pattern} — under a skipped root; it protects again "
+            f"when the template restores that root. Keep it"
+        )
+    for pattern in plan.unmatched:
+        lines.append(f"  unmatched: {pattern} — matched nothing this run")
+    return "\n".join(lines)
+
+
+def apply_plan(
+    repo: str, plan: Plan
+) -> Tuple[List[str], List[Tuple[str, str]], List[Tuple[str, str]]]:
+    """Delete the retirement set, prune the emptied directories, report removals.
+
+    Returns what it actually removed and what it could not, rather than what it
+    intended to. A mid-loop failure that propagated would abandon the record of
+    the files already gone, leaving the operator to discover them with
+    `git status` — for a tool whose list is the record of what was destroyed,
+    that is the one hole that matters.
+
+    Pruning stops at the syncable root: an absent root and an empty one are
+    different states to every other reader of the tree, and only the deletions
+    below it were authorised.
+    """
+    removed: List[str] = []
+    failed: List[Tuple[str, str]] = []
+    pruned_failed: List[Tuple[str, str]] = []
+    for relative in plan.retire:
+        try:
+            os.remove(os.path.join(repo, relative))
+        except OSError as exc:
+            failed.append((relative, str(exc)))
+            continue
+        removed.append(relative)
+    for relative in removed:
+        try:
+            _prune_upwards(repo, os.path.dirname(relative), plan.roots)
+        except PruneError as exc:
+            # The file is already gone; only the empty directory above it
+            # survives. Propagating here would discard `removed` -- the record
+            # of what was destroyed -- which is the one hole this function
+            # exists to close. A leftover directory is cosmetic; a lost record
+            # is not.
+            entry = (exc.directory, exc.reason)
+            if entry not in pruned_failed:
+                pruned_failed.append(entry)
+    return removed, failed, pruned_failed
+
+
+# Every character validate_pattern rejects outright, plus the glob tokens this
+# language has no escape for. Restating this set by hand is what let backslash
+# drift out of it: `validate_pattern` refuses `\`, but `_as_pattern` happily
+# wrote one, so the tool emitted a line that made every later sync exit 1.
+UNEXPRESSIBLE_CHARS = UNSUPPORTED_GLOB_CHARS + "*?" + "\\" + "\n\r"
+
+
+def _is_unexpressible(path: str) -> bool:
+    """A path no sync-keep line can name, for any reason the reader would trip on."""
+    return path != path.strip() or bool(set(path) & set(UNEXPRESSIBLE_CHARS))
+
+
+def _as_pattern(path: str) -> str:
+    """Emit a project path as an allowlist pattern, or comment it out.
+
+    Candidate lines are read back as globs, and this language has no escape
+    syntax. A path containing `*` would become an over-broad rule that silently
+    protects unrelated siblings from retirement; one containing `[` would make
+    every later sync exit 1 on a line this tool wrote itself. Neither is
+    something a human asked for, so an unexpressible path is written as a
+    comment naming the problem.
+    """
+    if _is_unexpressible(path):
+        return (
+            "# UNEXPRESSIBLE — this path contains glob metacharacters, surrounding\n"
+            "# whitespace, or a line break, and no exact pattern can name it: the\n"
+            "# reader strips each line, so such a rule would silently protect\n"
+            "# nothing and the file would be retired anyway. Widen it\n"
+            "# deliberately, or rename the file:\n"
+            + "\n".join(f"#   {line}" for line in path.splitlines() or [path])
+        )
+    return path
+
+
+def assert_candidate_writable(repo: str) -> None:
+    """Raise if the candidate file cannot be written, touching nothing.
+
+    Separated from the write so the bootstrap apply path can check it *before*
+    deleting: a precondition that only fires after the destruction it guards
+    reports nothing about what was destroyed.
+    """
+    path = os.path.join(repo, CANDIDATE_FILE)
+    # lexists, not exists: a dangling symlink is invisible to `exists`, and
+    # `open(path, "w")` then follows it and writes through to whatever it
+    # names. `read_keep_patterns` already refuses this for the allowlist; the
+    # candidate is the file this tool writes, which makes it the better target.
+    if os.path.lexists(path):
+        raise RetireError(
+            f"{CANDIDATE_FILE} already exists — review it and rename it to "
+            f"{KEEP_FILE}, or delete it to regenerate. Refusing to overwrite a "
+            f"file this tool asked a human to edit"
+        )
+
+
+def write_candidate(repo: str, plan: Plan) -> str:
+    """Write the reviewable candidate allowlist, never the allowlist itself.
+
+    Promoting the candidate is the human's confirming act. A script that wrote
+    `.claude/sync-keep` directly would record an intent nobody expressed, and
+    every later run would treat that guess as data.
+    """
+    assert_candidate_writable(repo)
+    path = os.path.join(repo, CANDIDATE_FILE)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    lines = [
+        "# Candidate sync-keep, written by /sync in bootstrap mode.",
+        "#",
+        "# Every path below exists in this project but not in the template. Delete",
+        "# the lines naming paths that were retired upstream, keep the ones that are",
+        f"# genuinely project-specific, then rename this file to {os.path.basename(KEEP_FILE)}.",
+        "# Until that file exists, /sync retires nothing.",
+        "",
+    ]
+    lines.extend(_as_pattern(path) for path in plan.candidates)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+    return path
+
+
+def _prune_upwards(repo: str, relative_dir: str, roots: Sequence[str]) -> None:
+    """Remove directories emptied by the deletion, stopping at the syncable root.
+
+    An OSError carries the directory it was raised for, because pruning walks
+    upward: the directory this was *called* with has usually been removed
+    successfully by the time a parent fails, so reporting the starting point
+    names a path that no longer exists.
+    """
+    boundaries = {root.rstrip("/") for root in roots}
+    while relative_dir and relative_dir not in boundaries:
+        absolute = os.path.join(repo, relative_dir)
+        if not os.path.isdir(absolute):
+            return
+        try:
+            if os.listdir(absolute):
+                return
+            os.rmdir(absolute)
+        except OSError as exc:
+            raise PruneError(relative_dir, str(exc))
+        relative_dir = os.path.dirname(relative_dir)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sync-retire",
+        description="Compute and apply the deterministic /sync retirement set.",
+    )
+    parser.add_argument("--from-ref", help="template inventory read from a git ref")
+    parser.add_argument("--from-dir", help="template inventory read from a checkout")
+    parser.add_argument("--repo", default=".", help="project root (default: cwd)")
+    parser.add_argument("--apply", action="store_true", help="perform the deletions")
+    return parser
+
+
+def apply_requested_writes(repo: str, plan: Plan) -> Tuple[str, int]:
+    """Carry out what `--apply` means in this mode, and report what happened.
+
+    Bootstrap writes a candidate for review and deletes nothing; a configured
+    project deletes the retirement set. Both return their outcome line and an
+    exit code rather than printing, so `render`'s format stays owned in one
+    place and a partial deletion still reports every file it removed.
+    """
+    if plan.bootstrap:
+        # Bootstrap deletes only what provenance proves was template content.
+        # Everything of unknown origin goes to the candidate file for a human,
+        # exactly as before -- the confirming act is still theirs, it just no
+        # longer stands between the project and a skill the template retired.
+        #
+        # Precondition first: write_candidate refuses an existing candidate, and
+        # that raise used to happen *after* the deletions, so `removed` -- the
+        # record of what was destroyed -- was discarded on the routine
+        # "candidate not promoted yet" path. Nothing may fail between the
+        # deletion and its report.
+        assert_candidate_writable(repo)
+        removed, failed, pruned_failed = apply_plan(repo, plan)
+        # The existence check above is a courtesy, not the guarantee. Every
+        # other way this write fails -- unwritable `.claude/`, read-only mount,
+        # ENOSPC -- can only be discovered by attempting it, which is *after*
+        # the deletions. So the failure is folded into the report rather than
+        # raised through it: propagating here would unwind past `removed`, the
+        # only record that those files ever existed.
+        unwritten: List[Tuple[str, str]] = []
+        try:
+            write_candidate(repo, plan)
+        except (OSError, RetireError) as exc:
+            unwritten.append((CANDIDATE_FILE, _one_line(exc)))
+        if not plan.retire and not failed and not pruned_failed and not unwritten:
+            return (
+                f"  wrote:  {CANDIDATE_FILE} "
+                f"({len(plan.candidates)} candidates to review)"
+            ), 0
+        outcome, code = _deletion_outcome(removed, failed, pruned_failed, unwritten)
+        if unwritten:
+            return outcome, code
+        return (
+            f"{outcome}\n  wrote:  {CANDIDATE_FILE} "
+            f"({len(plan.candidates)} candidates to review)"
+        ), code
+    removed, failed, pruned_failed = apply_plan(repo, plan)
+    return _deletion_outcome(removed, failed, pruned_failed)
+
+
+def _deletion_outcome(
+    removed: List[str],
+    failed: List[Tuple[str, str]],
+    pruned_failed: List[Tuple[str, str]],
+    unwritten: Sequence[Tuple[str, str]] = (),
+) -> Tuple[str, int]:
+    """One format for what a deletion did, shared by both apply paths.
+
+    `unwritten` is a fourth category because a run can delete successfully and
+    still fail afterwards — the bootstrap candidate write is the case. It has
+    to make the run *partial*, or the deletion record collapses back to a count
+    at exactly the moment the operator most needs the paths.
+    """
+    if not failed and not pruned_failed and not unwritten:
+        return f"  mode:   applied ({len(removed)} deleted)", 0
+    headline = f"  mode:   applied ({len(removed)} deleted"
+    if failed:
+        headline += f", {len(failed)} failed"
+    if pruned_failed:
+        headline += f", {len(pruned_failed)} not pruned"
+    if unwritten:
+        headline += f", {len(unwritten)} not written"
+    lines = [headline + ")"]
+    # The docstring promises a partial run "reports every file it removed", and a
+    # count is not that: the operator would have to subtract FAILED lines from an
+    # earlier render they may no longer have.
+    lines.extend(f"  deleted: {path}" for path in removed)
+    lines.extend(f"  FAILED: {path} — {reason}" for path, reason in failed)
+    # A directory left behind is reported separately: the files under it are
+    # gone either way, so this must not read as a deletion that did not happen.
+    lines.extend(f"  UNPRUNED: {path} — {reason}" for path, reason in pruned_failed)
+    lines.extend(f"  FAILED: cannot write {path} — {reason}" for path, reason in unwritten)
+    return "\n".join(lines), 1
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    # An option supplied but empty means the caller's variable was unset -- the
+    # shape `--from-dir "$WORKFLOW_CLONE"` takes when that assignment did not
+    # survive. Treating it as "not supplied" would silently sync against the
+    # wrong source, so it is a usage error rather than a default.
+    for flag, value in (("--from-ref", args.from_ref), ("--from-dir", args.from_dir)):
+        if value is not None and not value.strip():
+            print(f"sync-retire: {flag} was given an empty value", file=sys.stderr)
+            return 2
+    # Truthiness, consistently: an empty --from-dir used to pass this guard, then
+    # take the directory branch for the roots doc and the ref branch for the file
+    # inventory -- reading roots from the *project* working tree. That is exactly
+    # the branch-dependent scan this feature exists to remove, at exit 0.
+    if bool(args.from_ref) == bool(args.from_dir):
+        print(
+            "sync-retire: pass exactly one of --from-ref or --from-dir, "
+            "and neither may be empty",
+            file=sys.stderr,
+        )
+        return 2
+    if args.from_ref and args.from_ref.startswith("-"):
+        print("sync-retire: --from-ref may not begin with '-'", file=sys.stderr)
+        return 2
+    repo = os.path.abspath(args.repo)
+    if not os.path.isdir(repo):
+        print(f"sync-retire: no such directory: {args.repo}", file=sys.stderr)
+        return 2
+
+    try:
+        plan = compute_plan(repo, args.from_ref, args.from_dir)
+    except RetireError as exc:
+        print(f"sync-retire: {exc}", file=sys.stderr)
+        return 1
+
+    print(render(plan))
+    if not args.apply:
+        print("  mode:   dry-run (no changes written)")
+        return 0
+    try:
+        outcome, code = apply_requested_writes(repo, plan)
+    except (OSError, RetireError) as exc:
+        print(f"sync-retire: {exc}", file=sys.stderr)
+        return 1
+    print(outcome)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -81,6 +81,12 @@ Run `/memory-maintain` (it self-gates on the session count — runs every 5 sess
   external task on its own. With no tracker configured this reconciles the local
   index alone and still reports stale and superseded entries.
 - Append session summary with idempotency fingerprint (commit range short-SHAs)
+  - **Resolve both endpoints to real short SHAs.** The pre-push wrap-up gate
+    validates them as bare hex, so `HEAD` — the obvious thing to write in this
+    step, since Step 7 has not committed yet — is rejected, and every commit in
+    the push is recorded as uncovered debt. Write the base and the last existing
+    commit; the bookkeeping commit that lands this summary touches only
+    `tasks/`, which the gate does not count as code.
 
 ```markdown
 ## Session Summary — [YYYY-MM-DD] [a1b2c3f..d4e5f6a]

--- a/specs/sync-deterministic-retirement.md
+++ b/specs/sync-deterministic-retirement.md
@@ -203,7 +203,30 @@ global config.
   through it, so the run still lists every path it removed and exits non-zero.
 - **A dangling symlink at the candidate path** — refused. `os.path.exists`
   reports False for one while `open(path, "w")` follows it and creates the
-  target, so the check is `lexists`.
+  target, so the precondition is `lexists` and the write itself is
+  `O_EXCL | O_NOFOLLOW`, which closes the window between the two.
+- **A symlinked directory inside a syncable root** — the deletion is refused and
+  reported. The project inventory confirms the leaf with `os.path.isfile`, which
+  follows every component, so without a containment check `os.remove` reaches
+  files outside the repository — files git never had, and so cannot restore.
+  Needs no hostile template: a symlinked skill tree between worktrees is enough.
+- **A path containing a newline or control character** — escaped in every report
+  line. The report is the only record of what was destroyed and the operator is
+  told to read it in full, so a filename must not be able to emit a line that
+  reads like a real entry. A file can otherwise be named so the run claims to
+  have kept what it deleted.
+- **The template's `core.quotePath`** — cannot change the retirement set. The
+  history walk uses `-z`, which suppresses git's C-quoting entirely rather than
+  pinning the knob that controls it; otherwise one line in an untrusted
+  checkout's config moves a non-ASCII path between "candidate" and "deleted",
+  and the two source modes disagree for identical content.
+- **A commit message containing a line beginning `parent `** — not a shallow
+  graft. The truncation probe reads the commit object's header block only;
+  reading the whole object let one upstream commit message disable retirement
+  for every downstream project.
+- **A ref that looks like a git option** — refused at the sink. Every revision
+  slot passes `--end-of-options`, rather than relying on the CLI-level check in
+  `main`, which callers importing this module never reach.
 - **Shallow *project*, complete template ref** — provenance is available. Depth
   is measured on the revision being read, not on the repository holding it, so a
   project that is itself a `--depth 1` checkout (the CI default) still retires.

--- a/specs/sync-deterministic-retirement.md
+++ b/specs/sync-deterministic-retirement.md
@@ -1,0 +1,339 @@
+---
+implementation_paths:
+  - .agents/skills/sync/**
+  - .claude/skills/sync/**
+  - tests/test-sync-retirement.sh
+---
+
+# Spec: Deterministic Retirement in `/sync`
+
+> Issue: [#89](https://github.com/Joaovsales/jplugin-agentic-development/issues/89)
+> Task: `sync.deterministic-retirement`
+
+## Behavior
+
+`/sync` copies a fixed set of harness paths from this template into a downstream
+project. Additions and modifications already arrive mechanically, through
+`git checkout workflow/$BRANCH -- <paths>`. **Deletions do not.** A file that
+exists in the project but not in the template is either *retired upstream* or
+*project-specific*, and today nothing in either repository answers which — so the
+answer is re-derived by a model on every run. Two runs against the same template
+commit can therefore produce different trees.
+
+This feature replaces that judgement with recorded data.
+
+A downstream project owns a `.claude/sync-keep` file: newline-delimited glob
+patterns naming the paths under syncable roots that belong to the project. A
+script computes the retirement set as pure set arithmetic —
+
+```
+retire = (project paths under syncable roots)
+       − (template paths under the same roots)
+       − (paths matching a sync-keep pattern)
+```
+
+— reports it in full, and with `--apply` deletes exactly that set. Nothing is
+classified at run time. Given the same template revision, the same project tree,
+and the same `sync-keep`, the retirement set is identical on every run and from
+every project branch.
+
+A project with no `.claude/sync-keep` is in **bootstrap** state, where that
+subtraction cannot run: nothing has recorded what is project-specific. Bootstrap
+is not therefore empty, because the template's history answers a narrower
+question on its own —
+
+```
+retire (bootstrap) = { p ∈ (project − template)
+                     : hash(project file at p) ∈ (blobs the template ever
+                                                  held at p) }
+```
+
+A file that is **byte-identical** to something the template once shipped at that
+same path was retired upstream: it is template content, not this project's, so
+deleting it needs no human classification. That is a record, not a judgement,
+which is the same standard the `sync-keep` arithmetic meets.
+
+The comparison is on **content, not on the path**, and the difference is not
+academic. `.claude/hooks/` is a syncable root and `pre-commit.sh` is a name a
+template and a project both reach for, so path membership alone would delete a
+file this project wrote itself and never synced. It also protects the case git
+cannot: a synced file the project later **edited** hashes to something no
+template commit produced, so it falls out of the retirement set — including when
+the edit is still uncommitted, which `git checkout` could never bring back.
+
+Hashing the working tree rather than the index is what makes that last case work.
+
+This matters because the mechanism being replaced — a hardcoded
+`for retired in tdd deslop simplify verify-e2e` loop — deleted unconditionally.
+Without provenance, a project that never promotes its candidate would keep every
+retired skill forever, making the new design strictly weaker than the old one for
+exactly the projects least likely to notice.
+
+Everything the template **never** carried is held back: the script retires none of
+it and emits a candidate allowlist for a human to review. Confirming that
+candidate is the single point at which intent gets written down; after that it is
+data.
+
+`.claude/sync-keep` is never synced. It needs no new exclusion mechanism to
+achieve that, and the reason is structural rather than a list to keep in step:
+every syncable root under `.claude/` is a subdirectory, while `sync-keep` is a
+file directly under `.claude/`, so it lies outside all of them by shape. This
+spec documents that property rather than adding one.
+
+### Scope boundary
+
+Only the **deletion** half of `/sync` becomes mechanical. Additions and
+modifications keep their existing `git checkout` path, which is already
+deterministic. The interactive choices `/sync` already offers — the file-picking
+menu, the `.claude/commands/` legacy migration, the Deployment Targets migration —
+are human decisions, not model guesses, and are unchanged.
+
+The retirement pass is deliberately **not** part of the file-picking menu. It runs
+in dry-run during the change summary so its output is visible before any write,
+and applies in full for both *all changes* and *pick files*. Retirement is defined
+by `sync-keep`, not by picking; a user who wants to keep a path adds it to
+`sync-keep`, which is the entire point of the mechanism. *Preview only* and
+*abort* apply nothing.
+
+## Inputs
+
+- `--from-ref <ref>` — template inventory read from a git ref
+  (`git ls-tree -r --name-only <ref> -- <roots>`). The git-remote mode.
+- `--from-dir <path>` — template inventory read from a local checkout: through
+  `git ls-files` when the checkout is a repository, which is how `/sync` obtains
+  it, and by walking the directory otherwise. Reading through git is what makes
+  this mode agree with `--from-ref`; a bare walk would count gitignored residue
+  as template content. The manual-diff mode. Exactly one of the two is required.
+- `--repo <path>` — project root; defaults to the working directory.
+- `--apply` — perform deletions. Absent, the run is a dry run.
+- `.claude/sync-keep` — the project's allowlist. Blank lines and `#` comments are
+  ignored. Each remaining line is one glob pattern.
+- The `## Syncable Paths` doc block in `.agents/skills/sync/SKILL.md` — the
+  canonical root list. The script *parses* this block rather than carrying a
+  copy, so it becomes a consumer of the one source `tests/test-syncable-paths.sh`
+  already pins, not an eighth hand-maintained duplicate of it.
+
+A syncable root must be a direct subdirectory of `.agents/` or `.claude/` —
+`.agents/skills/`, `.claude/hooks/`, and so on. The doc block is read from the
+template, which is a remote repository or a local directory, so it is untrusted
+input to a file-deleting operation: an unconstrained block naming `src/` would
+delete the project's source, and `.claude/` would sweep in the never-sync files
+including `sync-keep` itself. Staying inside the repository is not sufficient,
+because all of those paths already are. A root failing this shape is an error.
+
+Glob semantics match the spec `implementation_paths` contract: case-sensitive,
+whole-path, `*` matches any run of characters except `/`, `?` matches exactly one
+character except `/`, `**` matches any run including `/`. No other glob syntax is
+accepted.
+
+## Outputs
+
+A report on stdout, then — under `--apply` only — deletions on disk.
+
+```
+sync retirement — source: workflow/master, roots: 7
+  retire: .agents/skills/tdd/SKILL.md
+  retire: .claude/hooks/pre-push-guard.sh
+  kept:   .agents/skills/ai-video-essay/SKILL.md (matched .agents/skills/ai-video-essay/**)
+  mode:   dry-run (no changes written)
+```
+
+- Every retire path is listed **in full**, never truncated. The progressive-
+  disclosure cap that bounds other reports in this repo is a readability
+  optimisation; here the list *is* the record of what is about to be destroyed,
+  and abbreviating it would hide exactly what the report exists to show.
+- Every allowlist hit is reported with the pattern that matched it, so a
+  surviving path is traceable to the line that saved it.
+- Directories emptied by the deletions are pruned.
+
+Exit codes: `0` success · `1` failure (unreadable ref, missing root, invalid
+pattern, invalid syncable root, deletion failure) · `2` usage error.
+
+Nothing is deleted on any non-zero exit **decided before the apply step** — every
+validation failure above is one of those. The single exception is an I/O error
+part-way through the deletion loop: files already removed stay removed. The run
+still exits `1`, and it reports `applied (N deleted, M failed)` followed by each
+path it could not delete, so the record always matches the disk.
+
+Pruning an emptied directory can fail independently of the deletion that emptied
+it — the file is gone either way. That is reported as `not pruned` in the
+outcome line with an `UNPRUNED:` line per directory, counted separately from a
+failed deletion so a leftover directory never reads as a file that survived. A
+prune failure must not abort the run: doing so would discard the record of
+everything already deleted, which is the one thing this tool cannot afford to
+lose.
+
+**The template checkout is untrusted input, including its git configuration.**
+`--from-dir` names a tree the project did not write, and git executes commands
+named by that repository's own config (`core.fsmonitor` on `ls-files`). The
+checkout is same-uid, so `safe.directory` does not fire, and the read happens
+during the Step 3 dry run — before the user approves anything and without
+`--apply`. Every git invocation therefore pins the exec-capable knobs off on the
+command line, where `-c` outranks repository config, and ignores system and
+global config.
+
+## Edge Cases
+
+- **No `.claude/sync-keep`** — bootstrap. Reports `bootstrap: required` and
+  splits the project-only paths by provenance: those the template has ever
+  carried are retired as template content, and only those it never carried are
+  listed as candidates. Under `--apply` it writes `.claude/sync-keep.candidate`,
+  never `.claude/sync-keep` itself; promoting the candidate is the human's
+  confirming act. Additions and modifications still sync normally.
+- **Provenance unreadable** — the template's history could not be read. Reports
+  `provenance: unavailable (<reason>)` and retires *nothing*, holding every
+  project-only path as a candidate rather than reading "I cannot tell" as
+  "project-specific". The reason is git's own, carried out of the probe and
+  flattened to one printable line, and the remediation hint belongs to the
+  reason rather than being appended to all of them: a truncated clone, a ref
+  that does not resolve and an unreadable object need different responses, and
+  only the first is fixed by deepening a clone.
+- **Truncated template history** — detected by whether the revision's root
+  commit *records a parent that is absent*, which is what a shallow graft looks
+  like at any depth. A commit count only ever caught depth 1, so a `--depth 5`
+  clone silently produced a different retirement set from the same commit SHA —
+  the exact non-determinism this feature exists to remove.
+- **A synced file the project edited** — held as a candidate, never retired. The
+  edit is what makes it the project's.
+- **A project's own file at a path the template once used** — held as a
+  candidate. A shared filename is a collision, not provenance.
+- **Bootstrap `--apply` whose candidate write fails** — for any reason other
+  than the file already existing (unwritable directory, read-only mount,
+  ENOSPC), the failure is folded into the deletion report rather than raised
+  through it, so the run still lists every path it removed and exits non-zero.
+- **A dangling symlink at the candidate path** — refused. `os.path.exists`
+  reports False for one while `open(path, "w")` follows it and creates the
+  target, so the check is `lexists`.
+- **Shallow *project*, complete template ref** — provenance is available. Depth
+  is measured on the revision being read, not on the repository holding it, so a
+  project that is itself a `--depth 1` checkout (the CI default) still retires.
+  Measuring the repository instead silently disabled retirement in `--from-ref`,
+  the mode the skill prescribes.
+- **Bootstrap `--apply` with a candidate already present** — exits 1 having
+  deleted nothing. The refusal to overwrite a file a human was asked to edit is
+  a *precondition*, checked before the deletions rather than after them: a guard
+  that fires after the destruction it guards reports nothing about what was
+  destroyed.
+- **Empty `.claude/sync-keep`** — a recorded, deliberate "nothing is
+  project-specific". Distinct from absent, and it permits deletion.
+- **Invalid pattern** — absolute, `..`-traversing, backslash-separated, using
+  unsupported glob syntax, or resolving outside every syncable root. Reported
+  with the offending pattern and its line, non-zero exit, nothing deleted. A
+  pattern outside every syncable root can never protect anything, so accepting it
+  would silently record intent that has no effect. "Outside every syncable root"
+  is judged against the roots the doc block **declares**, not the subset the
+  template currently has files under — otherwise a root emptied upstream turns a
+  project's correctly recorded intent into a fatal error and blocks every
+  unrelated retirement.
+- **File roots** — `CLAUDE.md` and `.claude/settings.json` are files, not
+  directories. Retirement is undefined for them and they are excluded from the
+  scan; they are already handled by the existing checkout step.
+- **A syncable root absent from the project** — treated as empty, not an error.
+  A project that never received `.claude/browsers/` has nothing to retire there.
+- **A syncable root absent from the template** — an error. The template is the
+  authority on what the roots contain; a missing root means the ref or checkout
+  is wrong, and proceeding would retire the project's entire copy of it.
+- **A trailing-slash pattern** — `.agents/skills/mine/` reaches a syncable root
+  but matches no file, so it protects nothing. Refused, naming the `**` form
+  that works. This is the most natural thing a human writes, and accepting it
+  silently retires exactly what it was written to save.
+- **A pattern that matches nothing this run** — reported as `unmatched:`, not an
+  error: the path it names may not exist yet. It is also the state a stale
+  allowlist is in immediately before it stops protecting something.
+- **A candidate path containing glob metacharacters** — the pattern language has
+  no escape syntax, so such a path cannot be expressed exactly. `sync-keep.candidate`
+  writes it as a comment naming the problem rather than as a pattern that would
+  either over-match or fail validation on a line the tool wrote itself.
+- **A root retired upstream** — once a directory leaves the doc block it is no
+  longer scanned, so the project keeps its copy indefinitely. The retirement set
+  is defined only within the roots the template currently declares; removing a
+  whole root needs a one-off manual deletion. Filed as a follow-up.
+- **Project on a stale branch** — a branch carrying skills that the project's
+  `main` already dropped retires them like any other project-only path. The
+  template, not the project branch, is the authority.
+
+- **A candidate path the reader would strip or split.** `read_keep_patterns`
+  strips each line, so a path with surrounding whitespace round-trips into a
+  pattern that cannot match it, and a path containing a line break splits into a
+  second, live rule at column 0. Both are written as `# UNEXPRESSIBLE` comments
+  naming the path — **every** line of it, since commenting only the first lets
+  the remainder escape back to column 0 — alongside the glob-metacharacter and
+  backslash cases: a rule that looks like protection and silently protects
+  nothing is worse than a refusal to write one. The rejected set is derived from
+  what `validate_pattern` refuses rather than restated, which is how backslash
+  drifted out of it once already.
+- **A syncable root whose segment is `.`, `..` or a glob.** Rejected by the root
+  validator itself, not by the downstream check that the template contains files
+  under every root. The downstream check happens to refuse these too, because
+  git normalises its output — but relying on that leaves whole-repo deletion one
+  refactor away, so the constraint lives in the shape the design depends on.
+
+## Acceptance Criteria
+
+- Running `/sync` twice against an unchanged template leaves a byte-identical
+  tree on the second run, and the second run reports zero retirements.
+- A file retired upstream is removed from the project without a human
+  classifying it.
+- A path listed in `.claude/sync-keep` survives a sync that would otherwise
+  delete it, and is reported with the pattern that matched it.
+- A project-only path not in `sync-keep` is reported before deletion, never
+  deleted silently; the default run reports without deleting at all.
+- Syncing the same project from two different branches yields the same set of
+  harness paths.
+- `.claude/sync-keep` is documented as non-syncable in `SKILL.md` § Syncable
+  Paths, in both the canonical and compatibility copies.
+- A project with no `.claude/sync-keep` still retires files that are
+  byte-identical to something the template's history shows it shipped at that
+  path, holds everything else — including customised, uncommitted, and
+  same-name-different-file cases — as a candidate, and is told how to bootstrap
+  the allowlist. When that history cannot be read it retires nothing and says why.
+- Bootstrap `--apply` that cannot write its candidate file deletes nothing, and
+  any run that deletes reports every path it removed even when part of it failed.
+- An invalid `sync-keep` pattern fails loudly, names the pattern, and deletes
+  nothing.
+- `--from-ref` and `--from-dir` produce the same retirement set for the same
+  template content.
+- The syncable roots the script scans come from the `## Syncable Paths` doc
+  block, so the block stays the single source the drift test already pins.
+
+## Implementation Paths
+
+- `.agents/skills/sync/SKILL.md` — canonical skill. Owns the `## Syncable Paths`
+  doc block the script parses, documents `.claude/sync-keep` in the never-sync
+  list, and adds the retirement pass to the procedure.
+- `.agents/skills/sync/scripts/sync-retire.py` — the mechanism. Stdlib-only
+  Python 3; computes, reports, and applies the retirement set.
+- `.claude/skills/sync/**` — byte-identical Claude Code compatibility copy of the
+  above, pinned by `tests/test-skill-parity.sh`.
+- `tests/test-sync-retirement.sh` — the behavioral suite for every criterion
+  above.
+
+## Deferred
+
+Two limits are deliberate, each filed rather than folded in:
+
+- The syncable-path list is still enumerated by hand across seven regions in
+  three files. This spec makes the script an eighth *consumer* of the canonical
+  block instead of an eighth copy, but does not collapse the other six.
+- `_pattern_to_regex` / `match_path` are re-implemented here rather than shared
+  with `.agents/skills/wrap-up-session/scripts/spec-reconcile.py`, which has the
+  same three-token semantics. That file's hyphenated name makes it importable
+  only through `importlib`, and the two validators have different contracts
+  (`sync-keep` additionally requires a syncable root). Extracting a shared module
+  would widen this change beyond the routed radius.
+
+Review raised four more, all filed and none fixed here:
+
+- A `sync-keep` pattern naming a root the template has since dropped is a hard
+  exit `1` that blocks every unrelated retirement, and blames the project's file
+  for an upstream change (`sync.stale-root-blocks-retirement`).
+- Runs of `**` / `*?` compile to adjacent unbounded quantifiers that backtrack
+  catastrophically. Input is the project's own never-synced `sync-keep`, and the
+  same shape exists in `spec-reconcile.py` — so the fix belongs with the shared
+  matcher, not ahead of it (`glob-matcher-redos`).
+- Step 6 asks the user to commit before Step 6.4 deletes, leaving the deletions
+  and the bootstrap candidate uncommitted. Pre-existing ordering, amplified now
+  the set is computed rather than four fixed paths
+  (`sync.retirement-lands-after-commit`).
+- Nothing bounds the size of the retirement set
+  (`sync.retire-blast-radius-cap`, already filed).

--- a/tasks/checkpoint.md
+++ b/tasks/checkpoint.md
@@ -1,4 +1,4 @@
-# Checkpoint — 2026-09-05T12:12:23Z
+# Checkpoint — 2026-09-05T18:45:15Z
 
 > Auto-written by PreCompact hook (trigger: auto). Re-read on resume.
 
@@ -6,47 +6,18 @@
 - Branch: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe
 
 ```
-M  .agents/skills/sync/SKILL.md
-AM .agents/skills/sync/scripts/sync-retire.py
-M  .claude/skills/sync/SKILL.md
-A  .claude/skills/sync/scripts/sync-retire.py
-A  specs/sync-deterministic-retirement.md
-M  tasks/checkpoint.md
-A  tasks/details/glob-matcher-redos.md
-A  tasks/details/glob-matcher-shared-module.md
-A  tasks/details/sync.bootstrap-skips-legacy-retirements.md
-A  tasks/details/sync.candidate-emits-per-file-patterns.md
-A  tasks/details/sync.emptied-root-blocks-retirement.md
-A  tasks/details/sync.retire-blast-radius-cap.md
-A  tasks/details/sync.retired-root-orphans.md
-A  tasks/details/sync.retirement-lands-after-commit.md
-A  tasks/details/sync.stale-root-blocks-retirement.md
-A  tasks/details/sync.syncable-paths-single-source.md
-M  tasks/history.md
-A  tasks/route-decision.md
-A  tasks/solutions/architecture/current-state-cannot-distinguish-removed-from-never-present.md
-A  tasks/solutions/process/an-assertion-can-pass-because-a-different-guard-fired.md
-A  tasks/solutions/process/scoping-a-guard-per-item-can-silently-weaken-it.md
-A  tasks/solutions/security/running-git-in-an-untrusted-checkout-executes-its-config.md
-A  tasks/solutions/tooling/mawk-has-no-interval-expressions.md
-M  tasks/todo.md
-A  tests/test-sync-retirement.sh
-M  tests/test-syncable-paths.sh
+ M tasks/route-decision.md
+ M tasks/todo.md
+?? tasks/details/route.finalize-discards-lane-completion.md
 ```
 
 ## In-Progress & Pending Tasks (tasks/todo.md)
-[ ] prelude: skip: not needed for this kind
-[ ] /plan (auto-confirm: no; wait for approval)
-[ ] /build (runs /quality-gate on completion)
-[ ] route radius tripwire: finalize_route before verification or push
-[ ] /verify (evidence: tests)
-[ ] /wrap-up-session (wait at pre-push gate)
+(none)
 
 ## Active Spec
 - specs/sync-deterministic-retirement.md
 
 ## How to Resume
 1. Read this file and `tasks/todo.md`
-2. Grep `tasks/solutions/` frontmatter (`problem_type`, `module`, `tags`) for the
-   areas this task touches — never bulk-load the store
+2. Grep `tasks/solutions/` frontmatter (problem_type, module, tags) for relevant learnings
 3. Continue from the first `[~]` (or `[ ]`) item in `tasks/todo.md`

--- a/tasks/checkpoint.md
+++ b/tasks/checkpoint.md
@@ -1,44 +1,52 @@
-# Checkpoint — 2026-09-02T12:45:54Z
+# Checkpoint — 2026-09-05T12:12:23Z
 
 > Auto-written by PreCompact hook (trigger: auto). Re-read on resume.
 
 ## Git
-- Branch: Joaovsales/wrap-u
+- Branch: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe
 
 ```
- M .agents/skills/brainstorm/SKILL.md
- M .agents/skills/plan/SKILL.md
- M .agents/skills/task-registry/SKILL.md
- M .agents/skills/task-registry/scripts/task-registry.py
- M .agents/skills/wrap-up-session/SKILL.md
- M .claude/skills/brainstorm/SKILL.md
- M .claude/skills/plan/SKILL.md
- M .claude/skills/task-registry/SKILL.md
- M .claude/skills/task-registry/scripts/task-registry.py
- M .claude/skills/wrap-up-session/SKILL.md
- M CLAUDE.md
- M project-template/CLAUDE.md
- M specs/README.md
- M specs/review-context-contract.md
- M specs/task-registry.md
- M tasks/checkpoint.md
- M tasks/todo.md
-?? .agents/skills/task-registry/scripts/registry/upsert.py
-?? .agents/skills/wrap-up-session/scripts/
-?? .claude/skills/task-registry/scripts/registry/upsert.py
-?? .claude/skills/wrap-up-session/scripts/
-?? .serena/
-?? specs/living-spec-reconciliation.md
-?? tests/test-living-spec-reconciliation.sh
+M  .agents/skills/sync/SKILL.md
+AM .agents/skills/sync/scripts/sync-retire.py
+M  .claude/skills/sync/SKILL.md
+A  .claude/skills/sync/scripts/sync-retire.py
+A  specs/sync-deterministic-retirement.md
+M  tasks/checkpoint.md
+A  tasks/details/glob-matcher-redos.md
+A  tasks/details/glob-matcher-shared-module.md
+A  tasks/details/sync.bootstrap-skips-legacy-retirements.md
+A  tasks/details/sync.candidate-emits-per-file-patterns.md
+A  tasks/details/sync.emptied-root-blocks-retirement.md
+A  tasks/details/sync.retire-blast-radius-cap.md
+A  tasks/details/sync.retired-root-orphans.md
+A  tasks/details/sync.retirement-lands-after-commit.md
+A  tasks/details/sync.stale-root-blocks-retirement.md
+A  tasks/details/sync.syncable-paths-single-source.md
+M  tasks/history.md
+A  tasks/route-decision.md
+A  tasks/solutions/architecture/current-state-cannot-distinguish-removed-from-never-present.md
+A  tasks/solutions/process/an-assertion-can-pass-because-a-different-guard-fired.md
+A  tasks/solutions/process/scoping-a-guard-per-item-can-silently-weaken-it.md
+A  tasks/solutions/security/running-git-in-an-untrusted-checkout-executes-its-config.md
+A  tasks/solutions/tooling/mawk-has-no-interval-expressions.md
+M  tasks/todo.md
+A  tests/test-sync-retirement.sh
+M  tests/test-syncable-paths.sh
 ```
 
 ## In-Progress & Pending Tasks (tasks/todo.md)
-(none)
+[ ] prelude: skip: not needed for this kind
+[ ] /plan (auto-confirm: no; wait for approval)
+[ ] /build (runs /quality-gate on completion)
+[ ] route radius tripwire: finalize_route before verification or push
+[ ] /verify (evidence: tests)
+[ ] /wrap-up-session (wait at pre-push gate)
 
 ## Active Spec
-- specs/README.md
+- specs/sync-deterministic-retirement.md
 
 ## How to Resume
 1. Read this file and `tasks/todo.md`
-2. Read `tasks/memory.md` for project context
+2. Grep `tasks/solutions/` frontmatter (`problem_type`, `module`, `tags`) for the
+   areas this task touches — never bulk-load the store
 3. Continue from the first `[~]` (or `[ ]`) item in `tasks/todo.md`

--- a/tasks/details/glob-matcher-redos.md
+++ b/tasks/details/glob-matcher-redos.md
@@ -1,0 +1,32 @@
+# Adjacent unbounded quantifiers make the glob matcher hang
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: glob-matcher-redos
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: `out.append(".*")` for `**` and `out.append("[^/]*")` for `*` in `_pattern_to_regex` (`.agents/skills/sync/scripts/sync-retire.py`); security review reproduced a hang exceeding an 8s alarm on a 70-char non-matching path for patterns `'**?' x9`, `'*?' x12` and `'**' x18`, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+Glob tokens are emitted verbatim, so runs of `**` or `*?` compile to `.*.*.*…` — catastrophic backtracking on a non-matching path. `match_path` runs once per pattern per project-only path with no cache, before any deletion, so a pathological sync-keep hangs `/sync` indefinitely rather than failing.
+
+Severity is bounded: the input is the project's own `.claude/sync-keep`, which is never synced, so this is self-inflicted or requires repo write access.
+
+Deliberately not fixed in the deterministic-retirement build: the same shape exists in `scripts/spec-reconcile.py`, and fixing one copy while the other keeps the defect is how the two silently diverge. This should land with — or after — [[glob-matcher-shared-module]].
+
+## Acceptance Criteria
+
+- [ ] Adjacent unbounded quantifiers cannot produce a regex that backtracks catastrophically
+- [ ] A pathological pattern fails fast or matches promptly; it never hangs
+- [ ] The fix lands in one place, not once per script
+- [ ] `spec-reconcile.py` gets the same behaviour, not a second implementation of it
+- [ ] A timing-bounded regression test covers the reproduced patterns
+
+## Notes
+
+Found in security review of the deterministic-retirement build (`autofix_class: manual`, `owner: human` — the judgement is about sequencing against the shared-matcher extraction). Related: [[glob-matcher-shared-module]].

--- a/tasks/details/glob-matcher-shared-module.md
+++ b/tasks/details/glob-matcher-shared-module.md
@@ -1,0 +1,30 @@
+# Extract the shared path-glob matcher out of spec-reconcile.py
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: glob-matcher-shared-module
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: .agents/skills/sync/scripts/sync-retire.py carries a `TODO(shortcut):` on `_pattern_to_regex` naming the duplication; .agents/skills/wrap-up-session/scripts/spec-reconcile.py:110-137 implements the same three-token semantics (`*` and `?` non-crossing, `**` crossing) and the same rejection list for absolute, traversing, backslash-separated and unsupported-glob patterns, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+Two scripts now implement the same whole-path glob semantics. They agree today, which is the dangerous state: a fix to one silently widens or narrows only half the surfaces that depend on it, and both are used to decide which files a destructive or bookkeeping operation touches.
+
+## Acceptance Criteria
+
+- [ ] One importable module owns `_pattern_to_regex` and `match_path`
+- [ ] Both `sync-retire.py` and `spec-reconcile.py` consume it; neither keeps a copy
+- [ ] The differing validation contracts stay separate — a sync-keep pattern must additionally name a syncable root, a spec `implementation_paths` entry must not
+- [ ] The module ships inside a syncable path, so downstream projects receive it
+- [ ] `tests/test-sync-retirement.sh` and `tests/test-living-spec-reconciliation.sh` both stay green, and the `TODO(shortcut):` marker is removed
+
+## Notes
+
+Deferred from the deterministic-retirement build. `spec-reconcile.py`'s hyphenated
+filename makes it importable only through `importlib`, so sharing needs a new
+module rather than an import of the existing file.

--- a/tasks/details/route.finalize-discards-lane-completion.md
+++ b/tasks/details/route.finalize-discards-lane-completion.md
@@ -1,0 +1,52 @@
+# Finalizing reviewers regenerates the lane block and discards its completion state
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: route.finalize-discards-lane-completion
+kind: bug
+spec: none
+evidence: `finalized = _demote(...)` then `return _persist_finalized(root, finalized, demotion is not None)` in `finalize_reviewers`, and `if rewrite_lane: todo = _merge_lane(todo, decision, _render_playbook(decision))` in `_persist_finalized` (`.agents/skills/route/scripts/route_issue.py`); `_render_playbook` renders from the decision alone and has no notion of which steps are done, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-05
+
+## Summary
+
+`finalize_reviewers` demotes when the runtime tripwire has not passed, and any
+demotion sets `rewrite_lane=True`, which re-renders the `<!-- route-lane -->`
+block from the playbook template. The template has no completion state, so every
+`[x]` in the checklist reverts to `[ ]`.
+
+Observed on this branch: the lane was fully walked — plan approved, build done,
+verification run, reviewers dispatched and finalized, wrap-up complete, PR open
+and CI green — and finalizing the reviewers reset all seven items to unchecked.
+
+## Why it matters
+
+The block is two things at once: a tool-managed artifact and the human-readable
+record of how far the lane has been walked. Regeneration treats it as purely the
+first. The reader after a demotion is told no step has been taken, which is the
+opposite of the truth, and re-checking by hand is undone by the next finalize.
+
+The loss is worst in exactly the case that triggers it. A demotion means
+something went wrong and the work needs closer human attention — and that is the
+moment the record of what has already been reviewed is discarded.
+
+## Acceptance Criteria
+
+- [ ] A demotion that does not change the lane preserves the checklist's completion state
+- [ ] A demotion that *does* change the lane states plainly which steps must be re-walked, rather than silently unchecking all of them
+- [ ] The distinction is covered in `tests/test-route-decision.sh`
+
+## Notes
+
+Found while running `finalize_reviewers` on this branch at the user's request.
+The demotion itself was correct and expected: the tripwire had recorded an
+overflow (4 paths outside declared scope) and `_review_demotion` checks
+`tripwire_passed` before it looks at reviewer outcomes at all, so the outcomes
+could not have avoided it.
+
+Related: the decision's `reviewers` list is fixed at route time, and
+`_validate_review_state` requires outcomes to name it exactly — so a reviewer
+dispatched later (`critic`, here) cannot be recorded in the decision at all.

--- a/tasks/details/sync.bootstrap-skips-legacy-retirements.md
+++ b/tasks/details/sync.bootstrap-skips-legacy-retirements.md
@@ -1,0 +1,35 @@
+# Bootstrap projects never remove the four legacy retired skills
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.bootstrap-skips-legacy-retirements
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: the removed hunk `-for retired in tdd deslop simplify verify-e2e; do` in `git diff master -- .agents/skills/sync/SKILL.md`, against `**A project with no `.claude/sync-keep` is in bootstrap.** The script retires nothing` (`.agents/skills/sync/SKILL.md`); a repo-wide grep finds no other removal path for those four names — not in `install.sh`, not in the hooks, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: done
+- updated: 2026-09-04
+
+## Summary
+
+This change deleted the only mechanism in the repo that removed `tdd`, `deslop`, `simplify` and `verify-e2e` from downstream projects, and did not replace it for projects in bootstrap. A project with no `.claude/sync-keep` retires nothing by design — so those four stale skills now persist indefinitely where the old hardcoded loop deleted them unconditionally.
+
+**This is the one case where the new mechanism is strictly weaker than what it replaced.** The old loop was already deterministic; it was the surrounding per-run judgement that was not. Determinism was bought here at the cost of the migration those four names encoded.
+
+Raised as `owner: human` because the resolution is a policy choice, not an implementation detail.
+
+## Acceptance Criteria
+
+- [x] A bootstrap project still loses the four known-retired skills, or the cost of not doing so is recorded in the spec
+- [x] Whatever mechanism is chosen does not reintroduce a hand-maintained name list that drifts
+- [x] `tests/test-sync-retirement.sh` covers the bootstrap path either way
+- [x] The decision is written down where the next person to read Step 6.4 will find it
+
+## Notes
+
+Options considered: keep the four-name loop as an explicitly-scoped legacy sweep until a project has promoted its candidate; have bootstrap flag known-retired names in the candidate; or accept and document the regression. Found in code review (Pass 1) of the deterministic-retirement build. Related: [[sync.retired-root-orphans]].
+
+## Resolution
+
+Resolved in the same session it was filed: bootstrap now retires paths with template provenance (`template_history_paths`), so the four legacy skills are removed without a hand-maintained name list. Pinned by `tests/test-sync-retirement.sh` §19.

--- a/tasks/details/sync.candidate-emits-per-file-patterns.md
+++ b/tasks/details/sync.candidate-emits-per-file-patterns.md
@@ -1,0 +1,31 @@
+# The bootstrap candidate protects a generated skill file-by-file
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.candidate-emits-per-file-patterns
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: `lines.extend(_as_pattern(path) for path in plan.candidates)` in `write_candidate` (`.agents/skills/sync/scripts/sync-retire.py`) — verified output is `.agents/skills/verify-myapp/SKILL.md`, not `.agents/skills/verify-myapp/**`, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+The candidate emits one exact pattern per project-only *file*. A project-local skill is therefore protected file-by-file, so any file added to it afterwards is a fresh retire candidate. The candidate generator is the one place that could reduce this by emitting a `**` rule per project-only *directory*.
+
+Nothing is deleted silently, so this is not a correctness defect — but the bootstrap output is the weakest form of the record the whole feature exists to produce, and it interacts directly with the `/create-verification-skill` exposure already documented in Step 6.4.
+
+`owner: human` because widening a generated allowlist rule is a deliberate trade: a `**` per directory protects more than the operator inspected.
+
+## Acceptance Criteria
+
+- [ ] The candidate expresses a project-only directory as one reviewable rule
+- [ ] Widening is visible to the human reviewing the candidate, never implicit
+- [ ] A path that cannot be expressed is still commented rather than widened
+- [ ] `tests/test-sync-retirement.sh` covers directory-level candidate emission
+
+## Notes
+
+Found in adversarial review (Pass 4), reported as advisory. Related: [[sync.retire-blast-radius-cap]].

--- a/tasks/details/sync.emptied-root-blocks-retirement.md
+++ b/tasks/details/sync.emptied-root-blocks-retirement.md
@@ -1,0 +1,42 @@
+# A root legitimately emptied upstream disables the whole retirement pass
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.emptied-root-blocks-retirement
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: `missing = [r for r in roots if not any(p.startswith(r) for p in template)]` raising `— refusing to retire a root the template cannot vouch for` in `assert_roots_present` (`.agents/skills/sync/scripts/sync-retire.py`); `.agents/git-hooks/` and `.claude/browsers/` each contain exactly one tracked file in this repo, so either is one upstream deletion away from triggering it, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: done
+- updated: 2026-09-04
+
+## Summary
+
+`assert_roots_present` conflates two different situations: "the template source is wrong" (a mistyped ref, a bad clone — which it exists to catch) and "a declared root was legitimately emptied upstream". In the second case every downstream Step 6.4 exits 1, retires nothing, and blames the operator's ref.
+
+It also fires *before* `read_keep_patterns`, so a correctly configured project gets no retirement at all until someone edits the template's doc block.
+
+Third distinct case in this family, and covered by none of the existing three: [[sync.retired-root-orphans]] is a root *removed from the block*; [[sync.stale-root-blocks-retirement]] is a *sync-keep pattern* naming a dropped root. This one is a root still declared, present in the project, and empty in the template.
+
+Raised as `owner: human`: the guard is correct to exist and the fix trades one failure mode for another, so the default belongs to a person.
+
+## Acceptance Criteria
+
+- [x] An emptied-but-declared root does not abort retirement for unrelated roots
+- [x] A genuinely wrong template source still fails loudly, as today
+- [x] The two are distinguishable from the message alone
+- [x] `tests/test-sync-retirement.sh` covers both and pins that they are not conflated
+
+## Notes
+
+The strongest form of the critique: the untrusted-template threat model justifies this guard, yet its failure mode is "retirement quietly stops working" — the state this feature was built to end. Found in adversarial review (Pass 4). Related: [[sync.retired-root-orphans]], [[sync.stale-root-blocks-retirement]].
+
+## Resolution
+
+Resolved in the same session it was filed, in **two** steps — the first was reported as complete and was not.
+
+1. An empty declared root is skipped and reported rather than aborting the run, with more than one empty root still refused as a truncated source. Pinned by `tests/test-sync-retirement.sh` §2.
+2. That left AC #1 false in the case that matters most. `compute_plan` passed the *scanned* roots to `read_keep_patterns`, so a `sync-keep` line naming a path under the skipped root was "outside every syncable root" — exit 1, every unrelated retirement blocked. A project that had correctly recorded its intent to protect a file was the one most punished for it. Fixed by scoping the pattern check to the **declared** roots, which is what a pattern's legality was always a property of. Pinned by §20.5.
+
+The gap between the two is the lesson: step 1 was verified by the tests written alongside it, and those tests never combined an emptied root with a `sync-keep` naming something under it. Closing on green rather than on the acceptance criterion is what let a false "done" stand — see [[scoping-a-guard-per-item-can-silently-weaken-it]].

--- a/tasks/details/sync.retire-blast-radius-cap.md
+++ b/tasks/details/sync.retire-blast-radius-cap.md
@@ -1,0 +1,30 @@
+# Bound the retirement blast radius before --apply deletes
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.retire-blast-radius-cap
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: `main` in `.agents/skills/sync/scripts/sync-retire.py` prints the plan and calls `apply_requested_writes` in the same non-interactive run, with no cap on the size of the retirement set and no second confirmation; raised as an advisory owner:human finding in security review of the deterministic-retirement change, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+The report satisfies "reported before deletion" literally, but nothing acts on the report: any upstream defect that inflates the retirement set destroys the whole set before a human can react. The root-shape constraint closed the known way to inflate it; a cap bounds the unknown ones.
+
+Raised as `owner: human` because choosing a default threshold is a policy call, not an implementation detail.
+
+## Acceptance Criteria
+
+- [ ] `--apply` aborts, deleting nothing, when the retirement set exceeds a threshold
+- [ ] The abort prints the full set and the explicit flag that overrides it
+- [ ] The default threshold is justified against real sync sizes, not guessed
+- [ ] Bootstrap is unaffected — it already deletes nothing
+- [ ] `tests/test-sync-retirement.sh` covers the abort, the override, and a set just under the threshold
+
+## Notes
+
+Deferred from the deterministic-retirement build. Related: [[sync.retired-root-orphans]].

--- a/tasks/details/sync.retired-root-orphans.md
+++ b/tasks/details/sync.retired-root-orphans.md
@@ -1,0 +1,31 @@
+# A syncable root retired upstream leaves permanent orphans
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.retired-root-orphans
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: `.agents/skills/sync/scripts/sync-retire.py` computes its scan set as exactly the roots the current template declares (`compute_plan` calls `parse_syncable_roots` on the template's doc block), so a directory removed from the block is never scanned again; pinned as intended behaviour by `tests/test-sync-retirement.sh` — "a path under a root the doc block does not declare is never scanned". Raised in code review of the deterministic-retirement change, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+Deterministic retirement removes files *within* the declared roots. If a whole root is retired upstream — the directory leaves the `## Syncable Paths` block — the project's entire copy of it survives forever, because nothing scans a root the template no longer declares. This is a silent hole in the "a file retired upstream is removed without a human classifying it" criterion, at the granularity of a whole directory.
+
+It is not fixable by scanning more: the previous root list is not available to the script, and widening the scan to undeclared directories is exactly the attack the root-shape constraint was added to prevent.
+
+## Acceptance Criteria
+
+- [ ] A root present in the project but absent from the template's doc block is detected and reported
+- [ ] The report distinguishes it from ordinary per-file retirement, since deleting a whole root is a larger act
+- [ ] Nothing is deleted for this case without an explicit human confirmation
+- [ ] The mechanism cannot be used to widen the scan to a directory that was never a syncable root
+- [ ] `specs/sync-deterministic-retirement.md` § Edge Cases is updated from "needs a one-off manual deletion" to whatever is implemented
+
+## Notes
+
+Deferred from the deterministic-retirement build and documented in the spec's Edge
+Cases in the meantime. Related: [[sync.syncable-paths-single-source]].

--- a/tasks/details/sync.retirement-lands-after-commit.md
+++ b/tasks/details/sync.retirement-lands-after-commit.md
@@ -1,0 +1,29 @@
+# Step 6.4 deletes after Step 6 has already asked the user to commit
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.retirement-lands-after-commit
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: `### Step 6 — Post-Sync` and `2. Ask the user if they want to commit the sync:` precede `### Step 6.4 — Retired Path Removal` in `.agents/skills/sync/SKILL.md`; raised in code review of the deterministic-retirement change, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+The commit prompt the user is told closes the sync fires *before* the retirement pass runs, and no later step commits. The deletions — and the `.claude/sync-keep.candidate` written in bootstrap mode — are left uncommitted, so a `git checkout .` resurrects everything and the next `/sync` re-reports the same retire list.
+
+**Pre-existing, amplified.** The old hardcoded `rm -rf` block sat in the same position; what changed is that the deletion set grew from four fixed paths to an arbitrary computed set. Filed rather than fixed in-session because reordering a user-facing procedure step is outside the boundary of the change that surfaced it.
+
+## Acceptance Criteria
+
+- [ ] The retirement pass and its deletions are covered by a commit
+- [ ] `.claude/sync-keep.candidate` is likewise not left dangling
+- [ ] The user is not told the sync is committed while deletions are still pending
+- [ ] `tests/test-syncable-paths.sh` / doc-convention tests still pin the step ordering
+
+## Notes
+
+Found in the second review round of the deterministic-retirement build (`owner: human`). Related: [[sync.retire-blast-radius-cap]].

--- a/tasks/details/sync.stale-root-blocks-retirement.md
+++ b/tasks/details/sync.stale-root-blocks-retirement.md
@@ -1,0 +1,32 @@
+# A root retired upstream turns a valid sync-keep into a hard failure
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.stale-root-blocks-retirement
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: `if not _reaches_a_root(pattern, roots):` raising `is outside every syncable root ... it can never protect anything` in `validate_pattern` (`.agents/skills/sync/scripts/sync-retire.py`); reproduced in code review of the deterministic-retirement change — a project sync-keep naming `.claude/browsers/**` against a template whose doc block no longer declares that root exits 1 and retires nothing at all, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+`validate_pattern` resolves sync-keep patterns against the *current template's* root list, so a pattern that was correct yesterday becomes a hard exit 1 the day upstream drops that root — blocking every unrelated retirement in the same run, and blaming the project's file for a change that happened in the template.
+
+Distinct from [[sync.retired-root-orphans]], which is about orphaned *files* surviving; this is about a stale *pattern* disabling the whole pass.
+
+Raised as `owner: human` because softening a hard failure in a tool that deletes files is a policy call: reporting `orphaned:` and continuing trades a loud stop for a quieter one, and the right default depends on how much upstream root churn is expected.
+
+## Acceptance Criteria
+
+- [ ] A pattern whose head names a root the template no longer declares is reported, not fatal
+- [ ] The report distinguishes it from a pattern that never named any root, which stays fatal
+- [ ] Unrelated retirements in the same run still proceed
+- [ ] The message names the template as the thing that changed, not the project's file
+- [ ] `tests/test-sync-retirement.sh` covers both classes and pins that they are not conflated
+
+## Notes
+
+Found in the second review round of the deterministic-retirement build. Related: [[sync.retired-root-orphans]], [[sync.retire-blast-radius-cap]].

--- a/tasks/details/sync.syncable-paths-single-source.md
+++ b/tasks/details/sync.syncable-paths-single-source.md
@@ -1,0 +1,29 @@
+# Collapse the seven-region syncable-path enumeration into script-owned data
+
+<!-- task-registry:begin -->
+<!-- Managed by /task-registry. Edit the fields, not the markers. -->
+task-id: sync.syncable-paths-single-source
+kind: task
+spec: specs/sync-deterministic-retirement.md
+evidence: tests/test-syncable-paths.sh:8-19 names seven hand-maintained regions across three files (the § Syncable Paths doc block, two `git diff` argument lists, their two compat-copy twins, and the session-start.sh drift check); .agents/skills/sync/scripts/sync-retire.py:parse_syncable_roots became an eighth *consumer* of the block rather than an eighth copy, but the other six copies are unchanged, revision: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe @ HEAD
+<!-- task-registry:end -->
+
+- status: open
+- updated: 2026-09-04
+
+## Summary
+
+The syncable-path list is retyped in seven regions across three files. `tests/test-syncable-paths.sh` pins them equal, which catches drift but does not remove it — the drift it was written for (a missing `.agents/agents` in the drift check) had already shipped. Deterministic retirement made the list machine-read for the first time; the remaining six regions could read the same source instead of restating it.
+
+## Acceptance Criteria
+
+- [ ] The `## Syncable Paths` doc block, or a data file it renders from, is the only place the path list is written
+- [ ] The two `git diff` argument lists in SKILL.md and their compat-copy twins are generated or read from that source rather than retyped
+- [ ] `.claude/hooks/session-start.sh` reads the same source for its drift check
+- [ ] `tests/test-syncable-paths.sh` still fails when any consumer disagrees with the source
+- [ ] Canonical and compatibility skill trees stay byte-identical
+
+## Notes
+
+Deferred from the deterministic-retirement build: collapsing the other six regions
+would have widened that change well beyond its routed radius.

--- a/tasks/e2e-log.md
+++ b/tasks/e2e-log.md
@@ -155,3 +155,52 @@ Corrected by addendum rather than by editing the line above: the log is the audi
 and an entry silently rewritten to look as though it always pointed at the right commit
 is worth less than one that shows what moved. Nothing about the run itself changed — same
 fixture, same `lightpanda/browser:0.3.6` image, same observed values.
+
+---
+
+## 2026-09-05 — Deterministic retirement in `/sync`
+
+Spec: `specs/sync-deterministic-retirement.md`
+Branch: `Joaovsales/sync-is-non-deterministic-retired-vs-project-spe`
+Commit: recorded at commit time (see the `test(sync)` commit adding §21)
+Harness: `tests/test-sync-retirement.sh` §21, run under `bash tests/run.sh`
+
+### Why a walkthrough was needed
+
+Sections 1–20 all invoke the script as `python3 "$RETIRE"` — the copy on disk in
+this repo. `SKILL.md` Steps 3 and 6.4 do not. They pipe the script **out of the
+template ref** into `python3 -`, so a downstream `/sync` runs whatever the
+template ships, read from stdin, against the project. No assertion covered that
+form, so a script that worked from a file and failed from stdin would have passed
+the entire suite.
+
+### What was exercised, verbatim from the skill
+
+A fixture project with the template as a `workflow` remote (as Step 1 leaves it),
+the template carrying its own copy of `sync-retire.py`, and a real retirement in
+the template's history (`.agents/skills/legacy/` shipped, then removed).
+
+1. **Step 3 dry run** — `git show workflow/main:.agents/skills/sync/scripts/sync-retire.py | python3 - --from-ref workflow/main`
+   → exit 0; reported `retire: .agents/skills/legacy/SKILL.md`; reported
+   `dry-run (no changes written)`; **deleted nothing**. Reading the program from
+   stdin does not imply `--apply`.
+2. **Step 6.4 apply** — same pipeline with `--apply`
+   → exit 0; `.agents/skills/legacy/SKILL.md` deleted; `.agents/skills/ours/SKILL.md`
+   (project-specific, no provenance) untouched; `.claude/sync-keep.candidate` written
+   for the human to promote.
+
+### The `set -o pipefail` claim, tested rather than trusted
+
+`SKILL.md` warns that without `pipefail` a failed `git show` feeds `python3 -` an
+empty program which exits 0, silently skipping the retirement gate. That warning
+is now verified rather than asserted:
+
+- without `pipefail`, `git show` on a non-existent path → **exit 0, no output at all**
+- with `pipefail`, the same pipeline → **exit 128**, git's failure reaching the caller
+
+The warning is accurate and the guard is load-bearing.
+
+Result: PASS — both user-facing acceptance criteria ("a file retired upstream is
+removed without a human classifying it" and "a project-only path is reported
+before deletion, never deleted silently") verified through the invocation a real
+`/sync` executes, not a test-only one.

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -242,3 +242,60 @@
 
 ## 2026-09-02 — qwen spend investigation + guardrails (yolo)
 Investigated a $26.53/24h OpenRouter burn: pi session logs traced it to 6,006 qwen3-coder-next requests from one autonomous /build in PROJECT-pix-receipt-tracker (22 backend-developer spawns; 95% cache-read at $0.07/M). Root cause: `subagents.defaultModel` blanket-enforced qwen on all unscoped agents. Applied: defaultModel → deepseek-v4-flash, 80-turn caps on builder agents, key-limit deferred (needs management key). Verified via live smoke spawn. Docs: tasks/solutions/patterns/cheap-per-token-is-not-cheap-per-task-cap-subagent-turns.md
+
+## 2026-09-04 — deterministic retirement in /sync (routed: gated-at-plan-and-pre-push)
+Replaced `/sync`'s per-run model judgement of "retired upstream vs project-specific"
+with set arithmetic over a recorded `.claude/sync-keep` allowlist:
+`retire = project paths under syncable roots − template paths under the same roots
+− paths matching a sync-keep pattern`. New stdlib-only `sync-retire.py` (mirrored
+byte-identically into `.claude/skills/`), 103 lines of rewritten `/sync` procedure,
+a spec, and a 230-assertion behavioural suite.
+- Verification: 33/33 test files, 2828 assertions, 0 failures; ruff and py_compile
+  clean; both skill trees byte-identical.
+- Review: three rounds, six dispatched reviewers. Round 1 (APOSD) returned HOLD.
+  Round 2 (code + security) returned FAIL on a reproduced command-execution defect:
+  an untrusted `--from-dir` template's `core.fsmonitor` ran during the pre-approval
+  dry run. Round 3 (consistency, defensive, coverage, adversarial critic) returned
+  REVISE and found the round-2 fixes incomplete — `_as_pattern` still let a newline
+  escape its own comment, and three of the new assertions survived mutation.
+- Every MUST-FIX was reproduced before being fixed and pinned by a mutation probe.
+  Four probes exposed assertions that certified nothing; all four were rewritten.
+- Ten follow-ups filed; two were then fixed in-session on the user's call. The
+  regression (bootstrap projects keeping retired skills forever) and the fragility
+  (one upstream file deletion disabling retirement everywhere) shared a root cause:
+  the script only ever consulted the template's *current* state. Both were closed by
+  reading the template's git history for provenance, and by scoping an empty root to
+  itself while still refusing a source missing several roots.
+- Learnings captured: `tasks/solutions/security/running-git-in-an-untrusted-checkout-executes-its-config.md`,
+  `tasks/solutions/process/an-assertion-can-pass-because-a-different-guard-fired.md`,
+  `tasks/solutions/tooling/mawk-has-no-interval-expressions.md`
+
+### Round 2 review (2026-09-05)
+
+Re-dispatched `code-reviewer` and `critic` against the fix batch. Both independently
+found the record-loss survivor and the depth probe — separately dispatched contexts,
+so that agreement counts.
+
+- **The one that mattered**: bootstrap retired on *path identity*. A file the project
+  wrote itself at a path the template once used (`.claude/hooks/pre-commit.sh` is a
+  name both reach for), a synced file the project later edited, and a file with
+  uncommitted changes were all deleted as "template content". Provenance is now the
+  working-tree hash against every blob the template held at that path. Hashing the
+  working tree rather than the index is what saves the uncommitted case, which
+  `git checkout` could never restore.
+- The precondition reordering closed one call site of the record-loss class, not the
+  class: `write_candidate` could still fail after `apply_plan` for any reason other
+  than "already exists". Folded into `_deletion_outcome` as a fourth category.
+- The shallow probe was wrong in both directions in turn — repository-scoped (broke
+  `--from-ref` for CI's `--depth 1` projects), then commit-count (caught only depth 1,
+  so a `--depth 5` clone produced a different retirement set from the same SHA). Now
+  detects a graft boundary, which is depth- and mode-independent.
+- Four of my own assertions certified nothing and were rewritten: a probe aimed at an
+  unreachable branch, a fixture appending after the block terminator, a symlink test
+  whose target existed, and a `Traceback` check that `main` had always caught.
+- Process: dispatching write-capable reviewers against the live worktree raced my own
+  test runs. Use `isolation: "worktree"` next time.
+- Learnings: `architecture/path-membership-is-not-proof-of-provenance.md`,
+  `architecture/a-repository-level-flag-does-not-describe-one-revision.md`,
+  `process/a-precondition-that-fires-after-the-act-reports-nothing.md`,
+  `tooling/pkill-f-matches-the-shell-that-runs-it.md`

--- a/tasks/route-decision.md
+++ b/tasks/route-decision.md
@@ -1,0 +1,71 @@
+# Route Decision
+
+```json
+{
+  "author_association": "unknown",
+  "auto_confirm": false,
+  "autonomy": "gated-at-plan-and-pre-push",
+  "baseline_revision": "c3809a1642f328dc286fa5266529e4d80fa43237",
+  "baseline_worktree": {},
+  "ceiling": {
+    "channel_grant": "gated-at-plan",
+    "content_ceiling": "gated-at-plan-and-pre-push",
+    "label_grant": "gated-at-plan"
+  },
+  "decision_id": "c2ec2147bbb941389a4fbfe445fec400",
+  "declared_paths": [
+    ".agents/skills/sync/",
+    ".claude/skills/sync/",
+    "tests/"
+  ],
+  "declared_radius": 1,
+  "downgrades": [
+    {
+      "reason": "irreversible or outward-facing work requires a human gate",
+      "signal": "irreversible_or_outward_facing"
+    },
+    {
+      "reason": "actual diff exceeded the declared scope",
+      "signal": "runtime_tripwire"
+    }
+  ],
+  "human_verification": {
+    "judges": [],
+    "needed": false
+  },
+  "ignored_directives": [],
+  "independently_dispatched_reviews": false,
+  "lane": "gated-at-plan-and-pre-push",
+  "prelude": "skip: not needed for this kind",
+  "review_outcomes": {},
+  "reviewers": [
+    "code-reviewer",
+    "security-reviewer"
+  ],
+  "runtime_tripwire": {
+    "actual_radius": 6,
+    "changed_paths": [
+      ".agents/skills/sync/SKILL.md",
+      ".agents/skills/sync/scripts/sync-retire.py",
+      ".claude/skills/sync/SKILL.md",
+      ".claude/skills/sync/scripts/sync-retire.py",
+      "specs/sync-deterministic-retirement.md",
+      "tasks/checkpoint.md",
+      "tasks/details/glob-matcher-shared-module.md",
+      "tasks/details/sync.syncable-paths-single-source.md",
+      "tests/test-sync-retirement.sh"
+    ],
+    "outside_declared_paths": [
+      "specs/sync-deterministic-retirement.md",
+      "tasks/checkpoint.md",
+      "tasks/details/glob-matcher-shared-module.md",
+      "tasks/details/sync.syncable-paths-single-source.md"
+    ],
+    "overflow": true,
+    "status": "failed"
+  },
+  "task_reference": "sync.deterministic-retirement",
+  "unresolved_review_findings": [],
+  "verification_method": "tests"
+}
+```

--- a/tasks/route-decision.md
+++ b/tasks/route-decision.md
@@ -27,6 +27,10 @@
     {
       "reason": "actual diff exceeded the declared scope",
       "signal": "runtime_tripwire"
+    },
+    {
+      "reason": "runtime tripwire did not pass before reviewer finalization",
+      "signal": "runtime-tripwire"
     }
   ],
   "human_verification": {
@@ -34,10 +38,13 @@
     "needed": false
   },
   "ignored_directives": [],
-  "independently_dispatched_reviews": false,
+  "independently_dispatched_reviews": true,
   "lane": "gated-at-plan-and-pre-push",
   "prelude": "skip: not needed for this kind",
-  "review_outcomes": {},
+  "review_outcomes": {
+    "code-reviewer": "completed",
+    "security-reviewer": "completed"
+  },
   "reviewers": [
     "code-reviewer",
     "security-reviewer"

--- a/tasks/solutions/architecture/a-repository-level-flag-does-not-describe-one-revision.md
+++ b/tasks/solutions/architecture/a-repository-level-flag-does-not-describe-one-revision.md
@@ -1,0 +1,41 @@
+---
+title: A repository-level flag does not describe a single revision inside it
+date: 2026-09-05
+problem_type: architecture-decision
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [git, provenance, shallow-clone, ci, sync]
+applies_when: testing whether some history is deep enough to answer a question
+---
+
+## The rule
+
+When the question is about one revision, measure that revision. Repository-wide
+git flags (`--is-shallow-repository`, `core.bare`, `--is-inside-work-tree`)
+describe the container, and a container can hold revisions with different
+properties — most obviously after a `fetch` from a second remote.
+
+## What happened
+
+`template_history_paths` asked whether provenance was readable by running
+`git rev-parse --is-shallow-repository`. In `--from-dir` mode that was roughly
+right: the checkout *is* the template. In `--from-ref` mode — the mode the skill
+actually prescribes — the template ref is fetched into the **project** repo, so
+the flag answered "is the project a shallow clone?"
+
+A project cloned with `--depth 1`, which is what CI does by default, therefore
+reported `provenance: unavailable` and retired nothing, no matter how complete
+the fetched template ref was. The feature silently no-opped in its recommended
+mode, in exactly the environment least likely to have a human reading the output.
+
+`git rev-list --count --max-count=2 <revision>` asks the question being asked, in
+both modes, and removed the mode-dependent branch rather than adding one.
+
+## The direction of the error matters
+
+A truncated-but-not-single-commit history still misreports, but conservatively:
+paths retired beyond the horizon fall out of the history set and are held as
+candidates for a human. Unknown provenance must fail toward "ask", never toward
+"delete" — and the repo-level flag failed toward "never delete anything at all",
+which reads as safe and is how the no-op went unnoticed.
+
+Related: [[current-state-cannot-distinguish-removed-from-never-present]].

--- a/tasks/solutions/architecture/current-state-cannot-distinguish-removed-from-never-present.md
+++ b/tasks/solutions/architecture/current-state-cannot-distinguish-removed-from-never-present.md
@@ -1,0 +1,54 @@
+---
+title: Current state cannot distinguish removed-upstream from never-present
+date: 2026-09-04
+problem_type: architecture-decision
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [provenance, git-history, set-arithmetic, sync, determinism]
+applies_when: computing a difference between two trees where one side's absences carry two different meanings
+---
+
+## The rule
+
+`A − B` tells you a path is in A and not in B. It cannot tell you *why*. When the
+two reasons demand opposite actions, the current state of B is not enough
+information, and no amount of care with the subtraction will recover it. Reach for
+B's history, which is a record, not a judgement.
+
+## How it showed up
+
+`/sync` retirement computed `project − template`. A path in that set is either
+retired upstream (delete it) or project-specific (keep it) — opposite actions from
+one subtraction. The original design resolved this by requiring the project to
+record an allowlist first, and deleting nothing until it had.
+
+That was correct but incomplete: a project that never recorded one kept every
+retired file forever. The mechanism being replaced — a hardcoded
+`for retired in tdd deslop simplify verify-e2e` loop — had deleted those
+unconditionally, so the new design was *strictly weaker* for exactly the projects
+least likely to notice.
+
+## The fix
+
+The template's git history answers the narrower question on its own:
+
+```
+retire (bootstrap) = (project − template) ∩ (paths the template has ever carried)
+```
+
+A path the template once shipped and no longer does was template content by
+provenance. Verified end-to-end on a real clone: 5 retired paths removed in
+bootstrap with no human classification, the project-local skill kept, and the
+candidate holding only the path provenance could not settle.
+
+## What generalises
+
+- Provenance is **per-path, not per-name**. A retired skill sitting at a path the
+  template never used has no provenance and stays a candidate. Conservative and
+  correct — do not match on names.
+- History must actually be present. A shallow clone's history *is* its current
+  state, which would silently classify every retired path as project-specific.
+  Detect it (`git rev-parse --is-shallow-repository`) and say "unknown" rather
+  than concluding. `/sync` clones `--filter=blob:none` so the question stays
+  answerable cheaply.
+- "Unknown" needs to be a distinct third state from "yes" and "no", in the return
+  type as well as the report.

--- a/tasks/solutions/architecture/path-membership-is-not-proof-of-provenance.md
+++ b/tasks/solutions/architecture/path-membership-is-not-proof-of-provenance.md
@@ -1,0 +1,53 @@
+---
+title: Path membership is not proof of provenance
+date: 2026-09-05
+problem_type: architecture-decision
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [provenance, data-loss, git, determinism, sync]
+applies_when: deleting a file because some other repository once had that path
+---
+
+## The rule
+
+"The template once had a file at this path" and "this file is the template's"
+are different claims. A tool that deletes without asking needs the second, and
+only content can supply it. Compare the bytes.
+
+## What happened
+
+Bootstrap retirement computed
+`retire = (project − template) ∩ (paths the template ever carried)` and reported
+each result as `was template content, retired upstream`. The set operation is on
+paths; the report line, the spec, and the acceptance criterion all claimed a fact
+about the *file*. Three cases break on that gap:
+
+- a synced file the project **edited** afterwards — deleted, edit gone
+- a file the project **wrote itself** at a colliding path — `.claude/hooks/` is a
+  syncable root and `pre-commit.sh` is a name both a template and a project reach
+  for — deleted, never recoverable because it was never upstream
+- a tracked file with **uncommitted** modifications — deleted, and
+  `git checkout --` restores only the committed version, silently losing the edit
+
+The fix compares the working-tree hash against every blob the template ever held
+at that path (`git log --raw --no-abbrev` carries both pre- and post-image blobs,
+so one walk yields the whole content history). A mismatch demotes the path to a
+candidate for a human.
+
+## Why hash the working tree, not the index
+
+Hashing the index would still delete the third case: the indexed blob matches the
+template's, so the arithmetic says "pristine" while the file on disk carries work
+nobody can recover. The working tree is the thing being deleted, so it is the
+thing to measure.
+
+## The generalisable trap
+
+Determinism was the goal, and determinism was achieved — but determinism
+guarantees the *same* answer, not a *correct* one. A cheap checkable proxy
+(path membership) was substituted for the expensive question (is this the
+template's file?), and then the proxy was described in prose as though it were
+the answer. Whenever a design replaces a judgement with a record, check that the
+record actually records what the prose claims.
+
+Related: [[current-state-cannot-distinguish-removed-from-never-present]],
+[[a-repository-level-flag-does-not-describe-one-revision]].

--- a/tasks/solutions/bugs/grep-zero-matches-aborts-hooks-under-set-e-pipefail.md
+++ b/tasks/solutions/bugs/grep-zero-matches-aborts-hooks-under-set-e-pipefail.md
@@ -40,6 +40,34 @@ The `tasks/solutions/*/` glob only descends into category directories
 Regression test: tests/test-session-start.sh:62-88 (zero-flag fixture with a
 README that mentions the flag literally).
 
+## Recurrence — 2026-09-05: the same defect, one level up
+
+The second half of the resolution above was **incomplete**, and this document is
+what proved it. Scoping the glob to `tasks/solutions/*/` excluded the store
+README, but not a *document* that quotes the flag in its own prose — and this
+document does, twice (lines 28 and 35 above). So the session-start banner
+reported `1 needs_review` while zero documents carried the flag, permanently.
+
+Found by running `/memory-maintain`, whose Phase 1 opened this file expecting a
+flagged document and found none.
+
+The corrected fix anchors to the frontmatter field rather than narrowing the
+search location:
+
+```bash
+REVIEW_COUNT=$(grep -rlE '^needs_review: true' tasks/solutions/*/ 2>/dev/null | wc -l | tr -d ' ' || true)
+```
+
+`.claude/hooks/session-start.sh:156`, and the same pattern in
+`/memory-maintain`'s light pass (both skill copies).
+
+**The generalisable error**: the first fix restricted *where* to look when the
+defect was *what* to match. A store of documents about a system will inevitably
+quote that system's own markers, so any grep over prose must match structure
+(column-0 frontmatter) rather than rely on no document ever mentioning the
+string. Same shape as
+[[scoping-a-guard-per-item-can-silently-weaken-it]].
+
 ## Prevention
 
 In any `set -eo pipefail` script, treat every counting/filtering grep as a

--- a/tasks/solutions/process/a-precondition-that-fires-after-the-act-reports-nothing.md
+++ b/tasks/solutions/process/a-precondition-that-fires-after-the-act-reports-nothing.md
@@ -1,0 +1,42 @@
+---
+title: A precondition that fires after the act it guards reports nothing
+date: 2026-09-05
+problem_type: process
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [ordering, error-handling, data-loss, preconditions, sync]
+applies_when: a destructive step and a validation both live in one function
+---
+
+## The rule
+
+Order a precondition before the irreversible step it guards, not merely before
+the step that *reports* it. A check that raises after the deletion has already
+happened discards the record of what was destroyed — and the operator is shown
+an error about the thing that did not happen instead of the thing that did.
+
+Nothing may fail between an irreversible act and the report of that act.
+
+## What happened
+
+Bootstrap `--apply` ran `apply_plan` (deletes) and then `write_candidate`, which
+refuses to overwrite an existing `.claude/sync-keep.candidate`. So the ordinary
+state "a candidate was generated last run and not yet promoted" deleted files,
+then raised, and the raise unwound past the accounting that held `removed`. The
+run exited 1 having destroyed a skill, printed no `deleted:` line, and the exit
+table told the reader that this exit code deleted nothing.
+
+The fix was not a `try`/`finally`. It was extracting the precondition
+(`assert_candidate_writable`) and calling it *first*, so the failure mode became
+"exits 1, changed nothing" — which is what the documentation already claimed.
+
+## Why it kept recurring
+
+This was the fourth instance of one defect in one file, and each earlier fix was
+applied at the call site that had been caught: the `os.remove` loop, then
+`os.rmdir`, then `os.listdir`, then this ordering. Each fix was correct and none
+generalised, so every new call site reintroduced it.
+
+The generalising question is not "does this call site handle its error?" but
+"what is the irreversible act here, and can anything fail after it?" See
+[[an-assertion-can-pass-because-a-different-guard-fired]] for the companion
+failure — a test that looked like it covered this and did not.

--- a/tasks/solutions/process/an-assertion-can-pass-because-a-different-guard-fired.md
+++ b/tasks/solutions/process/an-assertion-can-pass-because-a-different-guard-fired.md
@@ -1,0 +1,49 @@
+---
+title: An assertion can pass because a different guard fired
+date: 2026-09-04
+problem_type: process
+module: tests/test-sync-retirement.sh, .agents/skills/sync/scripts/sync-retire.py
+tags: [testing, mutation-probe, vacuous-assertion, defence-in-depth]
+applies_when: testing a validator that sits upstream of another check which would reject the same input
+---
+
+## The rule
+
+When two guards reject the same input, asserting only "the run failed" pins
+**neither**. Mutation-probe the guard you meant to test; if the suite stays green,
+the assertion is measuring its downstream neighbour.
+
+## How it showed up
+
+A root-shape validator was tightened to reject `.claude/../`, `.claude/./` and
+`.claude/*/`. The new assertions checked exit status and that the message named
+the offending root — and stayed green when the fix was reverted, because a
+later check (`assert_roots_present`) refuses those roots incidentally: git
+normalises its output, so no template path literally begins with `.claude/../`.
+
+The test certified a safety property it could not observe. Reverting the
+traversal fix produced a green suite with whole-repo deletion one refactor away.
+
+## The fix
+
+Assert on the *specific* guard's message, not on the outcome both guards share:
+
+```
+assert_contains "$RUN_OUTPUT" "is not a syncable root" \
+  "the root-shape validator is what rejects it, not a downstream accident"
+```
+
+Re-probed: reverting the regex now fails 3 assertions.
+
+## What generalises
+
+- Defence-in-depth makes tests harder to write, not easier. Every redundant guard
+  is a way for an assertion to pass for the wrong reason.
+- Some properties are genuinely unobservable behind a stronger guard. When that is
+  true, say so in the test rather than leaving an assertion that looks like proof —
+  a comment naming what it cannot distinguish is honest; silence is not.
+- Two distinct failure shapes need two distinct messages, or they cannot be
+  told apart from the outside.
+
+Sibling case, different mechanism (wrong *half* of a payload rather than wrong
+*guard*): [[assertion-must-be-scoped-to-the-half-it-tests]].

--- a/tasks/solutions/process/scoping-a-guard-per-item-can-silently-weaken-it.md
+++ b/tasks/solutions/process/scoping-a-guard-per-item-can-silently-weaken-it.md
@@ -1,0 +1,51 @@
+---
+title: Scoping an all-or-nothing guard per item can silently weaken it
+date: 2026-09-04
+problem_type: process
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [guards, blast-radius, review, threshold, sync]
+applies_when: relaxing a coarse safety check into a per-item one to fix a false positive
+---
+
+## The rule
+
+An all-or-nothing guard often protects against a case no single item exhibits.
+Splitting it per item removes that protection without the diff looking like it
+removed anything. Before scoping a guard down, ask what the *aggregate* was
+catching.
+
+## How it showed up
+
+`assert_roots_present` required the template to contain ≥1 file under every
+declared syncable root, else hard error. It was too strict: two roots hold a
+single file each, so one ordinary upstream deletion made every downstream `/sync`
+exit 1 and retire nothing.
+
+The obvious fix — skip the empty root, keep going — quietly reopened the
+catastrophe it existed to prevent. The doc block that declares the roots lives
+under `.agents/skills/`, so **that root is non-empty in any template the script
+can read**. A truncated clone carrying only the sync skill would leave every other
+root empty, skip them all, scan `.agents/skills/` against a near-empty inventory,
+and retire the project's remaining 76 skill files.
+
+## The fix
+
+A threshold rather than a per-item rule: **one** empty root is an upstream
+deletion (skip and report), **several** is a truncated source (refuse). Upstream
+retires roots one release at a time; a broken checkout empties many at once.
+
+Pinned by a fixture that simulates the truncated clone and asserts nothing under
+`.agents/skills/` is deleted. Mutation-probed: removing the threshold fails 3
+assertions.
+
+## What generalises
+
+- The item that can never trip a guard is the one that makes per-item scoping
+  unsafe — here, the root containing the config that defines the roots.
+- A false positive in a safety check is a reason to make it *more precise*, not
+  more permissive. A threshold keeps the aggregate signal while admitting the
+  benign single case.
+- Self-referential configuration (a list that lives inside the thing it describes)
+  deserves explicit thought whenever it appears in a guard.
+
+Related: [[../architecture/current-state-cannot-distinguish-removed-from-never-present]].

--- a/tasks/solutions/security/a-guard-list-of-exec-knobs-misses-the-ones-that-choose-targets.md
+++ b/tasks/solutions/security/a-guard-list-of-exec-knobs-misses-the-ones-that-choose-targets.md
@@ -1,0 +1,55 @@
+---
+title: Hardening a list of exec-capable knobs misses the ones that choose targets
+date: 2026-09-05
+problem_type: security
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [git, untrusted-input, config, deletion, sync]
+symptoms: identical template content produced different retirement sets depending on one line in the untrusted checkout's .git/config
+root_cause: the git hardening enumerated knobs that execute commands; core.quotePath executes nothing but decides how paths are spelled, and the deletion set is keyed on those strings
+resolution: pass -z to the history walk so git never quotes, removing the dependence instead of pinning the knob (sync-retire.py, template_history_blobs)
+---
+
+## The rule
+
+When you harden against untrusted configuration, enumerate by **what the config
+can influence**, not by what it can execute. A knob that runs no command can
+still choose which file gets deleted.
+
+## What happened
+
+Reading an untrusted template checkout with git executes that checkout's config —
+`core.fsmonitor` names a command git runs on `ls-files`. That was found and fixed
+by pinning the exec-capable knobs on the command line (`-c` outranks repo config)
+and dropping system and global config.
+
+The fix was correct and incomplete, because the list was built from one question:
+*which knobs run a command?* `core.quotePath` runs nothing. It decides whether
+`git log --raw` C-quotes paths holding non-ASCII bytes. The provenance map was
+keyed on those strings while the project side used raw bytes, so:
+
+```
+quotePath=true    candidate: .claude/hooks/café.sh   ← held for a human
+quotePath=false   retire:    .claude/hooks/café.sh   ← deleted
+```
+
+Same template content, same project, one line of someone else's config. It also
+broke the acceptance criterion that `--from-ref` and `--from-dir` agree, since
+the knob is read from the project in one mode and the template in the other.
+
+## Prefer removing the dependence to pinning the knob
+
+`-c core.quotePath=false` would have worked and would have been wrong in kind: it
+adds a second entry to the same fragile enumeration. `-z` makes git emit
+NUL-separated raw bytes, so no configuration can affect the spelling at all. When
+a knob can be made irrelevant, make it irrelevant.
+
+## Where the enumeration is still an enumeration
+
+The exec-knob pin remains a list, and lists rot. What bounds it here is that the
+script uses six read-only subcommands with no pager, no patch generation and no
+network — verified by testing `core.pager`, `diff.external`,
+`core.alternateRefsCommand`, `uploadpack.packObjectsHook` and `core.sshCommand`,
+none of which fire. That reasoning belongs in the code, because the next
+subcommand added is what invalidates it.
+
+Related: [[running-git-in-an-untrusted-checkout-executes-its-config]].

--- a/tasks/solutions/security/running-git-in-an-untrusted-checkout-executes-its-config.md
+++ b/tasks/solutions/security/running-git-in-an-untrusted-checkout-executes-its-config.md
@@ -1,0 +1,46 @@
+---
+title: Running git inside an untrusted checkout executes that repository's config
+date: 2026-09-04
+problem_type: security
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [git, command-execution, trust-boundary, untrusted-input, sync]
+symptoms: A dry run that writes nothing created a sentinel file in the fixture, before any user approval and without --apply.
+root_cause: git honours the inspected repository's own .git/config, and core.fsmonitor names a command git executes on ls-files. The checkout is same-uid, so safe.directory never fires.
+resolution: Pin the exec-capable knobs on the command line, where -c outranks repository config, and drop system/global config from the environment.
+---
+
+## The rule
+
+`git -C <dir> <cmd>` is not a read-only operation on `<dir>`. It is a request to
+execute whatever that directory's configuration names. If `<dir>` came from
+anywhere but the project itself, its config is untrusted input.
+
+## How it showed up
+
+`/sync` obtains a template checkout and this script inventories it. Switching the
+manual-diff path from `diff -rq` to `git ls-files` introduced the sink without
+introducing an obviously new capability — the diff looked like a fidelity
+improvement.
+
+Reproduced with `git config core.fsmonitor "touch …/PWNED; false"` planted in the
+template. The sentinel appeared during the **Step 3 dry run**: before approval,
+without `--apply`, on the code path whose entire purpose is to *preview*.
+
+## The fix
+
+`-c core.fsmonitor=` on the command line beats repository config, because
+command-line `-c` has the highest precedence. `GIT_CONFIG_NOSYSTEM=1` and
+`GIT_CONFIG_GLOBAL=/dev/null` remove the other two config layers.
+
+Verified: `git -C tmpl ls-files` executed the payload; `git -C tmpl -c
+core.fsmonitor= ls-files` did not, with identical output otherwise.
+
+## What generalises
+
+- A "read-only" subcommand is not safety evidence. Ask what the *config* can do.
+- `safe.directory` protects against **other users'** repositories. It does nothing
+  for a directory your own uid created — which is exactly what `mktemp -d` plus a
+  clone produces.
+- The env-var suppression is defence-in-depth *behind* the `-c` pin and is not
+  independently observable once the pin is in place. A test asserting it passes
+  either way; see [[../process/an-assertion-can-pass-because-a-different-guard-fired]].

--- a/tasks/solutions/security/the-record-of-a-destructive-action-is-an-attack-surface.md
+++ b/tasks/solutions/security/the-record-of-a-destructive-action-is-an-attack-surface.md
@@ -1,0 +1,50 @@
+---
+title: The record of a destructive action is itself an attack surface
+date: 2026-09-05
+problem_type: security
+module: .agents/skills/sync/scripts/sync-retire.py
+tags: [output-injection, logging, data-loss, deletion, sync]
+symptoms: a run reported `kept: audit.sh` for a file it deleted in the same run
+root_cause: paths were interpolated raw into one-line-per-item report entries, so a filename containing a newline emitted lines indistinguishable from real ones
+resolution: escape every path entering a report line so it can only occupy one line (sync-retire.py `_field`)
+---
+
+## The rule
+
+If a tool prints a record of what it destroyed, that record is security-relevant
+output. Anything attacker-influenceable inside it — filenames above all — must be
+escaped so it cannot forge or hide an entry.
+
+## What happened
+
+`render` and `_deletion_outcome` interpolated paths straight from `git ls-files`.
+A file named:
+
+```
+.claude/hooks/a.md
+  kept:   audit.sh (matched keepall)
+```
+
+produced a dry run whose middle line was a perfectly-formed `kept:` entry, and an
+`--apply` that deleted `audit.sh` while the operator's record said it was kept.
+`\r` is worse on a terminal: it overwrites the line above.
+
+The same file already had the primitive. `_is_unexpressible` rejects `\n\r` when
+emitting candidate patterns, and `_one_line` flattens git's stderr for the same
+reason. Both were written to protect the report; neither was applied to the two
+functions whose output *is* the report.
+
+## Why it survived several review rounds
+
+Every earlier round asked whether the tool deleted the right files. None asked
+whether the report could lie about which files those were. The retirement set and
+the record of it are two different surfaces, and correctness of the first says
+nothing about integrity of the second.
+
+## Prevention
+
+Escape at the single point data enters the record, not at each call site — there
+were ten here (`retire:`, `kept:`, `candidate:`, `unmatched:`, `dormant:`,
+`deleted:`, `FAILED:` ×2, `UNPRUNED:`). Test it by asserting the *shape* of the
+output (no line outside the expected prefixes) rather than the absence of one
+payload string, since the payload legitimately appears inside the escaped field.

--- a/tasks/solutions/tooling/mawk-has-no-interval-expressions.md
+++ b/tasks/solutions/tooling/mawk-has-no-interval-expressions.md
@@ -1,0 +1,45 @@
+---
+title: mawk silently never matches a bounded regex interval
+date: 2026-09-04
+problem_type: tooling
+module: tests/test-syncable-paths.sh
+tags: [awk, mawk, regex, portability, silent-failure]
+applies_when: writing an awk regex in a shell test, especially one that gates or terminates parsing
+---
+
+## The rule
+
+`mawk` does not support interval expressions (`{n,m}`). A pattern using one does
+not error — it simply never matches, so the guard it implements silently does
+nothing.
+
+## How it showed up
+
+Two parsers read the same `## Syncable Paths` doc block: a Python one and an awk
+extractor in a pinning test. They were aligned by changing the awk terminator to
+`/^#{2,6} /`. The suite stayed green, which looked like confirmation.
+
+Checking directly showed the terminator never fired — awk still emitted a root
+declared after a `### Subsection`, while the Python parser stopped there. The
+"fix" was a no-op, and the two parsers were still disagreeing.
+
+```
+$ awk --version | head -1
+mawk 1.3.4 20240123
+```
+
+`gawk` supports intervals by default and would have masked this entirely on a
+different machine.
+
+## The fix
+
+`/^##+ /` — one-or-more, which is plain ERE and portable. Verified against the
+same fixture: awk and the Python parser now return the same root set.
+
+## What generalises
+
+- A green suite after a regex change proves nothing if no test exercises the
+  branch the regex guards. Check the regex against a fixture directly.
+- `mawk` is the default `awk` on Debian/Ubuntu, so "works on my machine" with
+  `gawk` is a real portability trap in shell test suites.
+- Prefer `+`/`*` over `{n,m}` in awk unless the bound is load-bearing.

--- a/tasks/solutions/tooling/pkill-f-matches-the-shell-that-runs-it.md
+++ b/tasks/solutions/tooling/pkill-f-matches-the-shell-that-runs-it.md
@@ -1,0 +1,42 @@
+---
+title: pkill -f matches the command line of the shell running it
+date: 2026-09-05
+problem_type: tooling
+module: tests/
+tags: [bash, process-management, self-inflicted, ci]
+applies_when: killing stray processes by command-line pattern from inside a script
+---
+
+## The rule
+
+`pkill -f <pattern>` matches full command lines, including the command line of
+the shell executing the `pkill`. If the pattern appears anywhere in the invoking
+script's own argv — which it does whenever the script was passed inline with
+`bash -c` — the script kills itself.
+
+Symptom: the command dies with no output and an exit code of 128 + signal
+(`143` for SIGTERM, or a stranger number when the harness re-signals).
+
+## What happened
+
+Two hung test processes needed clearing, so the next command started with
+`pkill -f "tests/test-"`. That string was also in the inline script's own argv,
+so it terminated its own shell before running anything — twice, costing about
+twenty minutes and producing a confusing `exit 144` each time.
+
+## What to do instead
+
+Kill by PID from a prior `ps` (`kill 12345`), or exclude self explicitly:
+
+```bash
+pkill -f --older 60 "pattern"     # only long-running matches
+pgrep -f "pattern" | grep -v $$ | xargs -r kill
+```
+
+## The adjacent lesson
+
+The hang itself was also self-inflicted: the sweep ran the whole suite three
+times over, and `tests/run.sh` is itself the runner, so two concurrent instances
+of a test that installs git hooks deadlocked on a shared lock. Run the project's
+own entry point once rather than iterating `tests/*.sh` — the glob includes the
+runner.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -336,3 +336,63 @@ assertions, and 51 parity assertions. Initial quality gate: APOSD GO.
   contract stands. Shipped as c000b04, PR #88. The gate defect the finding
   exposed is filed as `review-gate.define-finding-resolution`.
 - [ ] Define finding resolution per owner, and remove the owner carve-out from every gate <!-- task-id: review-gate.define-finding-resolution --> — The word "unresolved" is load-bearing in four commit gates and defined nowhere, so each gate re-derives it and two deri… ([review-gate.define-finding-resolution](tasks/details/review-gate.define-finding-resolution.md))
+- [x] /sync is non-deterministic: retired-vs-project-specific is re-judged every run <!-- task-id: sync.deterministic-retirement --> — record the keep/retire decision as data (`.claude/sync-keep`) so `/sync` is reproducible instead of re-judged per run ([#89](https://github.com/Joaovsales/jplugin-agentic-development/issues/89))
+- [ ] Collapse the seven-region syncable-path enumeration into script-owned data <!-- task-id: sync.syncable-paths-single-source --> — the list is retyped in seven regions across three files; deterministic retirement made it machine-read for the first time ([sync.syncable-paths-single-source](tasks/details/sync.syncable-paths-single-source.md))
+- [ ] Extract the shared path-glob matcher out of spec-reconcile.py <!-- task-id: glob-matcher-shared-module --> — two scripts implement the same three-token whole-path glob semantics; they agree today, which is the dangerous state ([glob-matcher-shared-module](tasks/details/glob-matcher-shared-module.md))
+- [ ] A syncable root retired upstream leaves permanent orphans <!-- task-id: sync.retired-root-orphans --> — retirement works within declared roots; removing a whole root from the doc block leaves the project's copy forever ([sync.retired-root-orphans](tasks/details/sync.retired-root-orphans.md))
+- [ ] Bound the retirement blast radius before --apply deletes <!-- task-id: sync.retire-blast-radius-cap --> — the plan is printed but nothing acts on it; a cap bounds defects that inflate the set ([sync.retire-blast-radius-cap](tasks/details/sync.retire-blast-radius-cap.md))
+- [ ] A root retired upstream turns a valid sync-keep into a hard failure <!-- task-id: sync.stale-root-blocks-retirement --> — a pattern naming a root the template dropped exits 1 and blocks every unrelated retirement ([sync.stale-root-blocks-retirement](tasks/details/sync.stale-root-blocks-retirement.md))
+- [ ] Adjacent unbounded quantifiers make the glob matcher hang <!-- task-id: glob-matcher-redos --> — `**`/`*?` runs compile to catastrophic backtracking; fix belongs with the shared-matcher extraction ([glob-matcher-redos](tasks/details/glob-matcher-redos.md))
+- [ ] Step 6.4 deletes after Step 6 already asked the user to commit <!-- task-id: sync.retirement-lands-after-commit --> — pre-existing ordering, amplified now the deletion set is computed rather than four fixed paths ([sync.retirement-lands-after-commit](tasks/details/sync.retirement-lands-after-commit.md))
+- [x] Bootstrap projects never remove the four legacy retired skills <!-- task-id: sync.bootstrap-skips-legacy-retirements --> — the only mechanism that deleted tdd/deslop/simplify/verify-e2e is gone; the one case the new design is strictly weaker ([sync.bootstrap-skips-legacy-retirements](tasks/details/sync.bootstrap-skips-legacy-retirements.md))
+- [x] A root legitimately emptied upstream disables the whole retirement pass <!-- task-id: sync.emptied-root-blocks-retirement --> — assert_roots_present conflates a wrong source with a root emptied upstream ([sync.emptied-root-blocks-retirement](tasks/details/sync.emptied-root-blocks-retirement.md))
+- [ ] The bootstrap candidate protects a generated skill file-by-file <!-- task-id: sync.candidate-emits-per-file-patterns --> — one exact rule per file, so anything added to a project-local skill is a fresh retire candidate ([sync.candidate-emits-per-file-patterns](tasks/details/sync.candidate-emits-per-file-patterns.md))
+
+<!-- route-lane:begin -->
+## Routed lane — gated-at-plan-and-pre-push
+
+[ ] prelude: skip: not needed for this kind
+[ ] /plan (auto-confirm: no; wait for approval)
+[ ] /build (runs /quality-gate on completion)
+[ ] route radius tripwire: finalize_route before verification or push
+[ ] /verify (evidence: tests)
+[x] reviewers: code-reviewer, security-reviewer — round 2 on the fixed diff: 1 MUST-FIX + 1 HIGH reproduced and fixed, 5 more applied, 4 filed; 191 assertions
+[ ] /wrap-up-session (wait at pre-push gate)
+<!-- route-lane:end -->
+
+---
+
+## Plan: Deterministic Retirement in /sync
+> Spec: specs/sync-deterministic-retirement.md
+> Task: sync.deterministic-retirement (#89) — routed gated-at-plan-and-pre-push
+> Branch: Joaovsales/sync-is-non-deterministic-retired-vs-project-spe (worktree off master @ c3809a1)
+> Baseline: `bash tests/run.sh` green before Task 1
+
+[x] TDD: `tests/test-sync-retirement.sh` covers pattern parsing and validation — blank lines and `#` comments ignored; empty, absolute, `..`-traversing, backslash-separated, `[ab]`-globbed, and outside-every-syncable-root patterns each fail non-zero naming the offending pattern and its line, deleting nothing -> `.agents/skills/sync/scripts/sync-retire.py`: argparse CLI, `.claude/sync-keep` reader, pattern validator, `_pattern_to_regex`/`match_path` with `TODO(shortcut):` naming the spec-reconcile.py duplication
+[x] TDD: syncable roots are parsed from the `## Syncable Paths` doc block — a fixture SKILL.md with an added root changes what is scanned, file roots (`CLAUDE.md`, `.claude/settings.json`) are excluded from retirement, a root absent from the project is empty rather than an error, and a root absent from the template is an error -> doc-block parser + root resolution
+[x] TDD: `--from-ref` and `--from-dir` yield identical retirement sets for the same template content; supplying both or neither is a usage error (exit 2) -> template inventory via `git ls-tree -r --name-only` and via directory walk
+[x] TDD: retirement set is project − template − allowlist; the default run lists every retire path in full (no truncation) and deletes nothing -> plan computation + report rendering
+[x] TDD: `--apply` deletes exactly the retirement set, prunes emptied directories, prints the same full list before deleting, and leaves non-retired paths untouched -> apply step
+[x] TDD: a path matched by `sync-keep` survives and is reported `kept: <path> (matched <pattern>)`; an empty `sync-keep` is distinct from an absent one and permits deletion -> allowlist wiring
+[x] TDD: absent `.claude/sync-keep` retires nothing, reports `bootstrap: required` with every project-only path as a candidate, and under `--apply` writes `.claude/sync-keep.candidate` and never `.claude/sync-keep` -> bootstrap mode
+      ↳ **amended on the user's call**: "retires nothing" left every bootstrap project keeping retired skills forever. Bootstrap now retires files that are byte-identical to something the template's history shows it shipped at that path, and holds everything else — customised, uncommitted, or same-name-different-file — as a candidate. Kept as an amendment rather than a rewrite: the original scope is what the earlier commits implement.
+[x] TDD: two `--apply` runs against an unchanged template leave a byte-identical tree and the second reports zero retirements -> idempotency assertions over a tree hash
+[x] TDD: two project branches with different project-only sets converge to the same harness path set against one template ref -> branch-independence fixture
+[x] TDD: `.claude/sync-keep` appears in the § Syncable Paths never-sync list, the retirement pass is documented in the procedure, and it applies for options 1 and 2 but not 3 or 4 -> edit `.agents/skills/sync/SKILL.md`
+[x] TDD: `tests/test-skill-parity.sh`, `tests/test-syncable-paths.sh`, `tests/test-skill-references.sh` and full `bash tests/run.sh` green -> byte-identical mirror of `.agents/skills/sync/**` into `.claude/skills/sync/**`
+[x] Follow-ups filed as registry tasks + GitHub issues: (a) collapse the seven-region syncable-path enumeration into script-owned data; (b) extract the shared `match_path` glob matcher out of spec-reconcile.py -> `/task-registry upsert --apply` for each, then publish
+
+## Session Summary — 2026-09-05 [c3809a1..HEAD]
+- Completed: deterministic retirement in `/sync` — all 12 planned tasks, plus two
+  behaviour changes the user requested mid-session (bootstrap provenance; empty
+  roots skipped rather than fatal).
+- Review: 6 dispatched reviewers across two rounds this session. Round 2 found
+  4 MUST-FIX (2 corroborated by both contexts) — all reproduced, fixed, and
+  mutation-probed. 11 fixes total, every one pinned by an assertion that goes
+  red when the fix is reverted.
+- The load-bearing correction: bootstrap deleted on **path identity**, so a file
+  the project authored at a colliding path — or a synced file it had edited, or
+  one with uncommitted changes — was destroyed. Provenance is now content:
+  the working-tree hash must match a blob the template actually shipped there.
+- Tests: 33/33 files, 2911 → 315 assertions in the retirement suite alone.
+- Pending: nothing carried forward from this plan.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -344,6 +344,7 @@ assertions, and 51 parity assertions. Initial quality gate: APOSD GO.
 - [ ] A root retired upstream turns a valid sync-keep into a hard failure <!-- task-id: sync.stale-root-blocks-retirement --> — a pattern naming a root the template dropped exits 1 and blocks every unrelated retirement ([sync.stale-root-blocks-retirement](tasks/details/sync.stale-root-blocks-retirement.md))
 - [ ] Adjacent unbounded quantifiers make the glob matcher hang <!-- task-id: glob-matcher-redos --> — `**`/`*?` runs compile to catastrophic backtracking; fix belongs with the shared-matcher extraction ([glob-matcher-redos](tasks/details/glob-matcher-redos.md))
 - [ ] Step 6.4 deletes after Step 6 already asked the user to commit <!-- task-id: sync.retirement-lands-after-commit --> — pre-existing ordering, amplified now the deletion set is computed rather than four fixed paths ([sync.retirement-lands-after-commit](tasks/details/sync.retirement-lands-after-commit.md))
+- [ ] Finalizing reviewers regenerates the lane block and discards its completion state <!-- task-id: route.finalize-discards-lane-completion --> — a demotion re-renders the checklist from the playbook template, so every `[x]` reverts to `[ ]` at exactly the moment the record matters most ([route.finalize-discards-lane-completion](tasks/details/route.finalize-discards-lane-completion.md))
 - [x] Bootstrap projects never remove the four legacy retired skills <!-- task-id: sync.bootstrap-skips-legacy-retirements --> — the only mechanism that deleted tdd/deslop/simplify/verify-e2e is gone; the one case the new design is strictly weaker ([sync.bootstrap-skips-legacy-retirements](tasks/details/sync.bootstrap-skips-legacy-retirements.md))
 - [x] A root legitimately emptied upstream disables the whole retirement pass <!-- task-id: sync.emptied-root-blocks-retirement --> — assert_roots_present conflates a wrong source with a root emptied upstream ([sync.emptied-root-blocks-retirement](tasks/details/sync.emptied-root-blocks-retirement.md))
 - [ ] The bootstrap candidate protects a generated skill file-by-file <!-- task-id: sync.candidate-emits-per-file-patterns --> — one exact rule per file, so anything added to a project-local skill is a fresh retire candidate ([sync.candidate-emits-per-file-patterns](tasks/details/sync.candidate-emits-per-file-patterns.md))
@@ -360,10 +361,10 @@ assertions, and 51 parity assertions. Initial quality gate: APOSD GO.
 [x] prelude: skip: not needed for this kind
 [x] /plan (auto-confirm: no) — spec + 12-task plan approved before any code
 [x] /build — 12/12 tasks, /quality-gate run on completion
-[x] route radius tripwire: finalize_route ran and recorded overflow (4 paths outside declared scope: the spec, checkpoint and two task details) — status: failed, carried in tasks/route-decision.md rather than cleared
-[x] /verify (evidence: tests) — 33/33 files, 2927 assertions; e2e walkthrough recorded in tasks/e2e-log.md
-[x] reviewers: code-reviewer, security-reviewer, critic — three rounds; round 3 security returned FAIL on a reproduced arbitrary-delete and a forgeable report, both fixed. finalize_reviewers not yet run
-[x] /wrap-up-session — user authorized the pre-push gate; pushed, PR #104 opened
+[x] route radius tripwire: finalize_route ran; recorded overflow — 4 paths outside declared scope (the spec, checkpoint, two task details). status: failed
+[x] /verify (evidence: tests) — 33/33 files, 2937 assertions; e2e walkthrough in tasks/e2e-log.md
+[x] reviewers: code-reviewer, security-reviewer — finalize_reviewers run: both completed, 0 unresolved, independently dispatched. Demoted on the tripwire, which had already failed (`critic` was also dispatched but is not in the decision's reviewer list, so it cannot be recorded there)
+[x] /wrap-up-session — user authorized the pre-push gate; pushed, PR #104 open, CI green
 <!-- route-lane:end -->
 
 ---

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -382,7 +382,7 @@ assertions, and 51 parity assertions. Initial quality gate: APOSD GO.
 [x] TDD: `tests/test-skill-parity.sh`, `tests/test-syncable-paths.sh`, `tests/test-skill-references.sh` and full `bash tests/run.sh` green -> byte-identical mirror of `.agents/skills/sync/**` into `.claude/skills/sync/**`
 [x] Follow-ups filed as registry tasks + GitHub issues: (a) collapse the seven-region syncable-path enumeration into script-owned data; (b) extract the shared `match_path` glob matcher out of spec-reconcile.py -> `/task-registry upsert --apply` for each, then publish
 
-## Session Summary — 2026-09-05 [c3809a1..HEAD]
+## Session Summary — 2026-09-05 [c3809a1..101cdfc]
 - Completed: deterministic retirement in `/sync` — all 12 planned tasks, plus two
   behaviour changes the user requested mid-session (bootstrap provenance; empty
   roots skipped rather than fatal).

--- a/tests/test-session-start.sh
+++ b/tests/test-session-start.sh
@@ -70,7 +70,7 @@ rm -rf "$tmpS"
 # counted as a flagged document.
 tmpZ=$(mktemp -d)
 cd "$tmpZ"
-mkdir -p tasks/solutions/patterns
+mkdir -p tasks/solutions/patterns tasks/solutions/bugs
 printf '`needs_review: true` is documentation, not a flag\n' > tasks/solutions/README.md
 cat > tasks/solutions/patterns/clean-doc.md <<'EOF'
 ---
@@ -83,12 +83,32 @@ applies_when: testing the zero-flag store path
 ---
 Body.
 EOF
+# A *document* that quotes the flag in its prose. Scoping the search to category
+# directories excludes the store README but not this, and a store of documents
+# about this system will inevitably quote its markers — one in the real store
+# does, which made the banner report a flag that no document carried.
+cat > tasks/solutions/bugs/quotes-the-flag.md <<'EOF'
+---
+title: Quotes the flag in prose
+date: 2026-08-13
+problem_type: bug
+module: tests
+tags: [fixture]
+symptoms: none, this is a fixture
+root_cause: none
+resolution: none
+---
+This document explains that `needs_review: true` in frontmatter marks a document
+for review. The mention is prose, not a flag:
+
+    needs_review: true
+EOF
 out_zero=$(printf '{"source":"startup"}' | CCW_SESSION_GUARD=0 bash "$HOOK" 2>/dev/null)
 ec_zero=$?
 assert_eq "0" "$ec_zero" "M3: zero-flag store does not abort the hook"
 assert_contains "$out_zero" "SKILLS AVAILABLE" "M3: zero-flag store still prints the full banner"
-assert_contains "$out_zero" "1 documents, 0 needs_review" \
-  "M3: zero-flag store counts 0 needs_review (README mention not counted)"
+assert_contains "$out_zero" "2 documents, 0 needs_review" \
+  "M3: neither the README nor a document quoting the flag is counted as flagged"
 assert_not_contains "$out_zero" "Partially migrated" \
   "M3: fully-migrated store gets no partial-migration warning"
 cd "$REPO"

--- a/tests/test-sync-retirement.sh
+++ b/tests/test-sync-retirement.sh
@@ -1863,4 +1863,165 @@ assert_eq "absent" "$([ -e "$VICTIM41" ] && echo created || echo absent)" \
 assert_contains "$RUN_OUTPUT" "sync-keep.candidate already exists" \
   "the refusal names the path it will not write"
 
+# ==================================== 23. security review regressions (round 3)
+#
+# Every case below was found by a dispatched security review of the finished
+# tool and reproduced before being fixed. They share a theme the earlier rounds
+# missed: the deletion set and the *record* of the deletion are both attacker-
+# influenceable surfaces, and neither had been tested as one.
+
+printf '\n-- 23. security regressions --\n'
+
+# --- 23.1 a symlinked directory component must not send os.remove outside ---
+#
+# `project_paths` reads the index and confirms the leaf with `os.path.isfile`,
+# which follows every component. A symlinked *directory* inside a syncable root
+# therefore aimed the delete anywhere on the filesystem — at files that were
+# never in this repository, so `git restore` could not bring them back. It needs
+# no hostile template: a developer sharing a skill tree across worktrees is enough.
+
+P42="$FIXTURE_ROOT/p42"; T42="$FIXTURE_ROOT/t42"
+OUTSIDE42="$FIXTURE_ROOT/outside42/nested"
+make_project "$P42"; make_template "$T42"
+mkdir -p "$P42/.agents/skills/sub"
+_f "$P42/.agents/skills/sub/victim.sh" "tracked here first"
+commit_all "$P42"
+# Now the tracked path resolves through a symlink to somewhere else entirely.
+mkdir -p "$OUTSIDE42"
+_f "$OUTSIDE42/victim.sh" "precious file, never in the repository"
+rm -rf "$P42/.agents/skills/sub"
+ln -s "$OUTSIDE42" "$P42/.agents/skills/sub"
+write_keep "$P42" ".agents/skills/nothing-at-all/**"
+
+run_retire --repo "$P42" --from-dir "$T42" --apply
+assert_eq "present" "$([ -f "$OUTSIDE42/victim.sh" ] && echo present || echo gone)" \
+  "a file outside the repository is never deleted through a symlinked directory"
+assert_eq "1" "$RUN_STATUS" "and the refusal is a non-zero outcome"
+assert_contains "$RUN_OUTPUT" "resolves outside the repository" \
+  "the report says why it refused, naming the mechanism"
+assert_not_contains "$RUN_OUTPUT" "deleted: .agents/skills/sub/victim.sh" \
+  "and never claims to have deleted it"
+
+# --- 23.2 a filename cannot forge a line in the record ----------------------
+#
+# The report is the only record of what a file-deleting tool destroyed, and
+# SKILL.md tells the operator to read it in full and never abbreviate it. A path
+# containing a newline emitted lines indistinguishable from real ones: the run
+# below claimed to have *kept* a file it was deleting.
+
+P43="$FIXTURE_ROOT/p43"; T43="$FIXTURE_ROOT/t43"
+make_project "$P43"; make_template "$T43"
+FORGED43=$'.claude/hooks/a.md\n  kept:   audit.sh (matched keepall)'
+_f "$P43/$FORGED43" "the payload is in the name, not the content"
+_f "$P43/.claude/hooks/audit.sh" "a real file the forged line lies about"
+commit_all "$P43"
+write_keep "$P43" ".claude/hooks/nothing-at-all/**"
+
+run_retire --repo "$P43" --from-dir "$T43"
+# The payload text still appears — inside the escaped path, on the retire line,
+# which is the point. What must not exist is a *line* that reads as a kept entry.
+assert_eq "0" "$(printf '%s\n' "$RUN_OUTPUT" | grep -c '^  kept:' || true)" \
+  "a newline in a filename cannot inject a kept: line into the record"
+assert_contains "$RUN_OUTPUT" "\\n  kept:" \
+  "the newline is escaped into the path field rather than ending the line"
+assert_eq "0" \
+  "$(printf '%s\n' "$RUN_OUTPUT" | tail -n +2 | grep -cv '^  ' || true)" \
+  "every report line still starts as a report line"
+assert_contains "$RUN_OUTPUT" "retire: .claude/hooks/audit.sh" \
+  "and the file the forgery lied about is correctly listed for retirement"
+
+# --- 23.3 the template's git config must not steer the deletion set --------
+#
+# `git log --raw` C-quotes non-ASCII paths, and `core.quotePath` decides whether
+# it does — read from the repository being inspected, which in --from-dir mode
+# is the untrusted template checkout. One line in someone else's .git/config
+# moved a file between "held for a human" and "deleted".
+
+P44="$FIXTURE_ROOT/p44"; T44="$FIXTURE_ROOT/t44"
+make_project "$P44"
+git init -q --initial-branch=main "$T44"
+git -C "$T44" config user.name fixture
+git -C "$T44" config user.email fixture@example.test
+make_template "$T44"
+_f "$T44/.claude/hooks/café.sh" "shipped once, retired later"
+commit_all "$T44"
+git -C "$T44" rm -q ".claude/hooks/café.sh"
+commit_all "$T44"
+_f "$P44/.claude/hooks/café.sh" "shipped once, retired later"
+commit_all "$P44"
+rm -f "$P44/.claude/sync-keep"
+
+git -C "$T44" config core.quotePath true
+run_retire --repo "$P44" --from-dir "$T44"
+QUOTED44="$(printf '%s\n' "$RUN_OUTPUT" | grep -c 'retire:' || true)"
+git -C "$T44" config core.quotePath false
+run_retire --repo "$P44" --from-dir "$T44"
+UNQUOTED44="$(printf '%s\n' "$RUN_OUTPUT" | grep -c 'retire:' || true)"
+assert_eq "$QUOTED44" "$UNQUOTED44" \
+  "the template's core.quotePath does not change what gets retired"
+assert_eq "1" "$QUOTED44" \
+  "and the non-ASCII path is retired in both, rather than neither (non-vacuity)"
+
+# --- 23.4 a commit message is not a commit header --------------------------
+#
+# `cat-file commit` emits headers, a blank line, then free text. Grepping the
+# whole object for `^parent ` read a *message* line as a shallow graft, so one
+# upstream commit message could report `provenance: unavailable` — and so retire
+# nothing — for every downstream project, forever.
+
+P45="$FIXTURE_ROOT/p45"; T45="$FIXTURE_ROOT/t45"
+make_project "$P45"
+git init -q --initial-branch=main "$T45"
+git -C "$T45" config user.name fixture
+git -C "$T45" config user.email fixture@example.test
+make_template "$T45"
+_f "$T45/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+git -C "$T45" add -A
+git -C "$T45" commit -q -m "$(printf 'init\n\nparent 0000000000000000000000000000000000000000 was dropped\n')"
+git -C "$T45" rm -q -r .agents/skills/legacy
+commit_all "$T45"
+_f "$P45/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+commit_all "$P45"
+rm -f "$P45/.claude/sync-keep"
+
+run_retire --repo "$P45" --from-dir "$T45"
+assert_not_contains "$RUN_OUTPUT" "provenance: unavailable" \
+  "a root commit whose message contains a 'parent ' line is not a graft"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/legacy/SKILL.md" \
+  "so provenance still resolves and the retired path is still retired"
+
+# --- 23.5 option interpretation is refused at the sink, not only in main ----
+#
+# `main` rejects a --from-ref beginning with `-`, but the tests already import
+# this module and call in directly, so that guard is one refactor from being
+# bypassed. Without --end-of-options, `git show "--output=...:path"` is read as
+# an option and git attempts the write.
+
+# `git show --output=FILE` writes to FILE. The ref is interpolated as
+# f"{ref}:{SKILL_DOC}", so the real target is `<ref-payload>:.agents/skills/
+# sync/SKILL.md` -- create those directories, or git fails for the wrong reason
+# and the test passes against the unfixed code.
+INJECT45="$FIXTURE_ROOT/inj"
+mkdir -p "$INJECT45:.agents/skills/sync"
+rm -f "$INJECT45:.agents/skills/sync/SKILL.md"
+
+INJECT_OUT="$(python3 - "$RETIRE" "$P45" "$INJECT45" <<'PYX' 2>&1 || true
+import importlib.util, sys
+script, repo, victim = sys.argv[1], sys.argv[2], sys.argv[3]
+spec = importlib.util.spec_from_file_location("sr", script)
+module = importlib.util.module_from_spec(spec)
+sys.modules["sr"] = module
+spec.loader.exec_module(module)
+try:
+    module.read_template_doc(repo, f"--output={victim}", None)
+except Exception as exc:
+    print(type(exc).__name__)
+PYX
+)"
+assert_eq "absent" \
+  "$([ -e "$INJECT45:.agents/skills/sync/SKILL.md" ] && echo created || echo absent)" \
+  "a ref that looks like an option never becomes one at the git show sink"
+assert_contains "$INJECT_OUT" "RetireError" \
+  "it is refused as a bad revision, through the module's own error type"
+
 finish

--- a/tests/test-sync-retirement.sh
+++ b/tests/test-sync-retirement.sh
@@ -1,0 +1,1866 @@
+#!/bin/bash
+# tests/test-sync-retirement.sh — behavioural contract for deterministic
+# retirement in /sync (specs/sync-deterministic-retirement.md).
+#
+# WHY THIS EXISTS
+#
+# `/sync` copies files in and never deletes. A path present in a project but
+# absent from the template is either retired upstream or project-specific, and
+# nothing recorded which — so the answer was re-derived by a model on every run
+# and two runs against one template commit could produce different trees.
+#
+# The mechanism under test replaces that judgement with set arithmetic:
+#
+#   retire = project paths under syncable roots
+#          - template paths under the same roots
+#          - paths matching a .claude/sync-keep pattern
+#
+# Every assertion below exists to pin one half of that sentence: that the inputs
+# are read the same way twice, and that nothing outside the difference is ever
+# deleted.
+. "$(dirname "$0")/lib.sh"
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+RETIRE="$REPO/.agents/skills/sync/scripts/sync-retire.py"
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+# ---------------------------------------------------------------- fixtures
+
+# The doc block the script parses for its root list. Kept in the same shape as
+# the real § Syncable Paths fence (`path   → description`) so a fixture cannot
+# pass against a parser that the real block would defeat. $1, when given, is an
+# extra root line appended inside the fence.
+write_skill_md() {
+  _dir="$1" _extra="${2:-}"
+  mkdir -p "$_dir/.agents/skills/sync"
+  {
+    printf '## Syncable Paths\n\n```\n'
+    printf 'CLAUDE.md             → Shared rules\n'
+    printf '.agents/skills/       → Canonical skills\n'
+    printf '.agents/agents/       → Canonical personas\n'
+    printf '.claude/skills/       → Compat copy\n'
+    printf '.claude/hooks/        → Lifecycle hooks\n'
+    printf '.claude/settings.json → Hook configuration\n'
+    [ -n "$_extra" ] && printf '%s\n' "$_extra"
+    printf '```\n\n## Next Section\n'
+  } > "$_dir/.agents/skills/sync/SKILL.md"
+}
+
+# A template checkout: the doc block plus one file under every directory root,
+# so no root is "absent from the template" unless a test says so.
+make_template() {
+  _dir="$1" _extra="${2:-}"
+  mkdir -p "$_dir"
+  write_skill_md "$_dir" "$_extra"
+  _f "$_dir/.agents/skills/build/SKILL.md"   "build skill"
+  _f "$_dir/.agents/agents/planner.md"       "planner"
+  _f "$_dir/.claude/skills/build/SKILL.md"   "build skill"
+  _f "$_dir/.claude/hooks/session-start.sh"  "hook"
+  _f "$_dir/CLAUDE.md"                       "rules"
+  _f "$_dir/.claude/settings.json"           "{}"
+}
+
+_f() { mkdir -p "$(dirname "$1")"; printf '%s\n' "$2" > "$1"; }
+
+# A project: a git repo, because the project inventory is the set of *tracked*
+# files. Untracked build residue was never synced in, so it is never retired.
+make_project() {
+  _dir="$1"
+  mkdir -p "$_dir"
+  git init -q --initial-branch=main "$_dir"
+  git -C "$_dir" config user.name fixture
+  git -C "$_dir" config user.email fixture@example.test
+  write_skill_md "$_dir"
+  _f "$_dir/.agents/skills/build/SKILL.md"   "build skill"
+  _f "$_dir/.agents/agents/planner.md"       "planner"
+  _f "$_dir/.claude/skills/build/SKILL.md"   "build skill"
+  _f "$_dir/.claude/hooks/session-start.sh"  "hook"
+  _f "$_dir/CLAUDE.md"                       "rules"
+  _f "$_dir/.claude/settings.json"           "{}"
+  commit_all "$_dir"
+}
+
+commit_all() {
+  git -C "$1" add -A
+  git -C "$1" commit -qm "state" 2>/dev/null || true
+}
+
+# Run the script; capture stdout+stderr and status into RUN_OUTPUT/RUN_STATUS.
+run_retire() {
+  python3 "$RETIRE" "$@" >"$FIXTURE_ROOT/out" 2>"$FIXTURE_ROOT/err"
+  RUN_STATUS=$?
+  RUN_OUTPUT="$(cat "$FIXTURE_ROOT/out"; cat "$FIXTURE_ROOT/err")"
+}
+
+# Write a .claude/sync-keep from the remaining arguments, one pattern per line.
+write_keep() {
+  _dir="$1"; shift
+  mkdir -p "$_dir/.claude"
+  : > "$_dir/.claude/sync-keep"
+  for _line in "$@"; do printf '%s\n' "$_line" >> "$_dir/.claude/sync-keep"; done
+}
+
+# ============================================================== 1. patterns
+#
+# A sync-keep pattern is the only thing standing between a project-specific
+# file and deletion. Every rejection below is a pattern that would otherwise
+# fail *silently* — recorded intent that protects nothing — so the run must
+# stop rather than proceed with an allowlist that does less than it appears to.
+
+printf '\n-- 1. sync-keep pattern parsing and validation --\n'
+
+P1="$FIXTURE_ROOT/p1"; T1="$FIXTURE_ROOT/t1"
+make_project "$P1"; make_template "$T1"
+# A project-only path exists, so a run that ignored its allowlist would delete
+# something — every invalid-pattern case below has real stakes.
+_f "$P1/.agents/skills/local-only/SKILL.md" "project specific"
+commit_all "$P1"
+
+# Blank lines and comments are ignored, not treated as patterns.
+write_keep "$P1" "# a comment" "" "   " ".agents/skills/local-only/**"
+run_retire --repo "$P1" --from-dir "$T1"
+assert_eq "0" "$RUN_STATUS" "comments and blank lines in sync-keep are ignored"
+assert_contains "$RUN_OUTPUT" "kept:" "the surviving path is reported as kept"
+
+# Each invalid pattern: non-zero, names the offending pattern AND its line, and
+# deletes nothing. The line number matters — an allowlist is edited by hand and
+# "some pattern is bad" is not an actionable message.
+assert_invalid_pattern() {
+  _pattern="$1" _label="$2"
+  write_keep "$P1" "# leading comment" "$_pattern"
+  run_retire --repo "$P1" --from-dir "$T1" --apply
+  assert_eq "1" "$RUN_STATUS" "invalid pattern ($_label): exits non-zero"
+  assert_contains "$RUN_OUTPUT" "$_pattern" "invalid pattern ($_label): names the pattern"
+  assert_contains "$RUN_OUTPUT" "line 2" "invalid pattern ($_label): names the line"
+  assert_eq "present" \
+    "$([ -f "$P1/.agents/skills/local-only/SKILL.md" ] && echo present || echo gone)" \
+    "invalid pattern ($_label): --apply deleted nothing"
+}
+
+assert_invalid_pattern "/etc/passwd"                      "absolute"
+assert_invalid_pattern ".agents/skills/../../etc"         "parent traversal"
+assert_invalid_pattern '.agents\skills\x'                 "backslash separators"
+assert_invalid_pattern '.agents/skills/[ab]/SKILL.md'     "unsupported [] glob"
+assert_invalid_pattern '.agents/skills/{a,b}/SKILL.md'    "unsupported {} brace expansion"
+assert_invalid_pattern '.agents/skills/!a/SKILL.md'       "unsupported ! negation"
+assert_invalid_pattern 'C:/agents/skills/x.md'            "windows drive letter is absolute"
+assert_invalid_pattern 'tasks/**'                         "outside every syncable root"
+
+# An empty pattern cannot be written as a bare line (it would be a blank line,
+# which is ignored), so it arrives as whitespace that survives a comment strip.
+write_keep "$P1" '"'
+run_retire --repo "$P1" --from-dir "$T1" --apply
+assert_eq "1" "$RUN_STATUS" "a pattern matching no syncable root is rejected"
+
+# ========================================================== 2. syncable roots
+#
+# The root list is parsed from the § Syncable Paths doc block rather than
+# copied into this script, so the block stays the single source
+# tests/test-syncable-paths.sh already pins. The block is read from the
+# *template*, never the project: the template is the authority on what the
+# roots contain, and reading the project's stale copy is the non-determinism
+# this feature exists to remove.
+
+printf '\n-- 2. syncable roots come from the doc block --\n'
+
+P2="$FIXTURE_ROOT/p2"; T2="$FIXTURE_ROOT/t2"; T2X="$FIXTURE_ROOT/t2x"
+make_project "$P2"
+_f "$P2/.claude/browsers/local.md" "project-only browser runbook"
+commit_all "$P2"
+write_keep "$P2"   # empty: recorded "nothing here is project-specific"
+
+# Template A does not declare .claude/browsers/ as a root.
+make_template "$T2"
+# Template B declares it, and carries a file under it.
+make_template "$T2X" ".claude/browsers/     → Browser runbooks"
+_f "$T2X/.claude/browsers/chrome.md" "chrome runbook"
+
+run_retire --repo "$P2" --from-dir "$T2"
+assert_eq "0" "$RUN_STATUS" "undeclared root: run succeeds"
+assert_not_contains "$RUN_OUTPUT" ".claude/browsers/local.md" \
+  "a path under a root the doc block does not declare is never scanned"
+
+run_retire --repo "$P2" --from-dir "$T2X"
+assert_eq "0" "$RUN_STATUS" "declared root: run succeeds"
+assert_contains "$RUN_OUTPUT" "retire: .claude/browsers/local.md" \
+  "adding a root to the doc block puts its project-only paths in scope"
+
+# Root counts track the block, so the header cannot silently disagree with it.
+run_retire --repo "$P2" --from-dir "$T2"
+assert_contains "$RUN_OUTPUT" "roots: 4" "header reports the 4 directory roots in the block"
+run_retire --repo "$P2" --from-dir "$T2X"
+assert_contains "$RUN_OUTPUT" "roots: 5" "header reports 5 once a root is added"
+
+# File roots are excluded. Retirement is undefined for a file — it has no
+# project-only paths inside it — and CLAUDE.md is already handled by the
+# checkout step. A template missing CLAUDE.md must not retire the project's.
+P2F="$FIXTURE_ROOT/p2f"; T2F="$FIXTURE_ROOT/t2f"
+make_project "$P2F"; write_keep "$P2F"
+make_template "$T2F"; rm -f "$T2F/CLAUDE.md" "$T2F/.claude/settings.json"
+run_retire --repo "$P2F" --from-dir "$T2F" --apply
+assert_eq "0" "$RUN_STATUS" "file roots absent from the template are not an error"
+assert_not_contains "$RUN_OUTPUT" "retire: CLAUDE.md" "CLAUDE.md is excluded from retirement"
+assert_eq "present" "$([ -f "$P2F/CLAUDE.md" ] && echo present || echo gone)" \
+  "--apply leaves the CLAUDE.md file root on disk"
+assert_eq "present" "$([ -f "$P2F/.claude/settings.json" ] && echo present || echo gone)" \
+  "--apply leaves the .claude/settings.json file root on disk"
+
+# A root absent from the PROJECT is empty, not an error: a project that never
+# received .claude/skills/ has nothing to retire there.
+P2E="$FIXTURE_ROOT/p2e"; T2E="$FIXTURE_ROOT/t2e"
+make_project "$P2E"; write_keep "$P2E"
+git -C "$P2E" rm -rq .claude/skills; commit_all "$P2E"
+make_template "$T2E"
+run_retire --repo "$P2E" --from-dir "$T2E"
+assert_eq "0" "$RUN_STATUS" "a syncable root absent from the project is treated as empty"
+
+# A root absent from the TEMPLATE is not scanned. Retiring from it would compute
+# "everything the project has" minus "nothing" and delete the project's whole
+# copy — the one mistake this script must never make quietly.
+#
+# Scoped to the root rather than aborting the run: two roots in the real template
+# hold a single file each, so one upstream commit removing that file used to exit
+# 1 for every downstream project and retire nothing at all. An ordinary upstream
+# deletion must not disable retirement everywhere.
+P2M="$FIXTURE_ROOT/p2m"; T2M="$FIXTURE_ROOT/t2m"
+make_project "$P2M"; write_keep "$P2M"
+_f "$P2M/.agents/skills/gone/SKILL.md" "retired upstream, under a root that IS vouched for"
+commit_all "$P2M"
+make_template "$T2M"; rm -rf "$T2M/.claude/hooks"
+run_retire --repo "$P2M" --from-dir "$T2M" --apply
+assert_eq "0" "$RUN_STATUS" "one empty template root does not abort the run"
+assert_contains "$RUN_OUTPUT" "skipped: .claude/hooks/" "the unvouched root is named"
+assert_eq "present" "$([ -f "$P2M/.claude/hooks/session-start.sh" ] && echo present || echo gone)" \
+  "and nothing under it is deleted"
+# The point of scoping: unrelated roots still work.
+assert_eq "gone" "$([ -e "$P2M/.agents/skills/gone/SKILL.md" ] && echo present || echo gone)" \
+  "while a root the template does vouch for still retires normally"
+
+# SEVERAL empty roots is a different claim: a truncated checkout, not an upstream
+# edit. It stays a hard stop, and that threshold is what preserves the
+# catastrophe guard -- the doc block lives under .agents/skills/, so that root is
+# non-empty in any readable template and an all-empty test could never fire.
+# Without the threshold, a clone carrying only the sync skill would skip every
+# other root and retire the project's entire copy of each.
+P2Z="$FIXTURE_ROOT/p2z"; T2Z="$FIXTURE_ROOT/t2z"
+make_project "$P2Z"; write_keep "$P2Z"
+_f "$P2Z/.agents/skills/victim/SKILL.md" "would be retired if a partial source were trusted"
+commit_all "$P2Z"
+make_template "$T2Z"
+# A truncated checkout: only the sync skill survived.
+rm -rf "$T2Z/.agents/agents" "$T2Z/.claude/skills" "$T2Z/.claude/hooks"
+rm -rf "$T2Z/.agents/skills/build"
+run_retire --repo "$P2Z" --from-dir "$T2Z" --apply
+assert_eq "1" "$RUN_STATUS" "a source missing several roots exits non-zero"
+assert_contains "$RUN_OUTPUT" "refusing a source this incomplete" \
+  "and says the source is too incomplete to retire against"
+assert_eq "present" "$([ -f "$P2Z/.agents/skills/victim/SKILL.md" ] && echo present || echo gone)" \
+  "deleting nothing -- including under the root the doc block itself lives in"
+
+# ======================================================== 3. template sources
+#
+# Two ways to name the same template: a git ref (the git-remote mode) and a
+# checkout on disk (the manual-diff mode). They must agree, or "deterministic"
+# holds only for whichever mode the operator happened to pick — and the two
+# modes are chosen by connection method, not by intent.
+
+printf '\n-- 3. --from-ref and --from-dir agree --\n'
+
+P3="$FIXTURE_ROOT/p3"; T3="$FIXTURE_ROOT/t3"
+make_project "$P3"
+_f "$P3/.agents/skills/local-only/SKILL.md" "project specific"
+_f "$P3/.claude/hooks/local-hook.sh"        "project specific"
+_f "$P3/.agents/agents/local-agent.md"      "project specific"
+commit_all "$P3"
+
+# The same template content, reachable both ways: built once on disk, then
+# committed to an orphan ref in the project repo (which is how /sync sees it —
+# workflow/$BRANCH is a remote-tracking ref inside the project's own clone).
+make_template "$T3"
+git -C "$P3" checkout -q --orphan template
+git -C "$P3" rm -rq --cached . >/dev/null 2>&1
+find "$P3" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+cp -r "$T3/." "$P3/"
+git -C "$P3" add -A
+git -C "$P3" commit -qm template
+git -C "$P3" checkout -q main
+
+# Written after the branch dance: sync-keep is untracked by design (it is the
+# project's own record, never synced), so a checkout would not restore it.
+write_keep "$P3" ".agents/agents/local-agent.md"
+
+retire_lines() { printf '%s\n' "$RUN_OUTPUT" | grep '^  retire:' | sort; }
+
+run_retire --repo "$P3" --from-ref template
+assert_eq "0" "$RUN_STATUS" "--from-ref succeeds"
+FROM_REF="$(retire_lines)"
+
+run_retire --repo "$P3" --from-dir "$T3"
+assert_eq "0" "$RUN_STATUS" "--from-dir succeeds"
+FROM_DIR="$(retire_lines)"
+
+assert_contains "$FROM_REF" ".agents/skills/local-only/SKILL.md" \
+  "--from-ref found the project-only paths (guards against a vacuous '' = '' pass)"
+assert_eq "$FROM_REF" "$FROM_DIR" \
+  "--from-ref and --from-dir yield the identical retirement set"
+
+# The allowlist is read once, from the project, so it applies to both modes.
+run_retire --repo "$P3" --from-ref template
+assert_contains "$RUN_OUTPUT" "kept:   .agents/agents/local-agent.md" \
+  "--from-ref honours the project's sync-keep"
+
+# Usage errors are exit 2, distinct from the exit 1 of a real failure: one means
+# the operator typed the command wrong, the other means the run found a problem.
+run_retire --repo "$P3"
+assert_eq "2" "$RUN_STATUS" "neither --from-ref nor --from-dir is a usage error"
+run_retire --repo "$P3" --from-ref template --from-dir "$T3"
+assert_eq "2" "$RUN_STATUS" "supplying both sources is a usage error"
+run_retire --repo "$FIXTURE_ROOT/does-not-exist" --from-dir "$T3"
+assert_eq "2" "$RUN_STATUS" "a --repo that is not a directory is a usage error"
+# --from-ref reaches `git ls-tree <ref>` and `git show <ref>:<path>`, so a value
+# that looks like an option is argument injection, not a bad ref.
+run_retire --repo "$P3" --from-ref "--upload-pack=touch $FIXTURE_ROOT/OWNED"
+assert_eq "2" "$RUN_STATUS" "a --from-ref beginning with - is a usage error"
+assert_eq "absent" "$([ -e "$FIXTURE_ROOT/OWNED" ] && echo present || echo absent)" \
+  "and it never reached git"
+# An option supplied but empty means the caller's variable was unset. Treating it
+# as absent is what let an empty --from-dir read roots from the project tree.
+run_retire --repo "$P3" --from-ref template --from-dir ""
+assert_eq "2" "$RUN_STATUS" "an empty --from-dir is a usage error, not an absent one"
+run_retire --repo "$P3" --from-dir "   "
+assert_eq "2" "$RUN_STATUS" "a whitespace-only source is likewise refused"
+
+# An unreadable ref is a failure, not a usage error, and retires nothing.
+run_retire --repo "$P3" --from-ref no-such-ref --apply
+assert_eq "1" "$RUN_STATUS" "an unreadable ref exits 1"
+assert_eq "present" "$([ -f "$P3/.agents/skills/local-only/SKILL.md" ] && echo present || echo gone)" \
+  "an unreadable ref deletes nothing"
+
+# ====================================================== 4. the retirement set
+#
+# retire = project - template - allowlist, and nothing else. The two most
+# expensive ways to get this wrong are retiring a path the template still
+# ships (data loss on every sync) and truncating the report (the operator
+# approves a list that is not the list).
+
+printf '\n-- 4. set arithmetic and the full report --\n'
+
+P4="$FIXTURE_ROOT/p4"; T4="$FIXTURE_ROOT/t4"
+make_project "$P4"; make_template "$T4"
+
+# A path present in BOTH, with different content. Modification is the checkout
+# step's job; retirement must not touch it.
+_f "$P4/.agents/skills/build/SKILL.md" "project's older build skill"
+
+# Enough project-only paths to exceed any plausible progressive-disclosure cap.
+# The list IS the record of what is about to be destroyed, so it is never
+# abbreviated — a cap here would hide exactly what the report exists to show.
+i=1
+while [ "$i" -le 25 ]; do
+  _f "$P4/.agents/skills/retired-$i/SKILL.md" "retired upstream"
+  i=$((i + 1))
+done
+commit_all "$P4"
+write_keep "$P4"
+
+run_retire --repo "$P4" --from-dir "$T4"
+assert_eq "0" "$RUN_STATUS" "default run succeeds"
+
+RETIRE_COUNT="$(printf '%s\n' "$RUN_OUTPUT" | grep -c '^  retire:')"
+assert_eq "25" "$RETIRE_COUNT" "every project-only path is listed — no truncation"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/retired-1/SKILL.md" "first path listed"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/retired-25/SKILL.md" "last path listed"
+assert_not_contains "$RUN_OUTPUT" "retire: .agents/skills/build/SKILL.md" \
+  "a path the template still ships is never retired, even when it differs"
+assert_not_contains "$RUN_OUTPUT" "..." "the report carries no truncation marker"
+
+# The default run is a dry run. Reporting and destroying are separate acts, and
+# the operator sees the list before either.
+assert_contains "$RUN_OUTPUT" "mode:   dry-run (no changes written)" "default run reports itself as a dry run"
+SURVIVORS="$(find "$P4/.agents/skills" -name 'SKILL.md' | wc -l | tr -d ' ')"
+assert_eq "27" "$SURVIVORS" "the default run deleted nothing (25 retired + build + sync)"
+
+# The header names the source, so a report pasted into a review says which
+# template revision produced it.
+assert_contains "$RUN_OUTPUT" "sync retirement — source: $T4" "the header names the template source"
+
+# ================================================================= 5. --apply
+#
+# The only step that destroys anything. It must delete the retirement set
+# exactly — no more (a deleted project file is unrecoverable from the template)
+# and no less (a survivor is the stale copy this feature exists to remove).
+
+printf '\n-- 5. --apply deletes exactly the retirement set --\n'
+
+P5="$FIXTURE_ROOT/p5"; T5="$FIXTURE_ROOT/t5"
+make_project "$P5"; make_template "$T5"
+_f "$P5/.agents/skills/retired/SKILL.md"           "retired upstream"
+_f "$P5/.agents/skills/retired/scripts/helper.sh"  "retired upstream"
+_f "$P5/.claude/hooks/retired-hook.sh"             "retired upstream"
+_f "$P5/.agents/skills/keepme/SKILL.md"            "project specific"
+commit_all "$P5"
+write_keep "$P5" ".agents/skills/keepme/**"
+
+run_retire --repo "$P5" --from-dir "$T5" --apply
+assert_eq "0" "$RUN_STATUS" "--apply succeeds"
+
+# The same full list is printed before deleting, so the record of what was
+# destroyed survives in the transcript.
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/retired/SKILL.md" "--apply prints the list it deletes"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/retired/scripts/helper.sh" "--apply lists nested paths"
+assert_contains "$RUN_OUTPUT" "retire: .claude/hooks/retired-hook.sh" "--apply lists every root's paths"
+assert_contains "$RUN_OUTPUT" "mode:   applied" "--apply reports itself as applied, not dry-run"
+
+assert_eq "gone" "$([ -e "$P5/.agents/skills/retired/SKILL.md" ] && echo present || echo gone)" \
+  "--apply deleted the retired skill file"
+assert_eq "gone" "$([ -e "$P5/.claude/hooks/retired-hook.sh" ] && echo present || echo gone)" \
+  "--apply deleted the retired hook"
+
+# Directories emptied by the deletions are pruned, so a sync does not leave a
+# tree full of empty husks that later reads as "the skill is still installed".
+assert_eq "gone" "$([ -d "$P5/.agents/skills/retired" ] && echo present || echo gone)" \
+  "--apply pruned the directory its deletions emptied"
+assert_eq "gone" "$([ -d "$P5/.agents/skills/retired/scripts" ] && echo present || echo gone)" \
+  "--apply pruned nested emptied directories"
+
+# The syncable root itself survives even when everything under it went, because
+# an absent root and an empty one are different states to every other reader.
+assert_eq "present" "$([ -d "$P5/.agents/skills" ] && echo present || echo gone)" \
+  "--apply keeps the syncable root directory itself"
+
+# Nothing outside the retirement set is touched.
+assert_eq "present" "$([ -f "$P5/.agents/skills/keepme/SKILL.md" ] && echo present || echo gone)" \
+  "--apply left the allowlisted path alone"
+assert_eq "present" "$([ -f "$P5/.agents/skills/build/SKILL.md" ] && echo present || echo gone)" \
+  "--apply left a path the template still ships alone"
+assert_eq "present" "$([ -f "$P5/CLAUDE.md" ] && echo present || echo gone)" \
+  "--apply left the file roots alone"
+assert_eq "present" "$([ -f "$P5/.claude/sync-keep" ] && echo present || echo gone)" \
+  "--apply left the allowlist itself alone"
+
+# Untracked files under a root were never synced in, so they are not this
+# program's to delete — the project inventory is the tracked set.
+_f "$P5/.claude/hooks/scratch.sh" "untracked local scratch"
+run_retire --repo "$P5" --from-dir "$T5" --apply
+assert_eq "present" "$([ -f "$P5/.claude/hooks/scratch.sh" ] && echo present || echo gone)" \
+  "--apply never deletes an untracked file"
+assert_not_contains "$RUN_OUTPUT" "scratch.sh" "an untracked file is not even reported"
+
+# A second --apply before the deletions are staged must not re-list them. The
+# project inventory reads the git *index*, which still names a file this script
+# deleted a moment ago; an unfiltered read would compute it as project-only
+# again and fail on the missing file, turning a no-op re-run into a crash.
+run_retire --repo "$P5" --from-dir "$T5" --apply
+assert_eq "0" "$RUN_STATUS" "a second --apply with the deletions unstaged succeeds"
+assert_not_contains "$RUN_OUTPUT" "retire: .agents/skills/retired/SKILL.md" \
+  "an already-deleted path is not re-listed from the index"
+assert_not_contains "$RUN_OUTPUT" "deletion failed" "the re-run does not fail on a missing file"
+
+# =============================================================== 6. allowlist
+#
+# A surviving path must be traceable to the line that saved it. "Kept" without
+# the pattern tells an operator that something was protected but not by what,
+# so a sync-keep entry that silently stopped matching looks identical to one
+# still doing its job.
+
+printf '\n-- 6. sync-keep matching and reporting --\n'
+
+P6="$FIXTURE_ROOT/p6"; T6="$FIXTURE_ROOT/t6"
+make_project "$P6"; make_template "$T6"
+_f "$P6/.agents/skills/mine/SKILL.md"            "project specific"
+_f "$P6/.agents/skills/mine/scripts/deep.sh"     "project specific, nested"
+_f "$P6/.claude/hooks/one.sh"                    "project specific"
+_f "$P6/.claude/hooks/two.sh"                    "project specific"
+_f "$P6/.agents/agents/unprotected.md"           "retired upstream"
+commit_all "$P6"
+
+# `**` crosses `/`; `*` does not. Borrowing fnmatch semantics, whose `*` spans
+# separators, would silently widen every entry written here.
+write_keep "$P6" ".agents/skills/mine/**" ".claude/hooks/*.sh"
+run_retire --repo "$P6" --from-dir "$T6"
+assert_eq "0" "$RUN_STATUS" "allowlisted run succeeds"
+assert_contains "$RUN_OUTPUT" "kept:   .agents/skills/mine/SKILL.md (matched .agents/skills/mine/**)" \
+  "a kept path names the pattern that matched it"
+assert_contains "$RUN_OUTPUT" "kept:   .agents/skills/mine/scripts/deep.sh (matched .agents/skills/mine/**)" \
+  "** matches across directory separators"
+assert_contains "$RUN_OUTPUT" "kept:   .claude/hooks/one.sh (matched .claude/hooks/*.sh)" \
+  "* matches within a single path segment"
+assert_contains "$RUN_OUTPUT" "retire: .agents/agents/unprotected.md" \
+  "a path no pattern matches is still retired"
+
+# `*` must not cross a separator: a pattern written for one directory level
+# must not silently protect everything beneath it.
+write_keep "$P6" ".agents/skills/*"
+run_retire --repo "$P6" --from-dir "$T6"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/mine/SKILL.md" \
+  "* does not cross a directory separator"
+
+# `?` is exactly one character, also non-crossing.
+write_keep "$P6" ".claude/hooks/???.sh"
+run_retire --repo "$P6" --from-dir "$T6"
+assert_contains "$RUN_OUTPUT" "kept:   .claude/hooks/one.sh (matched .claude/hooks/???.sh)" \
+  "? matches exactly one character"
+assert_contains "$RUN_OUTPUT" "kept:   .claude/hooks/two.sh (matched .claude/hooks/???.sh)" \
+  "? applies to every path of the right shape"
+# Non-crossing, the same property `*` is pinned for above: widening `?` to `.`
+# would silently widen every allowlist entry containing one.
+write_keep "$P6" ".agents/skills/mine?SKILL.md"
+run_retire --repo "$P6" --from-dir "$T6"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/mine/SKILL.md" \
+  "? does not cross a directory separator either"
+
+# An EMPTY sync-keep is a recorded, deliberate "nothing here is
+# project-specific". It permits deletion; only an ABSENT file withholds it.
+# Collapsing the two would make an unconfigured project look like one that had
+# opted in — the difference between silence and consent.
+P6E="$FIXTURE_ROOT/p6e"; T6E="$FIXTURE_ROOT/t6e"
+make_project "$P6E"; make_template "$T6E"
+_f "$P6E/.agents/skills/retired/SKILL.md" "retired upstream"
+commit_all "$P6E"
+write_keep "$P6E"
+run_retire --repo "$P6E" --from-dir "$T6E" --apply
+assert_eq "0" "$RUN_STATUS" "an empty sync-keep is a valid recorded intent"
+assert_not_contains "$RUN_OUTPUT" "bootstrap" "an empty sync-keep is not bootstrap"
+assert_eq "gone" "$([ -e "$P6E/.agents/skills/retired/SKILL.md" ] && echo present || echo gone)" \
+  "an empty sync-keep permits deletion"
+
+# =============================================================== 7. bootstrap
+#
+# Until a project records its intent, nothing is deleted. A project with no
+# sync-keep has never been asked which of its paths are project-specific, and
+# guessing on its behalf is precisely the run-time classification this feature
+# removes. So bootstrap retires nothing and hands a human a candidate list.
+#
+# The candidate is written to a .candidate file, never to sync-keep itself:
+# promoting it is the human's confirming act, and a script that wrote the real
+# file would be recording an intent nobody expressed.
+
+printf '\n-- 7. bootstrap when no sync-keep exists --\n'
+
+P7="$FIXTURE_ROOT/p7"; T7="$FIXTURE_ROOT/t7"
+make_project "$P7"; make_template "$T7"
+_f "$P7/.agents/skills/mine/SKILL.md"   "project specific"
+_f "$P7/.claude/hooks/retired-hook.sh"  "retired upstream"
+commit_all "$P7"
+# Deliberately NO write_keep: this is the unconfigured state.
+
+run_retire --repo "$P7" --from-dir "$T7"
+assert_eq "0" "$RUN_STATUS" "bootstrap is a normal outcome, not a failure"
+assert_contains "$RUN_OUTPUT" "bootstrap: required" "bootstrap is announced"
+assert_contains "$RUN_OUTPUT" ".claude/sync-keep" "the report names the file to create"
+assert_contains "$RUN_OUTPUT" "candidate: .agents/skills/mine/SKILL.md" "every project-only path is a candidate"
+assert_contains "$RUN_OUTPUT" "candidate: .claude/hooks/retired-hook.sh" "candidates span every root"
+assert_not_contains "$RUN_OUTPUT" "retire:" "bootstrap proposes no retirements"
+
+run_retire --repo "$P7" --from-dir "$T7" --apply
+assert_eq "0" "$RUN_STATUS" "bootstrap under --apply still succeeds"
+assert_eq "present" "$([ -f "$P7/.agents/skills/mine/SKILL.md" ] && echo present || echo gone)" \
+  "bootstrap --apply deletes nothing"
+assert_eq "present" "$([ -f "$P7/.claude/hooks/retired-hook.sh" ] && echo present || echo gone)" \
+  "bootstrap --apply deletes nothing, not even an upstream-retired path"
+
+# The candidate file is written; the real allowlist is not.
+assert_eq "present" "$([ -f "$P7/.claude/sync-keep.candidate" ] && echo present || echo gone)" \
+  "bootstrap --apply writes the candidate allowlist"
+assert_eq "gone" "$([ -f "$P7/.claude/sync-keep" ] && echo present || echo gone)" \
+  "bootstrap --apply never writes .claude/sync-keep itself"
+assert_file_contains "$P7/.claude/sync-keep.candidate" ".agents/skills/mine/SKILL.md" \
+  "the candidate lists the project-only paths"
+
+# The candidate is a working allowlist once promoted: reviewed, renamed, and
+# the next run keeps exactly what it names.
+cp "$P7/.claude/sync-keep.candidate" "$P7/.claude/sync-keep"
+run_retire --repo "$P7" --from-dir "$T7"
+assert_not_contains "$RUN_OUTPUT" "bootstrap" "promoting the candidate leaves bootstrap"
+assert_contains "$RUN_OUTPUT" "retire: (none)" \
+  "a promoted candidate keeps every path it named"
+
+# A dry run must not write the candidate either — a dry run writes nothing.
+P7D="$FIXTURE_ROOT/p7d"; T7D="$FIXTURE_ROOT/t7d"
+make_project "$P7D"; make_template "$T7D"
+_f "$P7D/.agents/skills/mine/SKILL.md" "project specific"; commit_all "$P7D"
+run_retire --repo "$P7D" --from-dir "$T7D"
+assert_eq "gone" "$([ -f "$P7D/.claude/sync-keep.candidate" ] && echo present || echo gone)" \
+  "a dry run writes no candidate file"
+
+# ============================================================= 8. idempotency
+#
+# The headline claim: running /sync twice against an unchanged template leaves
+# a byte-identical tree, and the second run reports nothing to do. This is the
+# property that was false before — two runs against one template commit could
+# produce different trees because a model re-derived the answer each time.
+
+printf '\n-- 8. two runs converge --\n'
+
+# Hash every file under the syncable roots, path and content, so a difference
+# in either shows up. .git is excluded: index and log churn are not tree state.
+tree_hash() {
+  find "$1" -name .git -prune -o -type f -print \
+    | sed "s|^$1/||" | LC_ALL=C sort \
+    | while IFS= read -r f; do printf '%s %s\n' "$f" "$(sha256sum "$1/$f" | cut -d' ' -f1)"; done \
+    | sha256sum | cut -d' ' -f1
+}
+
+P8="$FIXTURE_ROOT/p8"; T8="$FIXTURE_ROOT/t8"
+make_project "$P8"; make_template "$T8"
+_f "$P8/.agents/skills/retired-a/SKILL.md" "retired upstream"
+_f "$P8/.agents/skills/retired-b/SKILL.md" "retired upstream"
+_f "$P8/.claude/hooks/old.sh"              "retired upstream"
+_f "$P8/.agents/agents/mine.md"            "project specific"
+commit_all "$P8"
+write_keep "$P8" ".agents/agents/mine.md"
+
+run_retire --repo "$P8" --from-dir "$T8" --apply
+assert_eq "0" "$RUN_STATUS" "first --apply succeeds"
+FIRST_COUNT="$(printf '%s\n' "$RUN_OUTPUT" | grep -c '^  retire:')"
+assert_eq "3" "$FIRST_COUNT" "first run retires the three upstream-retired paths"
+HASH_AFTER_FIRST="$(tree_hash "$P8")"
+
+run_retire --repo "$P8" --from-dir "$T8" --apply
+assert_eq "0" "$RUN_STATUS" "second --apply succeeds"
+assert_contains "$RUN_OUTPUT" "retire: (none)" "the second run reports zero retirements"
+assert_eq "$HASH_AFTER_FIRST" "$(tree_hash "$P8")" \
+  "the second run leaves a byte-identical tree"
+
+# And once the deletions are committed, which is what a real /sync ends with.
+commit_all "$P8"
+HASH_COMMITTED="$(tree_hash "$P8")"
+run_retire --repo "$P8" --from-dir "$T8" --apply
+assert_contains "$RUN_OUTPUT" "retire: (none)" "a third run after committing still reports zero"
+assert_eq "$HASH_COMMITTED" "$(tree_hash "$P8")" "a third run leaves the tree untouched"
+
+# Non-vacuity: the hash must actually respond to a change, or every comparison
+# above is comparing two constants.
+_f "$P8/.agents/skills/retired-a/SKILL.md" "resurrected"
+assert_eq "changed" \
+  "$([ "$HASH_COMMITTED" = "$(tree_hash "$P8")" ] && echo same || echo changed)" \
+  "tree_hash detects a change (guards against a constant-hash pass)"
+
+# ====================================================== 9. branch independence
+#
+# Syncing the same project from two different branches must yield the same set
+# of harness paths. A branch carrying skills the project's main already dropped
+# retires them like any other project-only path: the template, not the project
+# branch, is the authority. Without this, "deterministic" would hold only per
+# branch, and the tree you got would depend on where you happened to be stood.
+
+printf '\n-- 9. two branches converge on one template --\n'
+
+P9="$FIXTURE_ROOT/p9"; T9="$FIXTURE_ROOT/t9"
+make_project "$P9"; make_template "$T9"
+_f "$P9/.agents/agents/shared-project-agent.md" "project specific, on both branches"
+commit_all "$P9"
+
+# main carries one stale skill; the feature branch carries a different one plus
+# a leftover hook. Neither set exists in the template.
+_f "$P9/.agents/skills/stale-on-main/SKILL.md" "retired upstream"
+commit_all "$P9"
+
+git -C "$P9" checkout -qb feature
+git -C "$P9" rm -rq .agents/skills/stale-on-main
+_f "$P9/.agents/skills/stale-on-feature/SKILL.md" "retired upstream"
+_f "$P9/.claude/hooks/stale-hook.sh"              "retired upstream"
+commit_all "$P9"
+
+harness_paths() {
+  find "$1/.agents/skills" "$1/.agents/agents" "$1/.claude/skills" "$1/.claude/hooks" \
+    -type f 2>/dev/null | sed "s|^$1/||" | LC_ALL=C sort
+}
+
+# The allowlist is the project's, not the branch's: written once, honoured from
+# either branch.
+write_keep "$P9" ".agents/agents/shared-project-agent.md"
+
+run_retire --repo "$P9" --from-dir "$T9" --apply
+assert_eq "0" "$RUN_STATUS" "sync from the feature branch succeeds"
+FEATURE_PATHS="$(harness_paths "$P9")"
+
+git -C "$P9" checkout -q main
+run_retire --repo "$P9" --from-dir "$T9" --apply
+assert_eq "0" "$RUN_STATUS" "sync from main succeeds"
+MAIN_PATHS="$(harness_paths "$P9")"
+
+assert_contains "$MAIN_PATHS" ".agents/agents/shared-project-agent.md" \
+  "the allowlisted project path survives on both branches (non-vacuity)"
+assert_eq "$FEATURE_PATHS" "$MAIN_PATHS" \
+  "both branches converge on the same set of harness paths"
+assert_not_contains "$MAIN_PATHS" "stale-on-main" \
+  "a skill the template dropped is retired even when only this branch had it"
+assert_not_contains "$FEATURE_PATHS" "stale-on-feature" \
+  "the same holds for the other branch's stale skill"
+
+# ========================================================== 10. documentation
+#
+# The mechanism is only reachable if /sync runs it. These assertions pin the
+# procedure to the script and pin the one property that makes the allowlist
+# safe: .claude/sync-keep is never synced, so a template update cannot
+# overwrite a project's record of its own intent.
+#
+# Asserted against BOTH trees. .claude/skills/ is the copy Claude Code actually
+# reads, so a canonical-only edit ships the feature to no one.
+
+printf '\n-- 10. SKILL.md documents the retirement pass --\n'
+
+for tree in .agents .claude; do
+  MD="$tree/skills/sync/SKILL.md"
+
+  assert_file_contains "$MD" "sync-keep" \
+    "$tree: SKILL.md documents .claude/sync-keep"
+  assert_file_contains "$MD" "scripts/sync-retire.py" \
+    "$tree: SKILL.md names the script that performs retirement"
+
+  # The never-sync list is where a reader checks whether /sync will clobber a
+  # file. sync-keep must be named there explicitly, even though it is already
+  # outside every root, because "outside the roots" is a property you have to
+  # derive and this list is where people look.
+  NEVER="$(awk '/^\*\*Never sync\*\*/ { inlist = 1; next }
+                inlist && /^## / { exit }
+                inlist { print }' "$MD")"
+  assert_contains "$NEVER" ".claude/sync-keep" \
+    "$tree: sync-keep appears in the Never sync list"
+
+  # The pass runs in dry-run during the change summary, so its output is
+  # visible before any write, and applies for options 1 and 2 only.
+  assert_prose_contains "$MD" "dry run" \
+    "$tree: the summary-time run is documented as a dry run"
+done
+
+# The retirement pass must be wired into the procedure, not merely described.
+assert_file_matches ".agents/skills/sync/SKILL.md" "^### Step 6\.4" \
+  "canonical: the retirement step exists in the procedure"
+
+# ================================================= 11. review-driven contracts
+#
+# Each block below pins a defect found in APOSD review of the first
+# implementation. They are grouped here, one block per finding, so a later
+# reader can see what the review bought.
+
+printf '\n-- 11. defects found in design review --\n'
+
+# F1 — the candidate allowlist is the one artifact a human edits by hand. It was
+# opened with "w", so a second bootstrap --apply silently destroyed a
+# half-finished review, and re-running /sync is routine.
+P11="$FIXTURE_ROOT/p11"; T11="$FIXTURE_ROOT/t11"
+make_project "$P11"; make_template "$T11"
+_f "$P11/.agents/skills/mine/SKILL.md" "project specific"; commit_all "$P11"
+
+run_retire --repo "$P11" --from-dir "$T11" --apply
+assert_eq "0" "$RUN_STATUS" "F1: first bootstrap --apply writes the candidate"
+printf '%s\n' "# reviewed by a human" ".agents/skills/mine/SKILL.md" > "$P11/.claude/sync-keep.candidate"
+run_retire --repo "$P11" --from-dir "$T11" --apply
+assert_eq "1" "$RUN_STATUS" "F1: a second bootstrap --apply refuses rather than overwriting"
+assert_contains "$RUN_OUTPUT" "sync-keep.candidate" "F1: the refusal names the file"
+assert_file_contains "$P11/.claude/sync-keep.candidate" "# reviewed by a human" \
+  "F1: the human's edits survive the second run"
+
+# F7 — the dry run is what SKILL.md Step 3 shows during the change summary, so
+# it is where an unconfigured project has to be told what to do. It named the
+# file and stopped, and carried no mode line at all.
+rm -f "$P11/.claude/sync-keep.candidate"
+run_retire --repo "$P11" --from-dir "$T11"
+assert_contains "$RUN_OUTPUT" "next:" "F7: the bootstrap dry run says what to do next"
+assert_contains "$RUN_OUTPUT" "--apply" "F7: the instruction names the flag that writes the candidate"
+assert_contains "$RUN_OUTPUT" "mode:   dry-run" "F7: bootstrap reports the same mode line as every other path"
+
+# F2 — the mode line was printed before any deletion ran, so a mid-loop failure
+# left stdout asserting N files were deleted when fewer were. For a tool whose
+# report is the record of what was destroyed, the record must follow the act.
+P11B="$FIXTURE_ROOT/p11b"; T11B="$FIXTURE_ROOT/t11b"
+make_project "$P11B"; make_template "$T11B"
+_f "$P11B/.agents/skills/gone-a/SKILL.md" "retired"; _f "$P11B/.agents/skills/gone-b/SKILL.md" "retired"
+commit_all "$P11B"; write_keep "$P11B"
+run_retire --repo "$P11B" --from-dir "$T11B" --apply
+assert_contains "$RUN_OUTPUT" "mode:   applied (2 deleted)" "F2: the count reports what was actually removed"
+# The list still precedes the act; only the outcome line follows it.
+assert_eq "0" "$(printf '%s\n' "$RUN_OUTPUT" | grep -n 'mode:' | cut -d: -f1 | \
+  { read -r m; printf '%s\n' "$RUN_OUTPUT" | grep -n 'retire:' | cut -d: -f1 | \
+    while read -r r; do [ "$r" -lt "$m" ] || echo late; done; } | grep -c late)" \
+  "F2: every retire line is printed before the outcome line"
+
+# F3 — validate_pattern tested a literal string prefix while match_path is a
+# glob matcher, so `.claude/**` was rejected with a message asserting it could
+# never protect anything, which is the opposite of true.
+P11C="$FIXTURE_ROOT/p11c"; T11C="$FIXTURE_ROOT/t11c"
+make_project "$P11C"; make_template "$T11C"
+_f "$P11C/.claude/hooks/mine.sh" "project specific"; commit_all "$P11C"
+write_keep "$P11C" ".claude/**"
+run_retire --repo "$P11C" --from-dir "$T11C"
+assert_eq "0" "$RUN_STATUS" "F3: a pattern whose glob reaches into a root is accepted"
+assert_contains "$RUN_OUTPUT" "kept:   .claude/hooks/mine.sh (matched .claude/**)" \
+  "F3: and it actually protects the path it reaches"
+# The check still rejects a pattern that reaches no root at all.
+write_keep "$P11C" "tasks/**"
+run_retire --repo "$P11C" --from-dir "$T11C"
+assert_eq "1" "$RUN_STATUS" "F3: a pattern reaching no root is still rejected"
+
+# F5 — the project inventory is the tracked set and --from-ref is the committed
+# tree, but --from-dir walked the filesystem, so gitignored residue counted as
+# template content. assert_roots_present could then be satisfied by a root that
+# the committed tree does not contain.
+P11D="$FIXTURE_ROOT/p11d"; T11D="$FIXTURE_ROOT/t11d"
+make_project "$P11D"; write_keep "$P11D"
+make_template "$T11D"
+git init -q --initial-branch=main "$T11D"
+git -C "$T11D" config user.name fixture; git -C "$T11D" config user.email fixture@example.test
+printf '__pycache__/\n' > "$T11D/.gitignore"
+git -C "$T11D" add -A >/dev/null 2>&1; git -C "$T11D" commit -qm template
+# Residue that exists on disk but was never committed.
+_f "$T11D/.agents/skills/residue/__pycache__/x.pyc" "build residue"
+_f "$P11D/.agents/skills/residue/__pycache__/x.pyc" "matching residue in the project"
+# Commit it: untracked residue can never appear in any output under any
+# implementation, so without this the assertion below passes vacuously and the
+# git branch of template_paths_from_dir has no load-bearing test at all.
+printf '__pycache__/\n' > "$P11D/.gitignore"
+_f "$P11D/.agents/skills/residue/x.md" "project-only, tracked, under a real root"
+commit_all "$P11D"
+run_retire --repo "$P11D" --from-dir "$T11D"
+assert_eq "0" "$RUN_STATUS" "F5: a git template checkout is read the same way as a ref"
+assert_not_contains "$RUN_OUTPUT" ".pyc" \
+  "F5: gitignored residue is not template content, and is not project content either"
+
+# F6 — a trailing slash in a Markdown table decides whether a root is scanned by
+# a destructive tool, and two hand-written parsers of that block must agree on
+# which entries are directories.
+AWK_DIRS="$(awk '/^## Syncable Paths/ { b = 1; next }
+                 b && /^## / { exit }
+                 b && /→/ { print $1 }' .agents/skills/sync/SKILL.md | grep '/$' | LC_ALL=C sort)"
+PY_DIRS="$(python3 - <<'PYX'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("sr", ".agents/skills/sync/scripts/sync-retire.py")
+m = importlib.util.module_from_spec(spec); sys.modules["sr"] = m; spec.loader.exec_module(m)
+print("\n".join(m.parse_syncable_roots(open(".agents/skills/sync/SKILL.md").read(), "SKILL.md")))
+PYX
+)"
+assert_contains "$AWK_DIRS" ".agents/skills/" "F6: the awk extractor found the block (non-vacuity)"
+assert_eq "$AWK_DIRS" "$PY_DIRS" \
+  "F6: the script's root list equals the drift test's directory subset"
+assert_prose_contains ".agents/skills/sync/SKILL.md" "machine-parsed" \
+  "F6: the block warns an editor that it is parsed by a script"
+
+# ========================================= 12. hostile template cannot escape
+#
+# The doc block that decides which roots get scanned is read from the TEMPLATE,
+# which is a remote repository. So the template chooses what a destructive tool
+# is pointed at. Two independent layers keep that choice inside the project, and
+# both are pinned here because both are currently incidental: a future refactor
+# of `project_paths` to a filesystem walk — the obvious "simplification" — would
+# silently remove the second one.
+
+printf '\n-- 12. a hostile template cannot reach outside the project --\n'
+
+OUTSIDE="$FIXTURE_ROOT/victim-outside"
+mkdir -p "$OUTSIDE"; printf 'precious\n' > "$OUTSIDE/secret.txt"
+P12="$FIXTURE_ROOT/p12"; T12="$FIXTURE_ROOT/t12"
+make_project "$P12"; write_keep "$P12"
+
+# Layer 1 — a root the template declares but cannot vouch for is refused.
+make_template "$T12" "../victim-outside/   → traversal"
+run_retire --repo "$P12" --from-dir "$T12" --apply
+assert_eq "1" "$RUN_STATUS" "a traversing root the template cannot vouch for is refused"
+assert_contains "$RUN_OUTPUT" "../victim-outside/" "the refusal names the traversing root"
+
+# Layer 2 — even when the template DOES carry files under that root, so a
+# contents check would be satisfied, the root is still refused on its shape.
+mkdir -p "$FIXTURE_ROOT/victim-outside"; printf 'decoy\n' > "$T12/../victim-outside/decoy.txt"
+run_retire --repo "$P12" --from-dir "$T12" --apply
+assert_eq "1" "$RUN_STATUS" "a traversing root backed by real template files is still refused"
+assert_file_contains "$OUTSIDE/secret.txt" "precious" \
+  "a file outside the project is never touched"
+
+# An absolute root is refused the same way, and deletes nothing.
+P12A="$FIXTURE_ROOT/p12a"; T12A="$FIXTURE_ROOT/t12a"
+make_project "$P12A"; write_keep "$P12A"
+make_template "$T12A" "/etc/                → absolute"
+run_retire --repo "$P12A" --from-dir "$T12A" --apply
+assert_eq "1" "$RUN_STATUS" "an absolute root in the doc block is refused"
+assert_eq "present" "$([ -f "$P12A/.agents/skills/build/SKILL.md" ] && echo present || echo gone)" \
+  "the refused run deleted nothing"
+
+# ================================== 13. the template cannot widen the blast radius
+#
+# Found by security review, reproduced before fixing: the doc block that decides
+# which roots are scanned is read from the TEMPLATE — a remote repository, or in
+# manual-diff mode a directory under /tmp. Nothing constrained what a root could
+# be, so a hostile or mistaken template could name `src/` or `.claude/` and this
+# tool would delete the project's source and its own never-sync config.
+#
+# Staying inside the repository is not sufficient: the earlier traversal tests
+# passed while this hole was wide open, because every path here IS inside the
+# repository. A root must additionally be one of the directories /sync manages.
+
+printf '\n-- 13. a hostile doc block cannot widen the scan --\n'
+
+P13="$FIXTURE_ROOT/p13"; T13="$FIXTURE_ROOT/t13"
+make_project "$P13"
+mkdir -p "$P13/src"
+_f "$P13/src/app.py" "production code"
+_f "$P13/.claude/project.md" "project config, never synced"
+commit_all "$P13"; write_keep "$P13"
+
+# An ordinary project directory named as a root.
+make_template "$T13" "src/                  → hostile"
+_f "$T13/src/decoy.py" "decoy so a contents check would pass"
+run_retire --repo "$P13" --from-dir "$T13" --apply
+assert_eq "1" "$RUN_STATUS" "a root outside the harness directories is refused"
+assert_contains "$RUN_OUTPUT" "src/" "the refusal names the offending root"
+assert_file_contains "$P13/src/app.py" "production code" "project source is untouched"
+
+# `.claude/` itself — one segment — would sweep in the never-sync files,
+# including the allowlist this whole mechanism depends on.
+P13B="$FIXTURE_ROOT/p13b"; T13B="$FIXTURE_ROOT/t13b"
+make_project "$P13B"; _f "$P13B/.claude/project.md" "project config"; commit_all "$P13B"
+write_keep "$P13B"
+make_template "$T13B" ".claude/              → hostile"
+_f "$T13B/.claude/decoy.md" "decoy"
+run_retire --repo "$P13B" --from-dir "$T13B" --apply
+assert_eq "1" "$RUN_STATUS" "a bare top-level harness directory is refused as a root"
+assert_file_contains "$P13B/.claude/project.md" "project config" \
+  "the project's never-sync config is untouched"
+assert_eq "present" "$([ -f "$P13B/.claude/sync-keep" ] && echo present || echo gone)" \
+  "the allowlist itself survives"
+
+# The seven real roots still parse — the constraint must not break the tool.
+run_retire --repo "$P13B" --from-dir "$T13B" >/dev/null 2>&1
+REAL_ROOTS="$(python3 - <<'PYX'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("sr", ".agents/skills/sync/scripts/sync-retire.py")
+m = importlib.util.module_from_spec(spec); sys.modules["sr"] = m; spec.loader.exec_module(m)
+print(len(m.parse_syncable_roots(open(".agents/skills/sync/SKILL.md").read(), "real")))
+PYX
+)"
+assert_eq "7" "$REAL_ROOTS" "all seven real syncable roots still pass the constraint"
+
+# ============================== 14. allowlist entries that protect nothing
+#
+# The validator's docstring says it exists so a pattern cannot fail silently.
+# Two shapes slipped through: a trailing-slash directory (the most natural thing
+# a human writes) and a truncated prefix. Both reach a root, so the reachability
+# check passed, but neither can ever fullmatch a FILE path — so every file they
+# were written to save was retired, exit 0, no warning.
+
+printf '\n-- 14. a sync-keep entry that can never match --\n'
+
+P14="$FIXTURE_ROOT/p14"; T14="$FIXTURE_ROOT/t14"
+make_project "$P14"; make_template "$T14"
+_f "$P14/.agents/skills/mine/SKILL.md" "project specific"
+_f "$P14/.agents/skills/mine/scripts/deep.sh" "project specific"
+commit_all "$P14"
+
+# A directory pattern is rejected outright, and the message names the fix.
+write_keep "$P14" ".agents/skills/mine/"
+run_retire --repo "$P14" --from-dir "$T14" --apply
+assert_eq "1" "$RUN_STATUS" "a trailing-slash directory pattern is refused"
+assert_contains "$RUN_OUTPUT" ".agents/skills/mine/**" "the refusal names the pattern that would work"
+assert_eq "present" "$([ -f "$P14/.agents/skills/mine/SKILL.md" ] && echo present || echo gone)" \
+  "nothing is deleted when a pattern is refused"
+
+# A pattern that is well-formed but matched nothing this run is reported, not
+# silently ignored — a stale allowlist entry is how a path starts being deleted.
+write_keep "$P14" ".agents/skills/mine/**" ".agents/skills/typo-never-matches/**"
+run_retire --repo "$P14" --from-dir "$T14"
+assert_eq "0" "$RUN_STATUS" "a pattern matching nothing is a warning, not a failure"
+assert_contains "$RUN_OUTPUT" "unmatched: .agents/skills/typo-never-matches/**" \
+  "the unmatched pattern is named"
+assert_not_contains "$RUN_OUTPUT" "unmatched: .agents/skills/mine/**" \
+  "a pattern that did match is not reported as unmatched"
+
+# ================================ 15. candidates must be patterns, not paths
+#
+# write_candidate emitted raw paths into a file whose lines are globs. A path
+# containing `*` became an over-broad rule that protected unrelated siblings
+# from retirement; a path containing `[` produced a candidate that, once
+# promoted, made every later sync exit 1. Both reviewers found this
+# independently.
+
+printf '\n-- 15. glob metacharacters in candidate paths --\n'
+
+P15="$FIXTURE_ROOT/p15"; T15="$FIXTURE_ROOT/t15"
+make_project "$P15"; make_template "$T15"
+_f "$P15/.agents/skills/note[1].md" "bracket in the filename"
+_f "$P15/.agents/skills/plain.md"   "ordinary project-only path"
+commit_all "$P15"
+
+run_retire --repo "$P15" --from-dir "$T15" --apply
+assert_eq "0" "$RUN_STATUS" "bootstrap succeeds even with an unexpressible path"
+assert_file_contains "$P15/.claude/sync-keep.candidate" ".agents/skills/plain.md" \
+  "an ordinary path is emitted as a usable pattern"
+assert_file_contains "$P15/.claude/sync-keep.candidate" "# UNEXPRESSIBLE" \
+  "a path with glob metacharacters is commented out, not emitted as a pattern"
+
+# The promoted candidate must be a valid allowlist — the failure this prevents
+# is a sync that exits 1 on a line the tool itself wrote.
+cp "$P15/.claude/sync-keep.candidate" "$P15/.claude/sync-keep"
+run_retire --repo "$P15" --from-dir "$T15"
+assert_eq "0" "$RUN_STATUS" "the promoted candidate validates"
+assert_contains "$RUN_OUTPUT" "kept:   .agents/skills/plain.md" "and protects what it names"
+
+# ============================== 16. a deletion that fails part-way still reports
+#
+# The uncovered branch on the destructive path, and the one where files are lost
+# without a record. `apply_plan` built a list of what it removed, but a
+# propagating OSError threw that list away: the operator saw a plan of N, an
+# errno, and had to run `git status` to learn which files were already gone.
+
+printf '\n-- 16. partial deletion leaves a record --\n'
+
+P16="$FIXTURE_ROOT/p16"; T16="$FIXTURE_ROOT/t16"
+make_project "$P16"; make_template "$T16"
+_f "$P16/.agents/skills/a-first/SKILL.md"  "retired, deletable"
+_f "$P16/.agents/skills/z-locked/SKILL.md" "retired, in a directory made read-only"
+commit_all "$P16"; write_keep "$P16"
+chmod a-w "$P16/.agents/skills/z-locked"
+
+run_retire --repo "$P16" --from-dir "$T16" --apply
+chmod u+w "$P16/.agents/skills/z-locked"
+
+assert_eq "1" "$RUN_STATUS" "a deletion failure exits non-zero"
+assert_contains "$RUN_OUTPUT" "mode:   applied (1 deleted, 1 failed)" \
+  "the outcome counts what happened, not what was planned"
+assert_contains "$RUN_OUTPUT" "FAILED: .agents/skills/z-locked/SKILL.md" \
+  "the path that could not be deleted is named"
+assert_eq "gone" "$([ -e "$P16/.agents/skills/a-first/SKILL.md" ] && echo present || echo gone)" \
+  "the deletable path really was deleted"
+assert_eq "present" "$([ -f "$P16/.agents/skills/z-locked/SKILL.md" ] && echo present || echo gone)" \
+  "the undeletable path really did survive"
+# The record must match the disk: exactly the paths reported deleted are gone.
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/a-first/SKILL.md" \
+  "the full plan is still printed before the outcome"
+
+# ====================== 17. second-review defects: exec, records, round-trips
+#
+# Each block below reproduces a defect that two independently dispatched
+# reviewers found in the shipped script. They are pinned here because every one
+# of them was invisible to the sixteen sections above: the suite was green while
+# the tool could execute a command from an untrusted checkout, and green while a
+# failed prune discarded the list of files it had just destroyed.
+
+# --- 17.1 a failed prune must not discard the record of what was deleted ------
+#
+# The deletion loop was already accounted for (section 16); the prune loop that
+# follows it was not, so an OSError there propagated out and the operator was
+# shown an errno instead of the list of files already gone.
+
+P17="$FIXTURE_ROOT/p17"; T17="$FIXTURE_ROOT/t17"
+make_project "$P17"; make_template "$T17"
+# Nested deliberately: os.remove needs write on the file's own directory, so
+# locking that would block the *deletion*. Locking the grandparent leaves the
+# delete free and makes only the rmdir above it fail -- the prune path.
+_f "$P17/.agents/skills/orphan/sub/SKILL.md" "retired; its grandparent resists rmdir"
+commit_all "$P17"; write_keep "$P17"
+chmod a-w "$P17/.agents/skills/orphan"
+
+run_retire --repo "$P17" --from-dir "$T17" --apply
+chmod u+w "$P17/.agents/skills/orphan"
+
+assert_contains "$RUN_OUTPUT" "applied (1 deleted" \
+  "a prune failure still reports the deletion that succeeded"
+assert_contains "$RUN_OUTPUT" "1 not pruned" \
+  "the unprunable directory is counted separately from a failed deletion"
+assert_contains "$RUN_OUTPUT" "UNPRUNED: .agents/skills/orphan/sub" \
+  "the directory that could not be pruned is named"
+assert_eq "gone" "$([ -e "$P17/.agents/skills/orphan/sub/SKILL.md" ] && echo present || echo gone)" \
+  "the file really was deleted, which is why the record must survive"
+
+# --- 17.2 an untrusted template checkout cannot choose what git executes ------
+#
+# `--from-dir` runs git inside a tree the project did not write. git honours
+# that repo's own config, and core.fsmonitor names a command git runs on
+# ls-files -- reached during the *dry run*, before any approval.
+
+P18="$FIXTURE_ROOT/p18"; T18="$FIXTURE_ROOT/t18"
+make_project "$P18"; make_template "$T18"
+git init -q --initial-branch=main "$T18"
+git -C "$T18" config user.name fixture
+git -C "$T18" config user.email fixture@example.test
+commit_all "$T18"
+write_keep "$P18"
+git -C "$T18" config core.fsmonitor "touch $FIXTURE_ROOT/PWNED; false"
+rm -f "$FIXTURE_ROOT/PWNED"
+
+run_retire --repo "$P18" --from-dir "$T18"
+
+assert_eq "absent" "$([ -e "$FIXTURE_ROOT/PWNED" ] && echo present || echo absent)" \
+  "a template's core.fsmonitor is not executed during the dry run"
+
+run_retire --repo "$P18" --from-dir "$T18" --apply
+assert_eq "absent" "$([ -e "$FIXTURE_ROOT/PWNED" ] && echo present || echo absent)" \
+  "nor under --apply"
+
+# --- 17.3 a candidate the reader would strip is written as a comment ---------
+#
+# read_keep_patterns strips each line, so a path with surrounding whitespace
+# round-trips into a pattern that cannot match it: the file the human
+# allowlisted is deleted anyway, at exit 0. Same class as the `[` case that
+# _as_pattern already guarded.
+
+P19="$FIXTURE_ROOT/p19"; T19="$FIXTURE_ROOT/t19"
+make_project "$P19"; make_template "$T19"
+_f "$P19/.agents/skills/mine/trailing " "project-only, name ends in a space"
+_f "$P19/.agents/skills/mine/plain.md"  "project-only, expressible"
+commit_all "$P19"
+rm -f "$P19/.claude/sync-keep"
+
+run_retire --repo "$P19" --from-dir "$T19" --apply
+
+assert_contains "$(cat "$P19/.claude/sync-keep.candidate")" "# UNEXPRESSIBLE" \
+  "a path the reader would strip is commented out, not offered as a pattern"
+assert_contains "$(cat "$P19/.claude/sync-keep.candidate")" ".agents/skills/mine/plain.md" \
+  "an expressible sibling is still written as a live pattern"
+# The live pattern must be the plain one only: a bare `trailing` line would look
+# like protection and silently match nothing on the next run.
+assert_eq "0" "$(grep -c '^\.agents/skills/mine/trailing $' "$P19/.claude/sync-keep.candidate" || true)" \
+  "the unexpressible path is never emitted as an uncommented rule"
+
+# --- 17.4 the root validator rejects a traversing or globbed segment ---------
+#
+# `[^/]+` matched `..`, `.` and `*`, so the guard whose stated job is refusing
+# to point a file-deleting tool at the wrong place accepted `.claude/../`.
+# assert_roots_present blocked it incidentally; the designated guard must too.
+
+for _bad in '.claude/../' '.claude/./' '.claude/*/'; do
+  P20="$FIXTURE_ROOT/p20"; T20="$FIXTURE_ROOT/t20"
+  rm -rf "$P20" "$T20"
+  make_project "$P20"; make_template "$T20" "$_bad          → hostile root"
+  write_keep "$P20"
+  run_retire --repo "$P20" --from-dir "$T20"
+  assert_eq "1" "$RUN_STATUS" "a root segment of '$_bad' is refused"
+  assert_contains "$RUN_OUTPUT" "$_bad" "the refusal names the offending root"
+  # Which guard rejected it matters. assert_roots_present also refuses these,
+  # incidentally, because git normalises its output -- so asserting only "exit 1"
+  # stays green with the traversal hole wide open. Pin the *designated* guard by
+  # its own message, or a later change to the reachability check silently
+  # reopens whole-repo deletion.
+  assert_contains "$RUN_OUTPUT" "is not a syncable root" \
+    "the root-shape validator is what rejects '$_bad', not a downstream accident"
+done
+
+# --- 17.5 a sub-heading closes the doc block --------------------------------
+#
+# The terminator matched "## " only, so a `### Subsection` left the block open
+# and any arrow line beneath it was read as a root. Matched at any heading depth
+# now -- but a single `#` shell comment inside a fence must still NOT close it.
+
+P21="$FIXTURE_ROOT/p21"; T21="$FIXTURE_ROOT/t21"
+make_project "$P21"; make_template "$T21"
+# Reopen the template's doc block with a sub-heading, then smuggle a root under it.
+python3 - "$T21/.agents/skills/sync/SKILL.md" <<'PY'
+import io, sys
+p = sys.argv[1]
+s = io.open(p, encoding="utf-8").read()
+s = s.replace("## Next Section", "### Subsection\n.claude/smuggled/  → injected\n\n## Next Section")
+io.open(p, "w", encoding="utf-8").write(s)
+PY
+_f "$P21/.claude/smuggled/x.md" "would be scanned if the block stayed open"
+commit_all "$P21"; write_keep "$P21"
+
+run_retire --repo "$P21" --from-dir "$T21"
+
+assert_eq "0" "$RUN_STATUS" "a sub-heading closes the block rather than erroring"
+# If the block had stayed open, .claude/smuggled/ would be a scanned root and
+# its project-only file would appear as a retire candidate.
+assert_not_contains "$RUN_OUTPUT" "smuggled" \
+  "a root declared after a sub-heading is not read as a syncable root"
+
+# ============== 18. third-review defects: seams, records and round-trips
+#
+# Round 2 fixed the script; round 3 found that most of what remained lived in
+# the seam between the script and the procedure that drives it, and that several
+# round-2 fixes were pinned by assertions that survived their own mutation.
+
+# --- 18.1 a candidate line the tool wrote must never break the next run -------
+#
+# _as_pattern detected a newline but interpolated the raw path into the comment's
+# last line, so everything after the break landed at column 0 as a live rule.
+# Backslash was missing from the set outright, though validate_pattern rejects it.
+
+P22="$FIXTURE_ROOT/p22"; T22="$FIXTURE_ROOT/t22"
+make_project "$P22"; make_template "$T22"
+_f "$P22/.agents/skills/mine/plain.md" "expressible"
+_f "$P22/.agents/skills/mine/we\\ird.md" "backslash: validate_pattern refuses this"
+_f "$P22/.agents/skills/mine/$(printf 'br\noken')" "a real newline inside the filename"
+commit_all "$P22"
+rm -f "$P22/.claude/sync-keep"
+
+run_retire --repo "$P22" --from-dir "$T22" --apply
+assert_eq "0" "$RUN_STATUS" "bootstrap writes a candidate"
+
+# Promote the tool's own output verbatim: it must be readable by its own reader.
+cp "$P22/.claude/sync-keep.candidate" "$P22/.claude/sync-keep"
+run_retire --repo "$P22" --from-dir "$T22"
+assert_eq "0" "$RUN_STATUS" \
+  "the candidate this tool wrote is accepted verbatim by its own reader"
+assert_not_contains "$RUN_OUTPUT" "use POSIX separators" \
+  "a backslash path is commented out, not emitted as a rule that fails every later sync"
+assert_not_contains "$RUN_OUTPUT" "is outside every syncable root" \
+  "and a newline does not split into a second, live rule at column 0"
+# Structural form of the same claim: every non-blank candidate line is either a
+# comment or a pattern the reader accepts. A continuation line is neither.
+assert_eq "0" "$(grep -vE '^#|^[[:space:]]*$' "$P22/.claude/sync-keep.candidate" \
+  | grep -cvE '^\.(agents|claude)/' || true)" \
+  "no candidate line is a bare fragment of a path"
+assert_contains "$RUN_OUTPUT" "kept:   .agents/skills/mine/plain.md" \
+  "while the expressible sibling still protects its file"
+
+# --- 18.2 pruning stops at the syncable root even when the root empties -------
+#
+# The old fixture kept the root alive on leftover contents, so deleting the
+# boundary check entirely left the suite green while a whole root was removed.
+
+P23="$FIXTURE_ROOT/p23"; T23="$FIXTURE_ROOT/t23"
+make_project "$P23"; make_template "$T23"
+rm -f "$P23/.claude/hooks/session-start.sh"          # root's ONLY surviving file
+_f "$P23/.claude/hooks/old-hook.sh" "retired upstream; the root's entire contents"
+commit_all "$P23"; write_keep "$P23"
+
+run_retire --repo "$P23" --from-dir "$T23" --apply
+assert_eq "gone" "$([ -e "$P23/.claude/hooks/old-hook.sh" ] && echo present || echo gone)" \
+  "the root's last file is retired"
+assert_eq "present" "$([ -d "$P23/.claude/hooks" ] && echo present || echo gone)" \
+  "but the syncable root itself survives being emptied"
+
+# --- 18.3 a partial run reports what it destroyed, and names the right dir ----
+
+P24="$FIXTURE_ROOT/p24"; T24="$FIXTURE_ROOT/t24"
+make_project "$P24"; make_template "$T24"
+_f "$P24/.agents/skills/gamma/deep/deeper/y.md" "retired; a parent will resist rmdir"
+commit_all "$P24"; write_keep "$P24"
+chmod a-w "$P24/.agents/skills/gamma"   # deeper prunes fine; gamma/deep cannot
+
+run_retire --repo "$P24" --from-dir "$T24" --apply
+chmod u+w "$P24/.agents/skills/gamma"
+
+assert_contains "$RUN_OUTPUT" "deleted: .agents/skills/gamma/deep/deeper/y.md" \
+  "a partial run prints the record of what it destroyed, not just a count"
+# Pruning walks upward, so the directory it STARTED at is usually removed fine.
+# Reporting that one names a path that no longer exists.
+assert_contains "$RUN_OUTPUT" "UNPRUNED: .agents/skills/gamma/deep " \
+  "the directory named is the one that actually failed"
+assert_eq "present" "$([ -d "$P24/.agents/skills/gamma/deep" ] && echo present || echo gone)" \
+  "and that directory is genuinely still on disk"
+
+# --- 18.4 sync-keep states: absent, empty, and unusable are three things ------
+
+P25="$FIXTURE_ROOT/p25"; T25="$FIXTURE_ROOT/t25"
+make_project "$P25"; make_template "$T25"
+_f "$P25/.agents/skills/mine/SKILL.md" "project-only"
+commit_all "$P25"
+
+rm -f "$P25/.claude/sync-keep"
+ln -s /nonexistent-target "$P25/.claude/sync-keep"
+run_retire --repo "$P25" --from-dir "$T25" --apply
+assert_eq "1" "$RUN_STATUS" "a sync-keep that is not a regular file is an error"
+assert_contains "$RUN_OUTPUT" "not a regular file" "and says so"
+assert_eq "absent" "$([ -e "$P25/.claude/sync-keep.candidate" ] && echo present || echo absent)" \
+  "it is not mistaken for bootstrap, so no candidate is written over it"
+
+rm -f "$P25/.claude/sync-keep"
+printf '.agents/skills/x\xff\xfe.md\n' > "$P25/.claude/sync-keep"
+run_retire --repo "$P25" --from-dir "$T25" --apply
+assert_eq "1" "$RUN_STATUS" "an undecodable sync-keep exits 1"
+assert_contains "$RUN_OUTPUT" "sync-retire: cannot read" \
+  "reported on the tool's own channel, not as a traceback"
+assert_not_contains "$RUN_OUTPUT" "Traceback" "specifically, not as a traceback"
+
+# --- 18.5 a .git FILE must not redirect the inventory to another repository ---
+#
+# read_template_doc reads SKILL.md from this directory's disk while the git
+# branch read the file list from wherever the gitdir pointer led: one plan, two
+# templates, exit 0.
+
+P26="$FIXTURE_ROOT/p26"; T26="$FIXTURE_ROOT/t26"; OTHER="$FIXTURE_ROOT/other26"
+make_project "$P26"; make_template "$T26"; make_project "$OTHER"
+_f "$OTHER/.agents/skills/beta/SKILL.md" "only in the unrelated repo"
+commit_all "$OTHER"
+_f "$P26/.agents/skills/beta/SKILL.md" "project copy, retired unless the pointer is followed"
+commit_all "$P26"; write_keep "$P26"
+printf 'gitdir: %s/.git\n' "$OTHER" > "$T26/.git"
+
+run_retire --repo "$P26" --from-dir "$T26"
+assert_eq "0" "$RUN_STATUS" "a .git file is treated as a plain directory, not a repo"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/beta/SKILL.md" \
+  "the inventory comes from the directory on disk, not from the repo its .git file names"
+
+# --- 18.6 a template checkout without the doc block is an error --------------
+
+P27="$FIXTURE_ROOT/p27"; T27="$FIXTURE_ROOT/t27"
+make_project "$P27"; make_template "$T27"; write_keep "$P27"
+rm -f "$T27/.agents/skills/sync/SKILL.md"
+
+run_retire --repo "$P27" --from-dir "$T27" --apply
+assert_eq "1" "$RUN_STATUS" "a template checkout with no SKILL.md exits 1"
+assert_contains "$RUN_OUTPUT" "template checkout has no" "and names what is missing"
+
+# --- 18.7 git config from outside the repo cannot choose what runs -----------
+#
+# 17.2 pinned the repo-config route only, so the GIT_CONFIG_GLOBAL suppression
+# and the core.hooksPath pin could both be deleted with the suite green.
+
+P28="$FIXTURE_ROOT/p28"; T28="$FIXTURE_ROOT/t28"
+make_project "$P28"; make_template "$T28"; write_keep "$P28"
+printf '[core]\n\tfsmonitor = "touch %s/PWNED_GLOBAL; false"\n' "$FIXTURE_ROOT" \
+  > "$FIXTURE_ROOT/evil-global-config"
+rm -f "$FIXTURE_ROOT/PWNED_GLOBAL"
+
+GIT_CONFIG_GLOBAL="$FIXTURE_ROOT/evil-global-config" \
+  python3 "$RETIRE" --repo "$P28" --from-dir "$T28" >/dev/null 2>&1
+# NOTE: this assertion cannot distinguish the two guards. `-c core.fsmonitor=`
+# outranks global config as well as repo config, so removing the
+# GIT_CONFIG_NOSYSTEM/GIT_CONFIG_GLOBAL suppression leaves this green. The env
+# hardening is defence-in-depth behind the `-c` pin, not an independently
+# observable behaviour -- recorded here as a smoke test, not as proof of it.
+assert_eq "absent" "$([ -e "$FIXTURE_ROOT/PWNED_GLOBAL" ] && echo present || echo absent)" \
+  "git config from outside the repo does not name a command this tool executes"
+
+# ================= 19. bootstrap still removes what the template retired
+#
+# The mechanism this feature replaced was a hardcoded `for retired in tdd deslop
+# simplify verify-e2e` loop that deleted unconditionally. Making retirement
+# depend on a recorded allowlist lost that for any project which never promotes
+# a candidate -- the one case where the new design was strictly weaker.
+#
+# The record that answers it without a hand-maintained name list is the
+# template's own history: a path the template once carried and no longer does
+# was retired upstream, not written by this project.
+
+P29="$FIXTURE_ROOT/p29"; T29="$FIXTURE_ROOT/t29"
+make_project "$P29"
+# A git template WITH history: it once shipped `legacy`, then retired it.
+git init -q --initial-branch=main "$T29"
+git -C "$T29" config user.name fixture
+git -C "$T29" config user.email fixture@example.test
+write_skill_md "$T29"
+_f "$T29/.agents/skills/build/SKILL.md"  "build skill"
+_f "$T29/.agents/agents/planner.md"      "planner"
+_f "$T29/.claude/skills/build/SKILL.md"  "build skill"
+_f "$T29/.claude/hooks/session-start.sh" "hook"
+_f "$T29/CLAUDE.md"                      "rules"
+_f "$T29/.claude/settings.json"          "{}"
+_f "$T29/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+commit_all "$T29"
+git -C "$T29" rm -q -r .agents/skills/legacy
+commit_all "$T29"
+
+# The project still carries the retired skill, and has its own local one.
+_f "$P29/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+_f "$P29/.agents/skills/ours/SKILL.md"   "this project's own, never in the template"
+commit_all "$P29"
+rm -f "$P29/.claude/sync-keep"            # bootstrap: no allowlist recorded
+
+run_retire --repo "$P29" --from-dir "$T29"
+assert_eq "0" "$RUN_STATUS" "bootstrap with template history succeeds"
+assert_contains "$RUN_OUTPUT" "bootstrap: required" "it is still bootstrap"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/legacy/SKILL.md (was template content" \
+  "a path the template retired upstream is retired without a human classifying it"
+assert_contains "$RUN_OUTPUT" "candidate: .agents/skills/ours/SKILL.md" \
+  "while a path the template never carried stays a candidate for the human"
+assert_not_contains "$RUN_OUTPUT" "retire: .agents/skills/ours/SKILL.md" \
+  "project-specific paths are never retired on provenance alone"
+
+run_retire --repo "$P29" --from-dir "$T29" --apply
+assert_eq "gone" "$([ -e "$P29/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "--apply removes the retired-upstream path in bootstrap"
+assert_eq "present" "$([ -f "$P29/.agents/skills/ours/SKILL.md" ] && echo present || echo gone)" \
+  "and leaves the project's own file untouched"
+assert_contains "$(cat "$P29/.claude/sync-keep.candidate")" ".agents/skills/ours/SKILL.md" \
+  "the candidate offers only what provenance could not settle"
+assert_not_contains "$(cat "$P29/.claude/sync-keep.candidate")" ".agents/skills/legacy/SKILL.md" \
+  "and never offers to keep something the template already retired"
+
+# --- 19.2 no history means no conclusion, said out loud ---------------------
+#
+# A shallow clone's "history" is its current state, which would classify every
+# retired path as project-specific. Unknown provenance must not read as proof.
+
+P30="$FIXTURE_ROOT/p30"; T30="$FIXTURE_ROOT/t30"
+make_project "$P30"
+git clone -q --depth 1 "file://$T29" "$T30" 2>/dev/null
+_f "$P30/.agents/skills/legacy/SKILL.md" "stale copy; provenance unavailable here"
+commit_all "$P30"
+rm -f "$P30/.claude/sync-keep"
+
+run_retire --repo "$P30" --from-dir "$T30" --apply
+assert_eq "0" "$RUN_STATUS" "a shallow template still produces a plan"
+assert_contains "$RUN_OUTPUT" "provenance: unavailable" \
+  "and says provenance could not be established"
+assert_eq "present" "$([ -f "$P30/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "retiring nothing rather than guessing"
+
+# =========================================== 20. wrap-up review regressions
+#
+# Each case below is a defect the review passes found in the code this session
+# wrote, reproduced before it was fixed. They share one shape: the program had
+# already destroyed something, and then lost the record of having done it. The
+# record is the only thing standing between an operator and `git status`
+# archaeology, so every path that deletes is pinned here separately -- fixing
+# this per call site is exactly what let it recur four times.
+
+printf '\n-- 20. record-loss and provenance regressions --\n'
+
+# A template repository that once shipped `legacy` and later retired it. Shared
+# by 20.1-20.3, which all need real history to read.
+make_history_template() {
+  _dir="$1"
+  git init -q --initial-branch=main "$_dir"
+  git -C "$_dir" config user.name fixture
+  git -C "$_dir" config user.email fixture@example.test
+  write_skill_md "$_dir"
+  _f "$_dir/.agents/skills/build/SKILL.md"  "build skill"
+  _f "$_dir/.agents/agents/planner.md"      "planner"
+  _f "$_dir/.claude/skills/build/SKILL.md"  "build skill"
+  _f "$_dir/.claude/hooks/session-start.sh" "hook"
+  _f "$_dir/CLAUDE.md"                      "rules"
+  _f "$_dir/.claude/settings.json"          "{}"
+  _f "$_dir/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+  commit_all "$_dir"
+  git -C "$_dir" rm -q -r .agents/skills/legacy
+  commit_all "$_dir"
+}
+
+# --- 20.1 a precondition may not fire after the deletion it guards ----------
+#
+# Bootstrap --apply deleted first and wrote the candidate second, and
+# write_candidate refuses to overwrite an existing candidate. So the ordinary
+# state "a candidate was generated but not yet promoted" -- which is every
+# second bootstrap run -- deleted files, then raised, and the raise discarded
+# `removed`. The operator saw an error about a *file it would not overwrite*,
+# exit 1, and no mention of the skill that had just been destroyed.
+
+P31="$FIXTURE_ROOT/p31"; T31="$FIXTURE_ROOT/t31"
+make_project "$P31"; make_history_template "$T31"
+_f "$P31/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+commit_all "$P31"
+rm -f "$P31/.claude/sync-keep"
+_f "$P31/.claude/sync-keep.candidate" "# generated earlier, not yet promoted"
+
+run_retire --repo "$P31" --from-dir "$T31" --apply
+assert_eq "1" "$RUN_STATUS" "bootstrap --apply refuses an existing candidate"
+assert_contains "$RUN_OUTPUT" "sync-keep.candidate already exists" \
+  "and says which file it will not overwrite"
+assert_eq "present" \
+  "$([ -f "$P31/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "the refusal happens before any deletion, not after it"
+assert_not_contains "$RUN_OUTPUT" "deleted:" \
+  "so there is no destruction to report"
+assert_file_contains "$P31/.claude/sync-keep.candidate" "not yet promoted" \
+  "and the human's file is left exactly as they left it"
+
+# Promoting the candidate unblocks the same run: the guard is a precondition,
+# not a permanent refusal. Without this the assertion above would also pass
+# against a program that had simply stopped retiring in bootstrap.
+rm -f "$P31/.claude/sync-keep.candidate"
+run_retire --repo "$P31" --from-dir "$T31" --apply
+assert_eq "0" "$RUN_STATUS" "with no stale candidate the same run succeeds"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/legacy/SKILL.md" \
+  "and the same run names the path it is about to destroy"
+assert_contains "$RUN_OUTPUT" "applied (1 deleted)" \
+  "and reports having destroyed it"
+assert_eq "gone" \
+  "$([ -e "$P31/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "so the guard was a precondition, not a permanent refusal to retire"
+
+# --- 20.2 every git failure is not "the clone was shallow" ------------------
+#
+# The probe swallowed its exception and reported one hardcoded cause, so a
+# missing ref and an unreadable object both told the operator to deepen a clone
+# that was already complete. The reason must be the one git gave.
+
+P32="$FIXTURE_ROOT/p32"; T32="$FIXTURE_ROOT/t32"
+make_project "$P32"
+git init -q --initial-branch=main "$T32"
+git -C "$T32" config user.name fixture
+git -C "$T32" config user.email fixture@example.test
+make_template "$T32"
+commit_all "$T32"                          # one commit: no history to read
+_f "$P32/.agents/skills/legacy/SKILL.md" "unclassifiable without provenance"
+commit_all "$P32"
+rm -f "$P32/.claude/sync-keep"
+
+run_retire --repo "$P32" --from-dir "$T32"
+assert_not_contains "$RUN_OUTPUT" "provenance: unavailable" \
+  "one commit is a complete history, not an unreadable one"
+assert_contains "$RUN_OUTPUT" "candidate: .agents/skills/legacy/SKILL.md" \
+  "it simply never retired anything, so nothing has provenance to retire"
+
+# The truncation that *does* hide a retirement is a clone shallower than it.
+# Counting commits caught only depth 1, so every deeper shallow clone silently
+# produced a different retirement set from the same commit SHA.
+
+P32C="$FIXTURE_ROOT/p32c"; T32CSRC="$FIXTURE_ROOT/t32c-src"; T32C="$FIXTURE_ROOT/t32c"
+make_project "$P32C"
+make_history_template "$T32CSRC"
+# Commits after the retirement, so a depth-2 clone lands entirely above it.
+for i in 1 2 3; do
+  _f "$T32CSRC/.agents/skills/build/SKILL.md" "build skill revision $i"
+  commit_all "$T32CSRC"
+done
+git clone -q --depth 2 "file://$T32CSRC" "$T32C" 2>/dev/null
+_f "$P32C/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+commit_all "$P32C"
+rm -f "$P32C/.claude/sync-keep"
+
+run_retire --repo "$P32C" --from-dir "$T32C"
+assert_eq "0" "$RUN_STATUS" "a shallow-but-not-single-commit template produces a plan"
+assert_contains "$RUN_OUTPUT" "provenance: unavailable" \
+  "a clone truncated below the retirement is detected at any depth"
+assert_contains "$RUN_OUTPUT" "truncated history" \
+  "and named as truncation rather than as a missing ref"
+assert_not_contains "$RUN_OUTPUT" "retire: .agents/skills/legacy/SKILL.md" \
+  "so it never concludes a retirement from history it cannot see"
+
+# The other way this probe fails is a git error, and it used to be reported with
+# the same shallow-clone wording -- telling the operator to deepen a clone whose
+# depth was never the problem. A template repo with a staged but uncommitted
+# tree reaches it: the doc block and the index both read fine, and only the
+# revision does not exist.
+
+P32B="$FIXTURE_ROOT/p32b"; T32B="$FIXTURE_ROOT/t32b"
+make_project "$P32B"
+make_template "$T32B"
+git init -q --initial-branch=main "$T32B"
+git -C "$T32B" add -A                      # staged, never committed: no HEAD
+_f "$P32B/.agents/skills/legacy/SKILL.md" "unclassifiable without provenance"
+commit_all "$P32B"
+rm -f "$P32B/.claude/sync-keep"
+
+run_retire --repo "$P32B" --from-dir "$T32B"
+assert_eq "0" "$RUN_STATUS" "an unreadable revision still produces a plan"
+assert_contains "$RUN_OUTPUT" "unknown revision" \
+  "and the reason is the one git gave, carried out of the probe"
+assert_not_contains "$RUN_OUTPUT" "single commit" \
+  "not the shallow-clone wording every failure used to borrow"
+# git's fatals run to three lines with a usage hint. The report is read one
+# item per line, so the reason has to arrive as one item.
+assert_eq "0" \
+  "$(printf '%s\n' "$RUN_OUTPUT" | tail -n +2 | grep -cv '^  ' || true)" \
+  "and it stays a single report line, however many lines git used to say it"
+assert_contains "$RUN_OUTPUT" "candidate: .agents/skills/legacy/SKILL.md" \
+  "unknown provenance holds the path for a human rather than deleting it"
+assert_not_contains "$RUN_OUTPUT" "a full clone" \
+  "and it does not advise deepening a clone whose depth was never the problem"
+
+# --- 20.3 shallowness is a property of the revision, not the repository -----
+#
+# `--from-ref` is the mode SKILL.md prescribes, and there the revision lives in
+# the *project* repo. Probing `--is-shallow-repository` therefore asked whether
+# the project was a shallow checkout -- which is what CI does by default -- and
+# answered "no provenance" for every one of them, however complete the fetched
+# template ref was. That silently no-ops retirement in the recommended mode.
+
+PORIGIN="$FIXTURE_ROOT/p33-origin"; P33="$FIXTURE_ROOT/p33"
+make_project "$PORIGIN"
+_f "$PORIGIN/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+_f "$PORIGIN/.agents/skills/ours/SKILL.md"   "this project's own"
+rm -f "$PORIGIN/.claude/sync-keep"
+commit_all "$PORIGIN"
+
+git clone -q --depth 1 "file://$PORIGIN" "$P33"
+git -C "$P33" config user.name fixture
+git -C "$P33" config user.email fixture@example.test
+assert_eq "true" "$(git -C "$P33" rev-parse --is-shallow-repository)" \
+  "the project itself is a shallow checkout"
+git -C "$P33" remote add workflow "file://$T31"
+git -C "$P33" fetch -q workflow main
+git -C "$P33" tag -f workflow-main FETCH_HEAD >/dev/null 2>&1
+
+run_retire --repo "$P33" --from-ref workflow-main
+assert_eq "0" "$RUN_STATUS" "a shallow project reads the template ref's history"
+assert_not_contains "$RUN_OUTPUT" "provenance: unavailable" \
+  "the project's own clone depth does not suppress the template's provenance"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/legacy/SKILL.md" \
+  "so retirement still happens in the mode SKILL.md prescribes"
+assert_contains "$RUN_OUTPUT" "candidate: .agents/skills/ours/SKILL.md" \
+  "and the project's own file is still only a candidate"
+
+# --- 20.4 a directory it cannot read is reported, not raised ----------------
+#
+# _prune_upwards guarded os.rmdir and not os.listdir, so a directory the
+# process may write but not read raised a bare OSError out of apply_plan --
+# past the accounting, discarding `removed`. The file was already gone. This is
+# the same defect as 20.1 at a different call site, which is why both are here.
+
+if [ "$(id -u)" -eq 0 ]; then
+  printf '  skip  20.4 needs an unprivileged user (root ignores permission bits)\n'
+else
+  P34="$FIXTURE_ROOT/p34"; T34="$FIXTURE_ROOT/t34"
+  make_project "$P34"; make_template "$T34"
+  _f "$P34/.agents/skills/gone/SKILL.md" "retired: no sync-keep pattern covers it"
+  commit_all "$P34"
+  write_keep "$P34" ".agents/skills/nothing-at-all/**"
+  chmod 300 "$P34/.agents/skills/gone"     # writable and enterable, not readable
+
+  run_retire --repo "$P34" --from-dir "$T34" --apply
+  chmod 700 "$P34/.agents/skills/gone" 2>/dev/null || true
+  assert_eq "1" "$RUN_STATUS" "an unprunable directory is a non-zero outcome"
+  assert_contains "$RUN_OUTPUT" "deleted: .agents/skills/gone/SKILL.md" \
+    "but the file it destroyed is still reported by path"
+  assert_contains "$RUN_OUTPUT" "UNPRUNED: .agents/skills/gone" \
+    "and the directory it could not remove is named separately"
+  assert_contains "$RUN_OUTPUT" "mode:   applied" \
+    "the accounting ran at all — the OSError did not escape past it"
+fi
+
+# --- 20.5 a pattern's legality is judged against the declared roots ---------
+#
+# read_keep_patterns was handed the *scanned* roots, so a sync-keep line naming
+# a path under a root the template had just emptied was "outside every syncable
+# root" -- exit 1, every unrelated retirement blocked. Skipping an emptied root
+# exists precisely so one upstream commit cannot stop retirement everywhere;
+# scoping the pattern check to the same list gave that back.
+
+P35="$FIXTURE_ROOT/p35"; T35="$FIXTURE_ROOT/t35"
+make_project "$P35"; make_template "$T35"
+rm -rf "$T35/.claude/hooks"                # upstream emptied this root
+_f "$P35/.claude/hooks/local.sh"      "project-specific, under the emptied root"
+_f "$P35/.agents/skills/gone/SKILL.md" "retired: nothing keeps it"
+commit_all "$P35"
+write_keep "$P35" ".claude/hooks/local.sh"
+
+run_retire --repo "$P35" --from-dir "$T35"
+assert_eq "0" "$RUN_STATUS" \
+  "a sync-keep entry under an emptied root does not abort the run"
+assert_contains "$RUN_OUTPUT" "skipped: .claude/hooks/" \
+  "the emptied root is skipped and said so"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/gone/SKILL.md" \
+  "and retirement under every other root still proceeds"
+
+assert_contains "$RUN_OUTPUT" "dormant: .claude/hooks/local.sh" \
+  "the pattern is reported as dormant, not as one that matched nothing"
+assert_not_contains "$RUN_OUTPUT" "unmatched: .claude/hooks/local.sh" \
+  "because `unmatched` reads as an invitation to delete the only protection"
+
+run_retire --repo "$P35" --from-dir "$T35" --apply
+assert_eq "present" "$([ -f "$P35/.claude/hooks/local.sh" ] && echo present || echo gone)" \
+  "nothing under a skipped root is deleted"
+
+# --- 20.6 the two readers of the doc block agree at every heading depth -----
+#
+# tests/test-syncable-paths.sh terminates the block on awk's `^##+ `, which is
+# unbounded. This parser used `^#{2,6} `, so a 7-hash heading closed the block
+# for one reader and not the other -- and the arrow line beneath it became a
+# seventh root here and nowhere else.
+
+P36="$FIXTURE_ROOT/p36"; T36="$FIXTURE_ROOT/t36"
+make_project "$P36"
+make_template "$T36"
+# Inside the block, before its real terminator -- appending after
+# `## Next Section` would test nothing, since that heading already closed it.
+python3 - "$T36/.agents/skills/sync/SKILL.md" <<'EOF_PY'
+import io, sys
+path = sys.argv[1]
+text = io.open(path, encoding="utf-8").read()
+io.open(path, "w", encoding="utf-8").write(
+    text.replace("## Next Section", "####### Deep heading\n\n/etc/ → not a root\n\n## Next Section")
+)
+EOF_PY
+
+run_retire --repo "$P36" --from-dir "$T36"
+assert_eq "0" "$RUN_STATUS" "a 7-hash heading after the fence is not a parse error"
+assert_contains "$RUN_OUTPUT" "roots: 4" \
+  "it closes the block, so the line beneath it is not read as a root"
+assert_not_contains "$RUN_OUTPUT" "/etc/" \
+  "and the absolute path below it never reaches the root validator"
+
+# ======================================= 21. the invocations SKILL.md prescribes
+#
+# Every section above calls the script as `python3 "$RETIRE"`. SKILL.md Step 3
+# and Step 6.4 do not: they pipe the script out of the template ref into
+# `python3 -`, so the *template's* copy runs against the project. Nothing tested
+# that form, which is the only one a real /sync ever executes -- a script that
+# works when imported from disk and fails when read from stdin would pass every
+# assertion in this file.
+
+printf '\n-- 21. the pipeline SKILL.md actually runs --\n'
+
+# A project with the template as a `workflow` remote, exactly as Step 1 leaves
+# it: the ref is fetched into the project, so `--from-ref` reads it from there.
+P37="$FIXTURE_ROOT/p37"; T37="$FIXTURE_ROOT/t37"
+make_project "$P37"; make_history_template "$T37"
+# The template must carry the script itself: this pipeline runs the *template's*
+# copy, not the one on disk here. That is the whole point -- a downstream /sync
+# executes whatever the template ships, never the project's local version.
+mkdir -p "$T37/.agents/skills/sync/scripts"
+cp "$RETIRE" "$T37/.agents/skills/sync/scripts/sync-retire.py"
+commit_all "$T37"
+_f "$P37/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+_f "$P37/.agents/skills/ours/SKILL.md"   "this project's own"
+commit_all "$P37"
+rm -f "$P37/.claude/sync-keep"
+git -C "$P37" remote add workflow "file://$T37"
+git -C "$P37" fetch -q workflow main
+
+# --- 21.1 the dry run, verbatim from Step 3 ---------------------------------
+
+PIPED_OUT="$(cd "$P37" && set -o pipefail && \
+  git show "workflow/main:.agents/skills/sync/scripts/sync-retire.py" \
+  | python3 - --from-ref "workflow/main" 2>&1)"
+PIPED_STATUS=$?
+assert_eq "0" "$PIPED_STATUS" "the piped dry run exits zero"
+assert_contains "$PIPED_OUT" "retire: .agents/skills/legacy/SKILL.md" \
+  "and reaches the same conclusion as the on-disk invocation"
+assert_contains "$PIPED_OUT" "dry-run (no changes written)" \
+  "reading the program from stdin does not imply --apply"
+assert_eq "present" "$([ -f "$P37/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "and the dry run deletes nothing"
+
+# --- 21.2 pipefail is load-bearing, not decoration --------------------------
+#
+# SKILL.md claims a failed `git show` feeds python3 an empty program that exits
+# 0, silently skipping the retirement gate. If that claim is wrong the warning
+# is noise; if it is right, `set -o pipefail` is the only thing catching it.
+
+EMPTY_OUT="$(cd "$P37" && git show "workflow/main:no/such/script.py" 2>/dev/null \
+  | python3 - --from-ref "workflow/main" 2>&1)"
+EMPTY_STATUS=$?
+assert_eq "0" "$EMPTY_STATUS" \
+  "without pipefail an empty program really does exit zero, as SKILL.md warns"
+assert_eq "" "$EMPTY_OUT" "having printed nothing at all"
+
+( cd "$P37" && set -o pipefail && git show "workflow/main:no/such/script.py" 2>/dev/null \
+  | python3 - --from-ref "workflow/main" >/dev/null 2>&1 )
+assert_eq "128" "$?" "with pipefail the failed git show is what the caller sees"
+
+# --- 21.3 the --apply form, verbatim from Step 6.4 --------------------------
+
+APPLY_OUT="$(cd "$P37" && set -o pipefail && \
+  git show "workflow/main:.agents/skills/sync/scripts/sync-retire.py" \
+  | python3 - --from-ref "workflow/main" --apply 2>&1)"
+APPLY_STATUS=$?
+assert_eq "0" "$APPLY_STATUS" "the piped --apply exits zero"
+assert_eq "gone" "$([ -e "$P37/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "the retired path is deleted through the prescribed pipeline"
+assert_eq "present" "$([ -f "$P37/.agents/skills/ours/SKILL.md" ] && echo present || echo gone)" \
+  "and the project's own file survives it"
+assert_contains "$APPLY_OUT" "wrote:  .claude/sync-keep.candidate" \
+  "the candidate is written for the human to promote"
+
+# ================================ 22. provenance is content, not a path name
+#
+# Bootstrap deletes without asking a human, so the thing it calls "proof" has to
+# actually be proof. Path membership is not: `.claude/hooks/` is a syncable root
+# and `pre-commit.sh` is a name a template and a project both reach for. These
+# cases are the ones where deleting on the path alone destroys work that no
+# `git checkout` can bring back.
+
+printf '\n-- 22. bootstrap retires content, not names --\n'
+
+P38="$FIXTURE_ROOT/p38"; T38="$FIXTURE_ROOT/t38"
+make_project "$P38"; make_history_template "$T38"
+
+# (a) a pristine synced copy — byte-identical to what the template shipped
+_f "$P38/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+# (b) the same retired file, but this project customised it after syncing
+_f "$P38/.claude/skills/legacy/SKILL.md" "shipped once, retired later
+
+plus a paragraph this project added"
+# (c) a path the template once used, with a file this project wrote itself.
+# The root must keep another file, or emptying it makes the root *skipped* and
+# nothing under it is examined at all.
+_f "$T38/.claude/hooks/pre-push.sh" "another hook, still shipped"
+commit_all "$T38"
+git -C "$T38" rm -q .claude/hooks/session-start.sh 2>/dev/null
+commit_all "$T38"
+_f "$P38/.claude/hooks/session-start.sh" "this project's own hook, never synced"
+commit_all "$P38"
+rm -f "$P38/.claude/sync-keep"
+
+# The template must have carried (b) at that path for the case to be real.
+git -C "$T38" log --oneline >/dev/null 2>&1
+
+run_retire --repo "$P38" --from-dir "$T38"
+assert_eq "0" "$RUN_STATUS" "the mixed bootstrap produces a plan"
+assert_contains "$RUN_OUTPUT" "retire: .agents/skills/legacy/SKILL.md" \
+  "a byte-identical copy of retired template content is retired"
+assert_not_contains "$RUN_OUTPUT" "retire: .claude/skills/legacy/SKILL.md" \
+  "a copy this project edited after syncing is not"
+assert_contains "$RUN_OUTPUT" "candidate: .claude/skills/legacy/SKILL.md" \
+  "it goes to the human, because the edit is what makes it theirs"
+assert_not_contains "$RUN_OUTPUT" "retire: .claude/hooks/session-start.sh" \
+  "a file this project wrote at a path the template once used is never retired"
+assert_contains "$RUN_OUTPUT" "candidate: .claude/hooks/session-start.sh" \
+  "a shared filename is a collision, not provenance"
+
+run_retire --repo "$P38" --from-dir "$T38" --apply
+assert_eq "gone" "$([ -e "$P38/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "--apply removes only the pristine copy"
+assert_file_contains "$P38/.claude/skills/legacy/SKILL.md" "this project added" \
+  "the customised copy survives with its edit intact"
+assert_file_contains "$P38/.claude/hooks/session-start.sh" "never synced" \
+  "and so does the project's own file at the colliding path"
+
+# --- 22.2 uncommitted work is not recoverable, so it is never deleted -------
+#
+# A tracked file whose *working tree* content was modified hashes to something
+# no template commit produced. Comparing the index instead would delete it and
+# `git checkout --` would restore only the committed version, silently losing
+# the edit.
+
+P39="$FIXTURE_ROOT/p39"; T39="$FIXTURE_ROOT/t39"
+make_project "$P39"; make_history_template "$T39"
+_f "$P39/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+commit_all "$P39"
+rm -f "$P39/.claude/sync-keep"
+printf 'shipped once, retired later\nlocal edit not yet committed\n' \
+  > "$P39/.agents/skills/legacy/SKILL.md"
+
+run_retire --repo "$P39" --from-dir "$T39" --apply
+assert_eq "present" "$([ -f "$P39/.agents/skills/legacy/SKILL.md" ] && echo present || echo gone)" \
+  "a file with uncommitted edits is never deleted"
+assert_file_contains "$P39/.agents/skills/legacy/SKILL.md" "local edit not yet committed" \
+  "and the edit git could not restore is still there"
+assert_contains "$RUN_OUTPUT" "candidate: .agents/skills/legacy/SKILL.md" \
+  "it is offered to the human instead"
+
+# --- 22.3 a candidate write that fails after deleting still reports ---------
+#
+# `assert_candidate_writable` checks existence, which is the one failure it can
+# see without trying. Every other one — unwritable dir, read-only mount, ENOSPC
+# — is only discoverable by attempting the write, which is after the deletions.
+
+if [ "$(id -u)" -eq 0 ]; then
+  printf '  skip  22.3 needs an unprivileged user (root ignores permission bits)\n'
+else
+  P40="$FIXTURE_ROOT/p40"; T40="$FIXTURE_ROOT/t40"
+  make_project "$P40"; make_history_template "$T40"
+  _f "$P40/.agents/skills/legacy/SKILL.md" "shipped once, retired later"
+  _f "$P40/.agents/skills/ours/SKILL.md"   "this project's own"
+  commit_all "$P40"
+  rm -f "$P40/.claude/sync-keep"
+  chmod 500 "$P40/.claude"                 # readable and enterable, not writable
+
+  run_retire --repo "$P40" --from-dir "$T40" --apply
+  chmod 700 "$P40/.claude" 2>/dev/null || true
+  assert_eq "1" "$RUN_STATUS" "an unwritable candidate is a non-zero outcome"
+  assert_contains "$RUN_OUTPUT" "deleted: .agents/skills/legacy/SKILL.md" \
+    "and the file it destroyed is still reported by path"
+  assert_contains "$RUN_OUTPUT" "FAILED: cannot write .claude/sync-keep.candidate" \
+    "alongside what it could not write, named separately"
+  assert_not_contains "$RUN_OUTPUT" "Traceback" \
+    "the failure is reported, not raised through the accounting"
+fi
+
+# --- 22.4 the candidate is never written through a dangling symlink ---------
+
+P41="$FIXTURE_ROOT/p41"; T41="$FIXTURE_ROOT/t41"
+make_project "$P41"; make_history_template "$T41"
+_f "$P41/.agents/skills/ours/SKILL.md" "this project's own"
+commit_all "$P41"
+rm -f "$P41/.claude/sync-keep"
+# The target must NOT exist: `os.path.exists` follows the link and reports
+# False for a dangling one, while `open(path, "w")` follows it and *creates*
+# the target. A link to an existing file is refused by either check, so it
+# would test nothing.
+VICTIM41="$FIXTURE_ROOT/victim41-not-yet-there.txt"
+rm -f "$VICTIM41"
+ln -s "$VICTIM41" "$P41/.claude/sync-keep.candidate"
+
+run_retire --repo "$P41" --from-dir "$T41" --apply
+assert_eq "1" "$RUN_STATUS" "a dangling symlink at the candidate path is refused"
+assert_eq "absent" "$([ -e "$VICTIM41" ] && echo created || echo absent)" \
+  "and the tool never writes through it to create the target"
+assert_contains "$RUN_OUTPUT" "sync-keep.candidate already exists" \
+  "the refusal names the path it will not write"
+
+finish

--- a/tests/test-syncable-paths.sh
+++ b/tests/test-syncable-paths.sh
@@ -60,9 +60,16 @@ paths_after_dashdash() {
 
 # --- source 1: the § Syncable Paths doc block --------------------------------
 # Lines inside the fence have the shape `path   → description`.
+# The terminator must match `parse_syncable_roots` in sync-retire.py, which
+# stops at a heading of ANY depth. `##+` rather than `#{2,6}`: mawk does not
+# support interval expressions, so the bounded form silently never matches.
+# When only this one stopped at `^## `, a
+# `### Subsection` inside the block left the script silently scanning fewer
+# roots while this test still saw them all -- the two readers disagreeing is
+# worse than either rule, because the drift test stays green through it.
 extract_doc_block() {
   awk '/^## Syncable Paths/ { inblock = 1; next }
-       inblock && /^## / { exit }
+       inblock && /^##+ / { exit }
        inblock && /→/ { print $1 }' "$1" | normalise
 }
 


### PR DESCRIPTION
Closes #89.

## The problem

`/sync` copied files in and never deleted. Whether a project-only path was
*retired upstream* or *project-specific* was re-decided by a model on every run,
so two runs against one template commit could produce different trees, and a
project could keep a skill the template retired forever.

## The change

`sync-retire.py` replaces that judgement with set arithmetic over a recorded
allowlist:

```
retire = project paths under syncable roots
       - template paths under the same roots
       - paths matching a .claude/sync-keep pattern
```

A project with no allowlist is in **bootstrap**, where the template's git history
supplies the missing record. Provenance there is **content, not path**: a file is
retired only when its working-tree hash matches a blob the template actually
shipped at that path.

That distinction is the one worth reviewing. Path membership alone would delete:

- a file the project wrote itself at a colliding name — `.claude/hooks/` is a
  syncable root and `pre-commit.sh` is a name both a template and a project reach for
- a synced file the project later edited
- a file with uncommitted changes, which `git checkout` could never restore

All three are held as candidates for a human instead. Promoting the candidate is
the only point at which intent gets written down; after that it is data.

## Safety properties, each pinned by a test that goes red when the fix is reverted

- **Nothing may fail between a deletion and the report of it.** The record of what
  was destroyed is the one thing a partial run must not lose. This recurred at four
  separate call sites during review before being closed structurally.
- **Truncated template history is detected by a graft boundary**, so it is found at
  any clone depth and in both `--from-ref` and `--from-dir`. A repository-scoped
  probe broke CI's `--depth 1` projects; a commit count caught only depth 1, letting
  a `--depth 5` clone produce a *different retirement set from the same commit SHA*.
- **git runs against an untrusted template checkout** with `core.fsmonitor` and
  `core.hooksPath` pinned off. Reading that checkout's config would otherwise execute
  it — a working RCE was demonstrated during review, before the user approves anything.
- **A dangling symlink at the candidate path is refused** rather than written through.

## Review

Eleven dispatched reviewers across five rounds, the last a security review that
returned **FAIL** and blocked the push until fixed (`101cdfc`):

- **deletion escaped the repository** — the inventory confirms the leaf with
  `os.path.isfile`, which follows every component, so a symlinked *directory*
  inside a syncable root aimed `os.remove` at files git never tracked here.
  Needs no hostile template; a skill tree symlinked between worktrees is enough.
- **the record was forgeable** — a filename containing a newline emitted a
  well-formed `kept:` line. A run deleted `audit.sh` while telling the operator
  it had kept it. This is the only record of what was destroyed.
- **the untrusted checkout still chose targets** — the earlier git hardening
  enumerated knobs that *execute*; `core.quotePath` executes nothing but decides
  how paths are spelled, and the provenance map was keyed on those strings.

Across all rounds, every MUST-FIX was reproduced before
being fixed and pinned by a mutation probe. Five of my own assertions were found to
certify nothing and were rewritten — including one caught by a reviewer, a
`Traceback` check that `main` had always swallowed.

**Lane finalization** (`b15e6be`) — the earlier version of these notes said
`finalize_reviewers` had not been run. It has now, through the route module's own
API: both dispatched reviewers `completed`, zero unresolved findings, independent
dispatch recorded. It **demoted** the lane, as expected — `_review_demotion` reads
`tripwire_passed` before it looks at any reviewer outcome, and the runtime tripwire
had already recorded an overflow (actual radius 6 against a declared 1: the spec,
the checkpoint and two task details fall outside the declared roots). No reviewer
outcome could have avoided it. The demotion is durable in
`tasks/route-decision.md`'s `downgrades`.

Finalizing also re-rendered the lane checklist from the playbook template and reset
all seven items to unchecked, which is false — every one is done. Restored, and
filed as `route.finalize-discards-lane-completion`: the loss lands at exactly the
moment a reader most needs to know what was already reviewed.

## Tests

33/33 files, 2937 assertions (2927 at the time this was first written; the merge with `master` and the lane finalization added the rest). 329 in the retirement suite, including §21, which runs
the pipeline `SKILL.md` actually prescribes (`git show … | python3 -`) rather than
the on-disk invocation every other test uses, and verifies the `set -o pipefail`
warning that guards it: without it a failed `git show` exits 0 and silent; with it, 128.

## The other three commits

Unrelated to the sync work; all three were found by *running* the wrap-up steps
rather than by reading code.

- `f0f8a06` — `/memory-maintain`'s Phase 1 opened the one `needs_review`
  document expecting missing fields and found a complete one, because **zero**
  documents carried the flag. The session-start banner had reported `1` since
  migration. An earlier fix narrowed *where* to search (excluding the store
  README) when the defect was *what* to match; a document can quote the flag in
  its prose too, and one does — the bug document about this very count. Now
  anchored to the frontmatter field. Its regression test passed against both the
  broken and fixed hook, so it gained a case that discriminates.
- `101cdfc` — the security fixes above.
- `4a69de3` — the pre-push wrap-up gate validates session fingerprints as bare
  hex, so the conventional `[<base>..HEAD]` is rejected and every code commit is
  logged as uncovered debt. It is an ordering problem: the summary is written in
  Step 2 and the commit happens in Step 7, so the final SHA does not exist yet.
  The constraint is now stated in the step.

## Known gaps

- No downstream project has run the candidate-promotion flow end to end.
- A template whose history is deep but whose blobs were pruned by a filtered clone is
  untested; `--filter=blob:none` fetches them on demand.

