### PR TITLE
fix(task-registry): refuse a task-tracking pointer whose target is missing (#82)

### DIFF
--- a/.agents/skills/task-registry/SKILL.md
+++ b/.agents/skills/task-registry/SKILL.md
@@ -124,7 +124,8 @@ write to a company tracker.
 
 The configuration document is `docs/task-tracking.md`, or wherever a
 `Task tracking instructions: <path>` line in `AGENTS.md`, `CLAUDE.md`, or
-`.claude/project.md` points. Copy `templates/task-tracking.md` to start one.
+`.claude/project.md` points. Copy `templates/task-tracking.md` to start one. A
+pointer whose target is missing is refused, naming the path — never defaulted.
 Full field reference, provider examples, and troubleshooting:
 `references/configuration.md`.
 

--- a/.agents/skills/task-registry/references/configuration.md
+++ b/.agents/skills/task-registry/references/configuration.md
@@ -18,6 +18,13 @@ The registry looks for its configuration in this order:
 3. nothing — configuration defaults apply; provider auto-selection still follows
    the table below.
 
+A pointer is a declaration. One whose target is missing or outside the project
+root is refused, naming the declaring file and the path it named — it is never
+read as "no configuration", because a project that says it is configured and is
+running on defaults is the failure nobody notices. Only step 3, no pointer and no
+default file, is silent. `doctor` still runs on a broken pointer and reports it
+on its `configuration:` line; every other command exits non-zero.
+
 Every path the configuration names — the pointer target, the index, the detail
 directory — must resolve inside the project root. One that escapes is refused,
 because the configuration arrives as a file in the repository and a file in the

--- a/.agents/skills/task-registry/scripts/registry/config.py
+++ b/.agents/skills/task-registry/scripts/registry/config.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 CONFIG_DEFAULT_PATH = "docs/task-tracking.md"
+CONFIG_TEMPLATE_PATH = ".agents/skills/task-registry/templates/task-tracking.md"
 #: Searched in order, first hit wins. Project-owned files come first: `.claude/
 #: project.md` and `AGENTS.md` are written by the team, while `CLAUDE.md` is
 #: template-managed and overwritten by `/sync` — a pointer there is the least
@@ -120,6 +121,15 @@ DEFAULT_JIRA_PRIORITIES: Mapping[str, str] = {
 
 class ConfigError(Exception):
     """The configuration exists but cannot be read as configuration."""
+
+
+class ConfigPointerError(ConfigError):
+    """A project-instruction pointer names a configuration file that cannot be used.
+
+    Missing target or a target outside the project root. Kept distinct from a
+    malformed file because `doctor` reports it on the `configuration:` line —
+    there is no loaded file for a routines fault to belong to.
+    """
 
 
 class Secret:
@@ -250,25 +260,59 @@ def _as_bool(value: str, default: bool) -> bool:
 
 
 def find_config_path(root: str) -> Optional[str]:
-    """Resolve the configuration document, following a project-instruction pointer."""
+    """Resolve the configuration document, following a project-instruction pointer.
+
+    Three states, and only the first is silent:
+
+      * no pointer anywhere — the default path when present, else None;
+      * a pointer whose target exists — that file;
+      * a pointer whose target is missing or escapes the root — ConfigPointerError.
+
+    The third is a declared intent with a broken target. Folding it into the
+    first made a project run on defaults while its own instructions said it was
+    configured, and nothing said so (#82). The first pointer found wins, broken
+    or not: a dangling `.claude/project.md` pointer is not rescued by a valid
+    `CLAUDE.md` one, because the most authoritative declaration is the wrong one.
+    """
     for pointer_file in POINTER_FILES:
-        absolute = os.path.join(root, pointer_file)
-        if not os.path.isfile(absolute):
+        declared = _declared_pointer(root, pointer_file)
+        if declared is None:
             continue
-        with open(absolute, "r", encoding="utf-8-sig") as handle:
-            match = POINTER_RE.search(handle.read())
-        if match:
-            # The pointer is read out of a repository file, so it is untrusted
-            # input: `Task tracking instructions: ../../etc/shadow` would
-            # otherwise be opened and echoed back in a parse error.
-            try:
-                candidate = confine(root, match.group(1), "task tracking pointer")
-            except ConfigError:
-                continue
-            if os.path.isfile(candidate):
-                return candidate
+        # The pointer is read out of a repository file, so it is untrusted
+        # input: `Task tracking instructions: ../../etc/shadow` is echoed back
+        # in the refusal, never opened.
+        try:
+            candidate = confine(root, declared, "task tracking pointer")
+        except ConfigError as exc:
+            raise ConfigPointerError(f"{pointer_file}: {exc}") from exc
+        if not os.path.isfile(candidate):
+            # ``!r`` matches ``confine``: the pointer is repository text, so it is
+            # echoed escaped, never raw, to a terminal or an agent's context.
+            state = "exists but is not a file" if os.path.exists(candidate) else "does not exist"
+            raise ConfigPointerError(
+                f"{pointer_file} declares `Task tracking instructions: {declared!r}`, "
+                f"but {declared!r} {state} — create it from {CONFIG_TEMPLATE_PATH}, "
+                "or remove the pointer"
+            )
+        return candidate
     default = os.path.join(root, CONFIG_DEFAULT_PATH)
     return default if os.path.isfile(default) else None
+
+
+def _declared_pointer(root: str, pointer_file: str) -> Optional[str]:
+    """The path a project-instruction file points at, or None if it has no pointer."""
+    absolute = os.path.join(root, pointer_file)
+    if not os.path.isfile(absolute):
+        return None
+    with open(absolute, "r", encoding="utf-8-sig") as handle:
+        match = POINTER_RE.search(handle.read())
+    if not match:
+        return None
+    # A prose mention can end the sentence the pointer sits in: `...: docs/
+    # task-tracking.md.` names `docs/task-tracking.md`, and reading the period
+    # as part of the path would turn a working project into a refusal.
+    declared = match.group(1).rstrip(".,;:!?)")
+    return declared or None
 
 
 def _parse_ini(text: str, source: str) -> configparser.ConfigParser:
@@ -276,7 +320,7 @@ def _parse_ini(text: str, source: str) -> configparser.ConfigParser:
     if not match:
         raise ConfigError(
             f"{source}: no ```ini configuration block found "
-            "(see .agents/skills/task-registry/templates/task-tracking.md)"
+            f"(see {CONFIG_TEMPLATE_PATH})"
         )
     parser = configparser.ConfigParser()
     parser.optionxform = str  # labels are case-sensitive provider vocabulary
@@ -290,12 +334,22 @@ def _parse_ini(text: str, source: str) -> configparser.ConfigParser:
 def load_config(
     root: str,
     env: Optional[Mapping[str, str]] = None,
-    validate_routines: bool = True,
+    strict: bool = True,
 ) -> Config:
     """Load configuration, or return defaults when the project has none.
 
     An absent configuration is not an error — that is the whole point of the
-    local fallback. A *malformed* one is.
+    local fallback. A *malformed* one is, and so is a *declared* one whose file
+    cannot be used: a pointer with no target is a configured project, broken,
+    not an unconfigured one.
+
+    `strict=False` is for `doctor` alone. It is the command a user runs BECAUSE
+    configuration is broken, so refusing to load would make the diagnostic
+    unreachable exactly when it is needed. Non-strict loading covers exactly two
+    faults — a broken pointer (defaults are returned) and routine validation
+    (skipped); the caller reports the fault it already caught. A target that
+    exists but cannot be parsed still raises, strict or not. Every other command
+    inherits the guarantees.
     """
     env = env if env is not None else os.environ
     jira = dict(
@@ -303,7 +357,12 @@ def load_config(
         jira_email=env.get("JIRA_EMAIL", ""),
         jira_token=Secret(env.get("JIRA_API_TOKEN", "")),
     )
-    config_path = find_config_path(root)
+    try:
+        config_path = find_config_path(root)
+    except ConfigPointerError:
+        if strict:
+            raise
+        config_path = None
     if config_path is None:
         return Config(root=root, **jira)
 
@@ -370,11 +429,7 @@ def load_config(
     # contested label makes selection depend on dict insertion order, and a gate
     # that only fires when a human types `selectors` does not protect the
     # unattended runs that are the whole point. Every command inherits it.
-    # `doctor` is the one caller that passes False: it is the command a user runs
-    # BECAUSE configuration is broken, so refusing to load would make the
-    # diagnostic unreachable exactly when it is needed. It reports the fault
-    # instead. Every other command still inherits the guarantee.
-    if validate_routines:
+    if strict:
         validate_selectors(config)
     return config
 

--- a/.agents/skills/task-registry/scripts/task-registry.py
+++ b/.agents/skills/task-registry/scripts/task-registry.py
@@ -26,6 +26,7 @@ import argparse
 import os
 import sys
 import traceback
+from typing import Optional
 
 # Set before the package is imported, and deliberately: this package lives inside
 # a *skills tree*, where `.agents/skills/` and `.claude/skills/` are pinned
@@ -36,7 +37,12 @@ sys.dont_write_bytecode = True
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from registry.config import ConfigError, load_config, select_provider  # noqa: E402
+from registry.config import (  # noqa: E402
+    ConfigError,
+    ConfigPointerError,
+    load_config,
+    select_provider,
+)
 from registry.migrate import apply_migration, plan_migration  # noqa: E402
 from registry.providers import build_provider  # noqa: E402
 from registry.providers.base import (  # noqa: E402
@@ -167,15 +173,15 @@ def _run(argv, set_redactor) -> int:
             print("task-registry: `upsert` requires --title", file=sys.stderr)
             return 2
 
-    routine_fault = None
+    config_fault = None
     try:
         config = load_config(root)
     except ConfigError as exc:
         if args.command != "doctor":
             print(f"task-registry: {exc}", file=sys.stderr)
             return 1
-        routine_fault = str(exc)
-        config = load_config(root, validate_routines=False)
+        config_fault = exc
+        config = load_config(root, strict=False)
     set_redactor(redactor_for(config))
 
     selection = select_provider(config)
@@ -198,7 +204,7 @@ def _run(argv, set_redactor) -> int:
 
     registry = Registry(config, provider, selection_reason=reason)
     try:
-        args.routine_fault = routine_fault
+        args.config_fault = config_fault
         output, code = _dispatch(args, config, registry, apply_writes)
     except WriteNotAuthorized as exc:
         print(f"task-registry: {exc}", file=sys.stderr)
@@ -237,7 +243,7 @@ def _dispatch(args, config, registry: Registry, apply_writes: bool):
         lines, code = upsert_task(registry, task, apply_writes)
         return ("\n".join(lines), code)
     if command == "doctor":
-        return _doctor(registry, args.routine_fault), (1 if args.routine_fault else 0)
+        return _doctor(registry, args.config_fault), (1 if args.config_fault else 0)
     if command == "selectors":
         return _selectors(registry)
     if command == "select":
@@ -267,14 +273,21 @@ def _dispatch(args, config, registry: Registry, apply_writes: bool):
     return report.render(verbose=args.verbose), report.exit_code
 
 
-def _doctor(registry: Registry, routine_fault=None) -> str:
-    """Answer 'which tracker am I talking to, and why' without touching anything."""
+def _doctor(registry: Registry, fault: Optional[ConfigError] = None) -> str:
+    """Answer 'which tracker am I talking to, and why' without touching anything.
+
+    `fault` is whatever strict loading refused. A pointer fault belongs on the
+    `configuration:` line — no file loaded, so "none" would be a lie (#82); any
+    other fault is a loaded file whose [routines] block is inconsistent.
+    """
     status = registry.provider.discover()
     config = registry.config
+    pointer_fault = fault if isinstance(fault, ConfigPointerError) else None
+    routine_fault = None if pointer_fault else fault
     lines = [
         f"provider:       {registry.provider.name}",
         f"selected because: {registry.selection_reason}",
-        f"configuration:  {config.source_path or 'none (defaults + local fallback)'}",
+        f"configuration:  {_configuration_line(config, pointer_fault)}",
         f"index:          {config.index_path}",
         f"capabilities:   {registry.provider.capabilities.render()}",
         f"reachable:      {'yes' if status.available else 'no'} — {status.detail}",
@@ -288,13 +301,18 @@ def _doctor(registry: Registry, routine_fault=None) -> str:
         f"offline reads:  {config.offline_reads}",
     ]
     if routine_fault:
-        lines.append(
-            f"routines:       MISCONFIGURED — {routine_fault}\n"
-            "  Every command except this one refuses to run until it is fixed."
-        )
+        lines.append(f"routines:       MISCONFIGURED — {routine_fault}")
     else:
         lines.append(f"routines:       {' > '.join(config.kind_precedence)}")
+    if fault:
+        lines.append("  Every command except this one refuses to run until it is fixed.")
     return "\n".join(lines)
+
+
+def _configuration_line(config, pointer_fault) -> str:
+    if pointer_fault:
+        return f"BROKEN — {pointer_fault}"
+    return config.source_path or "none (defaults + local fallback)"
 
 
 def _selectors(registry: Registry):

--- a/.agents/skills/task-registry/templates/task-tracking.md
+++ b/.agents/skills/task-registry/templates/task-tracking.md
@@ -2,8 +2,8 @@
 
 > Copy this file to `docs/task-tracking.md` in your project and edit the block
 > below. Discovery finds it there automatically; to keep it elsewhere, add a line
-> `Task tracking instructions: <path>` to `AGENTS.md`, `CLAUDE.md`, or
-> `.claude/project.md`.
+> `Task tracking instructions: <path>` to `.claude/project.md` (Claude Code) or
+> `AGENTS.md` (Pi) — never to `CLAUDE.md`, which `/sync` overwrites.
 >
 > Read by `/task-registry`. Everything is optional — without configuration,
 > selection still prefers GitHub when a GitHub remote and an authenticated `gh`

--- a/.claude/skills/task-registry/SKILL.md
+++ b/.claude/skills/task-registry/SKILL.md
@@ -124,7 +124,8 @@ write to a company tracker.
 
 The configuration document is `docs/task-tracking.md`, or wherever a
 `Task tracking instructions: <path>` line in `AGENTS.md`, `CLAUDE.md`, or
-`.claude/project.md` points. Copy `templates/task-tracking.md` to start one.
+`.claude/project.md` points. Copy `templates/task-tracking.md` to start one. A
+pointer whose target is missing is refused, naming the path — never defaulted.
 Full field reference, provider examples, and troubleshooting:
 `references/configuration.md`.
 

--- a/.claude/skills/task-registry/references/configuration.md
+++ b/.claude/skills/task-registry/references/configuration.md
@@ -18,6 +18,13 @@ The registry looks for its configuration in this order:
 3. nothing — configuration defaults apply; provider auto-selection still follows
    the table below.
 
+A pointer is a declaration. One whose target is missing or outside the project
+root is refused, naming the declaring file and the path it named — it is never
+read as "no configuration", because a project that says it is configured and is
+running on defaults is the failure nobody notices. Only step 3, no pointer and no
+default file, is silent. `doctor` still runs on a broken pointer and reports it
+on its `configuration:` line; every other command exits non-zero.
+
 Every path the configuration names — the pointer target, the index, the detail
 directory — must resolve inside the project root. One that escapes is refused,
 because the configuration arrives as a file in the repository and a file in the

--- a/.claude/skills/task-registry/scripts/registry/config.py
+++ b/.claude/skills/task-registry/scripts/registry/config.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 CONFIG_DEFAULT_PATH = "docs/task-tracking.md"
+CONFIG_TEMPLATE_PATH = ".agents/skills/task-registry/templates/task-tracking.md"
 #: Searched in order, first hit wins. Project-owned files come first: `.claude/
 #: project.md` and `AGENTS.md` are written by the team, while `CLAUDE.md` is
 #: template-managed and overwritten by `/sync` — a pointer there is the least
@@ -120,6 +121,15 @@ DEFAULT_JIRA_PRIORITIES: Mapping[str, str] = {
 
 class ConfigError(Exception):
     """The configuration exists but cannot be read as configuration."""
+
+
+class ConfigPointerError(ConfigError):
+    """A project-instruction pointer names a configuration file that cannot be used.
+
+    Missing target or a target outside the project root. Kept distinct from a
+    malformed file because `doctor` reports it on the `configuration:` line —
+    there is no loaded file for a routines fault to belong to.
+    """
 
 
 class Secret:
@@ -250,25 +260,59 @@ def _as_bool(value: str, default: bool) -> bool:
 
 
 def find_config_path(root: str) -> Optional[str]:
-    """Resolve the configuration document, following a project-instruction pointer."""
+    """Resolve the configuration document, following a project-instruction pointer.
+
+    Three states, and only the first is silent:
+
+      * no pointer anywhere — the default path when present, else None;
+      * a pointer whose target exists — that file;
+      * a pointer whose target is missing or escapes the root — ConfigPointerError.
+
+    The third is a declared intent with a broken target. Folding it into the
+    first made a project run on defaults while its own instructions said it was
+    configured, and nothing said so (#82). The first pointer found wins, broken
+    or not: a dangling `.claude/project.md` pointer is not rescued by a valid
+    `CLAUDE.md` one, because the most authoritative declaration is the wrong one.
+    """
     for pointer_file in POINTER_FILES:
-        absolute = os.path.join(root, pointer_file)
-        if not os.path.isfile(absolute):
+        declared = _declared_pointer(root, pointer_file)
+        if declared is None:
             continue
-        with open(absolute, "r", encoding="utf-8-sig") as handle:
-            match = POINTER_RE.search(handle.read())
-        if match:
-            # The pointer is read out of a repository file, so it is untrusted
-            # input: `Task tracking instructions: ../../etc/shadow` would
-            # otherwise be opened and echoed back in a parse error.
-            try:
-                candidate = confine(root, match.group(1), "task tracking pointer")
-            except ConfigError:
-                continue
-            if os.path.isfile(candidate):
-                return candidate
+        # The pointer is read out of a repository file, so it is untrusted
+        # input: `Task tracking instructions: ../../etc/shadow` is echoed back
+        # in the refusal, never opened.
+        try:
+            candidate = confine(root, declared, "task tracking pointer")
+        except ConfigError as exc:
+            raise ConfigPointerError(f"{pointer_file}: {exc}") from exc
+        if not os.path.isfile(candidate):
+            # ``!r`` matches ``confine``: the pointer is repository text, so it is
+            # echoed escaped, never raw, to a terminal or an agent's context.
+            state = "exists but is not a file" if os.path.exists(candidate) else "does not exist"
+            raise ConfigPointerError(
+                f"{pointer_file} declares `Task tracking instructions: {declared!r}`, "
+                f"but {declared!r} {state} — create it from {CONFIG_TEMPLATE_PATH}, "
+                "or remove the pointer"
+            )
+        return candidate
     default = os.path.join(root, CONFIG_DEFAULT_PATH)
     return default if os.path.isfile(default) else None
+
+
+def _declared_pointer(root: str, pointer_file: str) -> Optional[str]:
+    """The path a project-instruction file points at, or None if it has no pointer."""
+    absolute = os.path.join(root, pointer_file)
+    if not os.path.isfile(absolute):
+        return None
+    with open(absolute, "r", encoding="utf-8-sig") as handle:
+        match = POINTER_RE.search(handle.read())
+    if not match:
+        return None
+    # A prose mention can end the sentence the pointer sits in: `...: docs/
+    # task-tracking.md.` names `docs/task-tracking.md`, and reading the period
+    # as part of the path would turn a working project into a refusal.
+    declared = match.group(1).rstrip(".,;:!?)")
+    return declared or None
 
 
 def _parse_ini(text: str, source: str) -> configparser.ConfigParser:
@@ -276,7 +320,7 @@ def _parse_ini(text: str, source: str) -> configparser.ConfigParser:
     if not match:
         raise ConfigError(
             f"{source}: no ```ini configuration block found "
-            "(see .agents/skills/task-registry/templates/task-tracking.md)"
+            f"(see {CONFIG_TEMPLATE_PATH})"
         )
     parser = configparser.ConfigParser()
     parser.optionxform = str  # labels are case-sensitive provider vocabulary
@@ -290,12 +334,22 @@ def _parse_ini(text: str, source: str) -> configparser.ConfigParser:
 def load_config(
     root: str,
     env: Optional[Mapping[str, str]] = None,
-    validate_routines: bool = True,
+    strict: bool = True,
 ) -> Config:
     """Load configuration, or return defaults when the project has none.
 
     An absent configuration is not an error — that is the whole point of the
-    local fallback. A *malformed* one is.
+    local fallback. A *malformed* one is, and so is a *declared* one whose file
+    cannot be used: a pointer with no target is a configured project, broken,
+    not an unconfigured one.
+
+    `strict=False` is for `doctor` alone. It is the command a user runs BECAUSE
+    configuration is broken, so refusing to load would make the diagnostic
+    unreachable exactly when it is needed. Non-strict loading covers exactly two
+    faults — a broken pointer (defaults are returned) and routine validation
+    (skipped); the caller reports the fault it already caught. A target that
+    exists but cannot be parsed still raises, strict or not. Every other command
+    inherits the guarantees.
     """
     env = env if env is not None else os.environ
     jira = dict(
@@ -303,7 +357,12 @@ def load_config(
         jira_email=env.get("JIRA_EMAIL", ""),
         jira_token=Secret(env.get("JIRA_API_TOKEN", "")),
     )
-    config_path = find_config_path(root)
+    try:
+        config_path = find_config_path(root)
+    except ConfigPointerError:
+        if strict:
+            raise
+        config_path = None
     if config_path is None:
         return Config(root=root, **jira)
 
@@ -370,11 +429,7 @@ def load_config(
     # contested label makes selection depend on dict insertion order, and a gate
     # that only fires when a human types `selectors` does not protect the
     # unattended runs that are the whole point. Every command inherits it.
-    # `doctor` is the one caller that passes False: it is the command a user runs
-    # BECAUSE configuration is broken, so refusing to load would make the
-    # diagnostic unreachable exactly when it is needed. It reports the fault
-    # instead. Every other command still inherits the guarantee.
-    if validate_routines:
+    if strict:
         validate_selectors(config)
     return config
 

--- a/.claude/skills/task-registry/scripts/task-registry.py
+++ b/.claude/skills/task-registry/scripts/task-registry.py
@@ -26,6 +26,7 @@ import argparse
 import os
 import sys
 import traceback
+from typing import Optional
 
 # Set before the package is imported, and deliberately: this package lives inside
 # a *skills tree*, where `.agents/skills/` and `.claude/skills/` are pinned
@@ -36,7 +37,12 @@ sys.dont_write_bytecode = True
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from registry.config import ConfigError, load_config, select_provider  # noqa: E402
+from registry.config import (  # noqa: E402
+    ConfigError,
+    ConfigPointerError,
+    load_config,
+    select_provider,
+)
 from registry.migrate import apply_migration, plan_migration  # noqa: E402
 from registry.providers import build_provider  # noqa: E402
 from registry.providers.base import (  # noqa: E402
@@ -167,15 +173,15 @@ def _run(argv, set_redactor) -> int:
             print("task-registry: `upsert` requires --title", file=sys.stderr)
             return 2
 
-    routine_fault = None
+    config_fault = None
     try:
         config = load_config(root)
     except ConfigError as exc:
         if args.command != "doctor":
             print(f"task-registry: {exc}", file=sys.stderr)
             return 1
-        routine_fault = str(exc)
-        config = load_config(root, validate_routines=False)
+        config_fault = exc
+        config = load_config(root, strict=False)
     set_redactor(redactor_for(config))
 
     selection = select_provider(config)
@@ -198,7 +204,7 @@ def _run(argv, set_redactor) -> int:
 
     registry = Registry(config, provider, selection_reason=reason)
     try:
-        args.routine_fault = routine_fault
+        args.config_fault = config_fault
         output, code = _dispatch(args, config, registry, apply_writes)
     except WriteNotAuthorized as exc:
         print(f"task-registry: {exc}", file=sys.stderr)
@@ -237,7 +243,7 @@ def _dispatch(args, config, registry: Registry, apply_writes: bool):
         lines, code = upsert_task(registry, task, apply_writes)
         return ("\n".join(lines), code)
     if command == "doctor":
-        return _doctor(registry, args.routine_fault), (1 if args.routine_fault else 0)
+        return _doctor(registry, args.config_fault), (1 if args.config_fault else 0)
     if command == "selectors":
         return _selectors(registry)
     if command == "select":
@@ -267,14 +273,21 @@ def _dispatch(args, config, registry: Registry, apply_writes: bool):
     return report.render(verbose=args.verbose), report.exit_code
 
 
-def _doctor(registry: Registry, routine_fault=None) -> str:
-    """Answer 'which tracker am I talking to, and why' without touching anything."""
+def _doctor(registry: Registry, fault: Optional[ConfigError] = None) -> str:
+    """Answer 'which tracker am I talking to, and why' without touching anything.
+
+    `fault` is whatever strict loading refused. A pointer fault belongs on the
+    `configuration:` line — no file loaded, so "none" would be a lie (#82); any
+    other fault is a loaded file whose [routines] block is inconsistent.
+    """
     status = registry.provider.discover()
     config = registry.config
+    pointer_fault = fault if isinstance(fault, ConfigPointerError) else None
+    routine_fault = None if pointer_fault else fault
     lines = [
         f"provider:       {registry.provider.name}",
         f"selected because: {registry.selection_reason}",
-        f"configuration:  {config.source_path or 'none (defaults + local fallback)'}",
+        f"configuration:  {_configuration_line(config, pointer_fault)}",
         f"index:          {config.index_path}",
         f"capabilities:   {registry.provider.capabilities.render()}",
         f"reachable:      {'yes' if status.available else 'no'} — {status.detail}",
@@ -288,13 +301,18 @@ def _doctor(registry: Registry, routine_fault=None) -> str:
         f"offline reads:  {config.offline_reads}",
     ]
     if routine_fault:
-        lines.append(
-            f"routines:       MISCONFIGURED — {routine_fault}\n"
-            "  Every command except this one refuses to run until it is fixed."
-        )
+        lines.append(f"routines:       MISCONFIGURED — {routine_fault}")
     else:
         lines.append(f"routines:       {' > '.join(config.kind_precedence)}")
+    if fault:
+        lines.append("  Every command except this one refuses to run until it is fixed.")
     return "\n".join(lines)
+
+
+def _configuration_line(config, pointer_fault) -> str:
+    if pointer_fault:
+        return f"BROKEN — {pointer_fault}"
+    return config.source_path or "none (defaults + local fallback)"
 
 
 def _selectors(registry: Registry):

--- a/.claude/skills/task-registry/templates/task-tracking.md
+++ b/.claude/skills/task-registry/templates/task-tracking.md
@@ -2,8 +2,8 @@
 
 > Copy this file to `docs/task-tracking.md` in your project and edit the block
 > below. Discovery finds it there automatically; to keep it elsewhere, add a line
-> `Task tracking instructions: <path>` to `AGENTS.md`, `CLAUDE.md`, or
-> `.claude/project.md`.
+> `Task tracking instructions: <path>` to `.claude/project.md` (Claude Code) or
+> `AGENTS.md` (Pi) — never to `CLAUDE.md`, which `/sync` overwrites.
 >
 > Read by `/task-registry`. Everything is optional — without configuration,
 > selection still prefers GitHub when a GitHub remote and an authenticated `gh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,15 +415,21 @@ dependency marker. Acceptance criteria, discussion, and evidence live in the
 external ticket or the linked spec, and are read one task at a time via
 `/task-registry show <task-id>`.
 
-Task tracking instructions: docs/task-tracking.md
-
-That file is the project's configuration contract: provider (`github`, `jira`, or
-`local`), repository/project identifier, label and status mappings, local detail
+The project's configuration contract is `docs/task-tracking.md`, or wherever a
+`Task tracking instructions: <path>` line in `.claude/project.md` (or `AGENTS.md`
+for Pi) points. That file declares: provider (`github`, `jira`, or `local`),
+repository/project identifier, label and status mappings, local detail
 directory, dependency strategy, whether external writes need approval, migration
 policy, and offline behaviour. It is optional — without one, provider selection
 still prefers GitHub when a GitHub remote and an authenticated `gh` both exist,
 then falls back to local Markdown. Start from
 `.agents/skills/task-registry/templates/task-tracking.md`.
+
+A pointer whose target is missing is refused, naming the path and the file that
+declared it — a declared configuration that cannot be read is broken, not absent.
+Put the pointer in `.claude/project.md` or `AGENTS.md`, never in this file: it is
+template-managed and `docs/` is outside every syncable root, so a live pointer
+here would ship to every project with a target the template can never deliver.
 
 It is optional, but **its absence is not the same as choosing `local`.** With no
 configuration the provider is resolved in order: an explicit `provider =` wins;

--- a/specs/task-registry.md
+++ b/specs/task-registry.md
@@ -89,7 +89,9 @@ copied into `tasks/todo.md`.
 - `docs/task-tracking.md` — the project configuration contract (an ```ini fenced
   block parsed with `configparser`). Discovered directly, or through a
   `Task tracking instructions: <path>` pointer in `AGENTS.md`, `CLAUDE.md`, or
-  `.claude/project.md`.
+  `.claude/project.md`. A pointer whose target is missing is refused, naming
+  the declaring file and the path (#82) — only "no pointer, no default file"
+  is silent.
 - `tasks/todo.md` — the compact local index.
 - `tasks/backlog.md`, `specs/`, `specs/pending/`, `specs/completed/` — reconciled inputs.
 - Environment: `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, `JIRA_PROJECT`.

--- a/tasks/checkpoint.md
+++ b/tasks/checkpoint.md
@@ -1,76 +1,33 @@
-# Checkpoint — 2026-09-05T17:30:21Z
+# Checkpoint — 2026-09-06T23:40:31Z
 
 > Auto-written by PreCompact hook (trigger: auto). Re-read on resume.
 
 ## Git
-- Branch: analysis/simplify-routing
+- Branch: Joaovsales/task-tracking-config-a-pointer-to-a-missing-file
 
 ```
-M  .agents/skills/auto-improve/SKILL.md
-M  .agents/skills/memory-maintain/SKILL.md
-D  .agents/skills/route/SKILL.md
-D  .agents/skills/route/playbooks/autonomous.md
-D  .agents/skills/route/playbooks/gated-at-plan-and-pre-push.md
-D  .agents/skills/route/playbooks/gated-at-plan.md
-D  .agents/skills/route/scripts/route_issue.py
-M  .agents/skills/task-registry/scripts/registry/config.py
-M  .agents/skills/task-registry/scripts/registry/providers/base.py
-M  .agents/skills/task-registry/scripts/registry/providers/github.py
-A  .agents/skills/task-registry/scripts/registry/routines.py
-M  .agents/skills/task-registry/scripts/task-registry.py
-M  .agents/skills/task-registry/templates/task-tracking.md
-M  .agents/skills/wrap-up-session/SKILL.md
-A  .agents/skills/wrap-up-session/references/routines.md
-A  .agents/skills/wrap-up-session/scripts/routine_branch.py
-M  .claude/hooks/session-start.sh
-D  .claude/hooks/user-prompt-route.sh
-M  .claude/settings.json
-M  .claude/skills/auto-improve/SKILL.md
-M  .claude/skills/memory-maintain/SKILL.md
-D  .claude/skills/route/SKILL.md
-D  .claude/skills/route/playbooks/autonomous.md
-D  .claude/skills/route/playbooks/gated-at-plan-and-pre-push.md
-D  .claude/skills/route/playbooks/gated-at-plan.md
-D  .claude/skills/route/scripts/route_issue.py
-M  .claude/skills/task-registry/scripts/registry/config.py
-M  .claude/skills/task-registry/scripts/registry/providers/base.py
-M  .claude/skills/task-registry/scripts/registry/providers/github.py
-A  .claude/skills/task-registry/scripts/registry/routines.py
-M  .claude/skills/task-registry/scripts/task-registry.py
-M  .claude/skills/task-registry/templates/task-tracking.md
-M  .claude/skills/wrap-up-session/SKILL.md
-A  .claude/skills/wrap-up-session/references/routines.md
-A  .claude/skills/wrap-up-session/scripts/routine_branch.py
-M  CLAUDE.md
-M  README.md
-A  specs/category-routines.md
-D  specs/issue-lane-routing.md
-MM tasks/checkpoint.md
-M  tasks/history.md
-A  tasks/solutions/architecture/a-bidirectional-map-cannot-be-widened-for-one-direction.md
-M  tasks/solutions/architecture/hard-gate-on-tasks-todo-md.md
-M  tasks/solutions/bugs/grep-zero-matches-aborts-hooks-under-set-e-pipefail.md
-M  tasks/solutions/patterns/consume-structured-records-before-rendering-human-summaries.md
-A  tasks/solutions/patterns/shape-validation-cannot-catch-a-membership-error.md
-A  tasks/solutions/patterns/validate-in-the-loader-not-in-one-optional-command.md
-M  tasks/todo.md
-M  tasks/wrap-up-debt.md
-A  tests/test-auto-improve-rewire.sh
-M  tests/test-doc-conventions.sh
-M  tests/test-model-tiers.sh
-M  tests/test-review-context.sh
-D  tests/test-route-decision.sh
-D  tests/test-route-hook.sh
-D  tests/test-route-skill.sh
-A  tests/test-routine-branch.sh
-A  tests/test-routine-selectors.sh
-A  tests/test-routine-step-ledger.sh
-A  tests/test-routine-wrapup.sh
-A  tests/test-routines-contract.sh
-M  tests/test-session-start.sh
-M  tests/test-skill-invocation-chain.sh
-M  tests/test-task-registry.sh
-?? tasks/tmp/
+ M .agents/skills/task-registry/SKILL.md
+ M .agents/skills/task-registry/references/configuration.md
+ M .agents/skills/task-registry/scripts/registry/config.py
+ M .agents/skills/task-registry/scripts/task-registry.py
+ M .agents/skills/task-registry/templates/task-tracking.md
+ M .claude/skills/task-registry/SKILL.md
+ M .claude/skills/task-registry/references/configuration.md
+ M .claude/skills/task-registry/scripts/registry/config.py
+ M .claude/skills/task-registry/scripts/task-registry.py
+ M .claude/skills/task-registry/templates/task-tracking.md
+ M CLAUDE.md
+ M specs/task-registry.md
+ M tasks/checkpoint.md
+ M tasks/e2e-log.md
+ M tasks/history.md
+ M tasks/solutions/bugs/grep-zero-matches-aborts-hooks-under-set-e-pipefail.md
+ M tasks/solutions/process/issue-lane-routing-e2e-gap.md
+ M tasks/todo.md
+ M tests/test-doc-conventions.sh
+ M tests/test-task-registry.sh
+?? tasks/solutions/bugs/task-tracking-pointer-to-a-missing-file-was-indistinguishable-from-no-pointer.md
+?? tasks/solutions/patterns/a-declared-intent-with-a-broken-target-is-not-an-absent-one.md
 ```
 
 ## In-Progress & Pending Tasks (tasks/todo.md)
@@ -81,5 +38,6 @@ M  tests/test-task-registry.sh
 
 ## How to Resume
 1. Read this file and `tasks/todo.md`
-2. Grep `tasks/solutions/` frontmatter (problem_type, module, tags) for relevant learnings
+2. Read `tasks/memory.md` for project context
 3. Continue from the first `[~]` (or `[ ]`) item in `tasks/todo.md`
+rst `[~]` (or `[ ]`) item in `tasks/todo.md`

--- a/tasks/e2e-log.md
+++ b/tasks/e2e-log.md
@@ -249,3 +249,36 @@ is #98's subject.
 
 Result: PASS for the composition above; the host-level gap is recorded, not
 claimed as covered.
+
+## Integration Proof — task-tracking pointer states (#82) — 2026-09-06 (branch `Joaovsales/task-tracking-config-a-pointer-to-a-missing-file`, uncommitted)
+
+Spec: `specs/task-registry.md` (one-line note under configuration discovery).
+The surface is the CLI alone — `task-registry doctor` and the refusal preamble of
+every other command — so the walkthrough is six throwaway projects run through
+the real script, not a browser session.
+
+### What ran
+
+| project | pointer | `doctor` configuration line | `doctor` exit |
+|---|---|---|---|
+| none | no pointer, no default file | `none (defaults + local fallback)` | 0 |
+| ok | `CLAUDE.md` → existing `docs/tracking.md` | `docs/tracking.md` | 0 |
+| missing | `CLAUDE.md` → absent `docs/tracking.md` | `BROKEN — CLAUDE.md declares \`Task tracking instructions: 'docs/tracking.md'\`, but 'docs/tracking.md' does not exist — create it from .agents/skills/task-registry/templates/task-tracking.md, or remove the pointer` | 1 |
+| dir | `CLAUDE.md` → `docs` (a directory) | `BROKEN — … 'docs' exists but is not a file — …` | 1 |
+| prose | `.claude/project.md` sentence ending `docs/tracking.md.` with the file present | `docs/tracking.md` | 0 |
+| escape | `AGENTS.md` → `../../etc/passwd` | `BROKEN — AGENTS.md: task tracking pointer '../../etc/passwd' resolves outside the project root — refusing to use it` | 1 |
+
+Every BROKEN diagnosis is followed by `Every command except this one refuses to
+run until it is fixed.`, and `reconcile` on the *missing* project exits 1 with the
+same sentence on stderr, prefixed `task-registry:`. This repository itself
+reports `none`, exit 0 — `CLAUDE.md` no longer carries a live pointer.
+
+### Result
+
+PASS. AC1 (distinguishable, names path and declaring file), AC2 (no pointer stays
+silent), AC3 (template `CLAUDE.md` emits no parseable pointer) observed directly;
+AC4–AC6 are the test suite (`tests/test-task-registry.sh` "Pointer states",
+`tests/test-doc-conventions.sh`, `bash tests/run.sh` 36/36). Residual gap, stated:
+a pointer to a file that exists but has no ` ```ini ` block still tracebacks under
+`doctor` — pre-existing on `master`, unchanged here, and the non-strict docstring
+now says so rather than claiming otherwise.

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -335,3 +335,32 @@ so that agreement counts.
   `architecture/a-repository-level-flag-does-not-describe-one-revision.md`,
   `process/a-precondition-that-fires-after-the-act-reports-nothing.md`,
   `tooling/pkill-f-matches-the-shell-that-runs-it.md`
+
+### [2026-09-06] — A task-tracking pointer to a missing file is no longer silent (#82)
+`/debug 82`. `find_config_path()` fell through `os.path.isfile` to the default
+path whenever a `Task tracking instructions:` pointer named a file that did not
+exist, and its `except ConfigError: continue` did the same for a pointer that
+escaped the project root — so "declared and broken" and "never declared" printed
+the same `doctor` line and ran on the same defaults. The template's own
+`CLAUDE.md` was the live instance: a bare pointer to `docs/task-tracking.md`,
+a file that never shipped and cannot (`docs/` is not syncable).
+- Root-Cause Prelude ranked three candidates; the regex (#2) was disconfirmed by
+  running `POINTER_RE` over `CLAUDE.md`, and the doctor renderer (#3) by the
+  absence of any declared-path field in `Config` for it to have dropped.
+- Fix: a `ConfigPointerError` raised from the loader, naming the declaring file,
+  the declared path, and the template to start from; `load_config(strict=)`
+  replaces `validate_routines`, and `doctor` alone loads non-strict so it can
+  render `configuration:  BROKEN — …` and exit 1 while every other command
+  refuses in the preamble. `CLAUDE.md` now carries the convention as prose with
+  a `<path>` placeholder — the issue's proposed backtick-wrap was tested and
+  found insufficient, since `POINTER_RE` stops at a backtick without needing one.
+- Tests: a three-state block (no pointer / pointer resolves / pointer missing,
+  plus precedence and escape) written RED first; the doc-conventions guard now
+  asserts the convention is documented and that any live pointer in `CLAUDE.md`
+  resolves to a shipped file. 36/36 test files green.
+- Two decisions recorded as `[AMBIGUITY]`: refuse rather than warn-and-run
+  (spec AC7 in the issue's comment, and the malformed-config precedent), and
+  make the escaping pointer loud too (same defect, same function, already
+  documented as refused).
+- Learnings captured: `tasks/solutions/bugs/task-tracking-pointer-to-a-missing-file-was-indistinguishable-from-no-pointer.md`,
+  `tasks/solutions/patterns/a-declared-intent-with-a-broken-target-is-not-an-absent-one.md`

--- a/tasks/solutions/bugs/grep-zero-matches-aborts-hooks-under-set-e-pipefail.md
+++ b/tasks/solutions/bugs/grep-zero-matches-aborts-hooks-under-set-e-pipefail.md
@@ -60,6 +60,11 @@ REVIEW_COUNT=$(grep -rlE '^needs_review: true' tasks/solutions/*/ 2>/dev/null | 
 
 `.claude/hooks/session-start.sh:156`, and the same pattern in
 `/memory-maintain`'s light pass (both skill copies).
+Regression test: `tests/test-session-start.sh` — a fixture document that
+mentions the flag in prose must count as zero flagged.
+
+_[merged duplicate section 2026-09-06: a second "Recurrence — 2026-09-05"
+section restated this one; its regression-test line is folded in above.]_
 
 **The generalisable error**: the first fix restricted *where* to look when the
 defect was *what* to match. A store of documents about a system will inevitably
@@ -74,31 +79,3 @@ In any `set -eo pipefail` script, treat every counting/filtering grep as a
 command that is *expected* to fail: `grep ... || true` inside pipelines, or
 `grep -c` with an explicit exit check. Test the zero-match path — it is the
 path that never shows up during development because fixtures always match.
-
-## Recurrence — 2026-09-05
-
-The glob fix was a symptom fix. Scoping to `tasks/solutions/*/` excluded the store
-README, but the real defect is that an **unanchored** grep counts every *mention*
-of the flag, and a category document may mention it too.
-
-This document is that document. Its prose and its code block both quote
-`needs_review: true`, so the counter reported one flagged document when the store
-had none — the session-start banner misreported store health, and
-`/memory-maintain`'s light pass inherited the same number from the same pattern.
-
-The flag is frontmatter, so the match belongs at the start of a line:
-
-```bash
-REVIEW_COUNT=$(grep -rl '^needs_review: true' tasks/solutions/*/ 2>/dev/null | wc -l | tr -d ' ' || true)
-```
-
-Fixed in `.claude/hooks/session-start.sh:156` and in both copies of
-`skills/memory-maintain/SKILL.md`. Regression test:
-`tests/test-session-start.sh` — a fixture document that mentions the flag in prose
-must count as zero flagged.
-
-**The general lesson**, which the original entry missed: when a grep asks "which
-files *are* X", excluding the one known false positive fixes that instance and
-leaves the class open. Anchor or otherwise constrain the pattern to the structural
-position the value actually occupies. A store of documents *about* the codebase
-will always eventually contain a document about the pattern you are grepping for.

--- a/tasks/solutions/bugs/task-tracking-pointer-to-a-missing-file-was-indistinguishable-from-no-pointer.md
+++ b/tasks/solutions/bugs/task-tracking-pointer-to-a-missing-file-was-indistinguishable-from-no-pointer.md
@@ -1,0 +1,61 @@
+---
+title: Task-tracking pointer to a missing file was indistinguishable from no pointer
+date: 2026-09-06
+problem_type: bug
+module: .agents/skills/task-registry/scripts/registry/config.py, .agents/skills/task-registry/scripts/task-registry.py, CLAUDE.md
+tags: [task-registry, configuration, silent-failure, sync, pointer]
+symptoms: A project whose CLAUDE.md declared `Task tracking instructions: docs/task-tracking.md` with no such file ran on defaults, and `doctor` printed byte-identical output to a project with no pointer at all
+root_cause: find_config_path folded a pointer whose target was missing (or escaped the root) into the no-pointer path, and the template's CLAUDE.md emitted a live pointer to a file `/sync` can never ship
+resolution: find_config_path raises ConfigPointerError naming the declaring file and path; doctor renders it on the configuration line and every other command refuses; CLAUDE.md documents the convention with the inert `<path>` placeholder instead of a live pointer
+---
+
+**Status**: fixed — 2026-09-06
+**Regression test**: `tests/test-task-registry.sh` ("Pointer states" block, line 411; escape block, line 1473) and `tests/test-doc-conventions.sh:337`
+
+Issue #82. Reproduced at Level 1 by running `doctor` against three throwaway
+repos: pointer with missing target, no pointer, and an escaping pointer
+(`../../etc/passwd`). All three printed the same three lines and exited 0.
+
+Three candidates were ranked. The regex (`POINTER_RE`) was disconfirmed by
+running it over `CLAUDE.md` — it matched. The `doctor` renderer was disconfirmed
+by reading `Config`: it has no field for a declared path, so it had nothing to
+render. That left the loader. `find_config_path` checked `isfile` on the
+resolved pointer and, on failure, fell through to the default path and then to
+`None` — the same return as "never configured". The sibling branch three lines
+up swallowed the confinement error for an escaping pointer the same way, while
+`references/configuration.md` already documented escapes as refused.
+
+The fix keeps the two silent states silent and makes the third loud
+(`.agents/skills/task-registry/scripts/registry/config.py:262`): a declared target that is missing raises
+`ConfigPointerError` (line 292), and an escaping one wraps the
+confinement error in the same type (line 287). The first pointer
+found wins, broken or not — a dangling `.claude/project.md` pointer is not
+rescued by a valid `CLAUDE.md` one. `load_config` gained `strict`, replacing
+`validate_routines`: `doctor` loads non-strictly (line 362) and renders
+the fault on its `configuration:` line (`.agents/skills/task-registry/scripts/task-registry.py:312`), exit 1;
+every other command refuses with the same message.
+
+The template side: `CLAUDE.md` shipped a bare, parseable pointer to
+`docs/task-tracking.md`, and `docs/` is outside every syncable root, so every
+consumer inherited a dangling pointer on `/sync`. The issue's suggested fix —
+backtick-wrap the pointer — does not work: `POINTER_RE` stops at a backtick but
+does not require one, so `` `Task tracking instructions: docs/x.md` `` still
+matches. Only the `<path>` placeholder is inert, which is why `SKILL.md` never
+self-triggered. `CLAUDE.md:428` now documents the convention that way
+and tells projects to put a real pointer in `.claude/project.md` or `AGENTS.md`.
+The doc-conventions test that used to pin the dangling pointer in place now
+asserts the convention is documented and that any live pointer resolves to a
+shipped file.
+
+Documented behaviour change (issue AC7): an escaping pointer was previously
+skipped silently and is now refused, matching what the configuration guide
+already claimed. Noted in `references/configuration.md`, `SKILL.md`, and
+`specs/task-registry.md`.
+
+Two decisions made without the user: refuse rather than warn-and-run, because
+the issue's own comment carries spec AC7 "refused loudly" and malformed
+configuration already refuses with `doctor` exempt; and widen scope to the
+escaping-pointer branch, because it is the same defect in the same function.
+
+Related pattern: [A declared intent with a broken target is not an absent one](../patterns/a-declared-intent-with-a-broken-target-is-not-an-absent-one.md).
+Related: [Validate in the loader, not in one optional command](../patterns/validate-in-the-loader-not-in-one-optional-command.md).

--- a/tasks/solutions/patterns/a-declared-intent-with-a-broken-target-is-not-an-absent-one.md
+++ b/tasks/solutions/patterns/a-declared-intent-with-a-broken-target-is-not-an-absent-one.md
@@ -1,0 +1,49 @@
+---
+title: A declared intent with a broken target is not an absent one
+date: 2026-09-06
+problem_type: pattern
+module: .agents/skills/task-registry/scripts/registry/config.py
+tags: [configuration, silent-failure, three-states, pointers, defaults]
+applies_when: Resolving an optional pointer, override, or config path where "not declared" legitimately falls back to defaults
+---
+
+## The failure shape
+
+An optional declaration has three states, and the tempting code handles two:
+
+| State | Right behaviour |
+|---|---|
+| not declared | defaults, silently — that is what optional means |
+| declared, target usable | use it |
+| **declared, target unusable** | **refuse, naming the declaration and the target** |
+
+`if os.path.isfile(target): return target` followed by a fall-through to the
+default collapses the third state into the first. The project then runs on
+defaults while its own instructions say it is configured, and the only tool that
+could have said so reports "configuration: none" (#82,
+`.agents/skills/task-registry/scripts/registry/config.py:261`). The same shape swallowed a path-escape error in the
+sibling branch.
+
+## The rule
+
+"Absent is not an error" licenses silence for *absent*. A declaration you found
+and could not honour is a broken configuration and gets the malformed-file
+treatment: refuse, name the declaring file and the declared path, say how to
+fix it. Keep the diagnostic command reachable — load non-strictly there and
+render the fault instead — so the failure is inspectable exactly when it fires.
+
+Check the sibling branches of the same resolver: a `try/except: continue` next
+to the `isfile` fall-through is the same bug wearing a different exception.
+
+## The template corollary
+
+A template-managed file must never emit a live pointer to a path outside the
+sync boundary. It ships the declaration to every consumer and can never ship
+the target, so every consumer inherits the third state by construction.
+Document the convention with a placeholder the parser treats as inert — here
+`<path>`, because the pointer regex stops at a backtick but does not require
+one, so a backticked concrete path still matches. Pin it with a test that
+resolves any live pointer it finds, not one that asserts the pointer is present.
+
+Related: [[validate-in-the-loader-not-in-one-optional-command]] — a gate that
+exists but never runs; this is a gate that runs and returns the wrong answer.

--- a/tasks/solutions/process/issue-lane-routing-e2e-gap.md
+++ b/tasks/solutions/process/issue-lane-routing-e2e-gap.md
@@ -26,3 +26,10 @@ session proceeded to commit and push.
 Run `/create-verification-skill` to define a project-owned verification surface,
 then replay the route hook, materialization, runtime tripwire, and reviewer
 finalization through that surface and record the walkthrough in `tasks/e2e-log.md`.
+
+**Correction — 2026-09-06.** The `/route` skill this gap was recorded against no
+longer exists: fb41c7a (#105) replaced it with the four category routines in
+`.agents/skills/wrap-up-session/references/routines.md`, selected by label rather
+than by a route hook. The gap itself still stands — the repository has no
+project-local verification skill — but the replay target is now the routine
+spine (select → claim → branch → routine step → review → PR), not the retired hook.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -449,7 +449,7 @@ Not executed by `/build`. Listed so the frontier shows the real dependency graph
 - [ ] task-registry: github provider reports native_hierarchy/native_dependencies false, but gh now exposes parent, subIssues, blockedBy and blocking <!-- task-id: task-registry.github-native-hierarchy-and-dependencies --> — The github provider hardcodes native_hierarchy=False and native_dependencies=False, so link_parent and add_dependency d… ([#97](https://github.com/Joaovsales/jplugin-agentic-development/issues/97))
 - [ ] routines: implement the `build` routine (deferred from the first category-routines PR) <!-- task-id: routines.build-routine --> — specs/category-routines.md defines four routines. Three (plan, fix, improve) ship in the first PR. `build` is deferred… ([#98](https://github.com/Joaovsales/jplugin-agentic-development/issues/98)) (blocked-by: task-registry.github-native-hierarchy-and-dependencies)
 
-## Session Summary — 2026-09-06 fb41c7a..HEAD (sha range closes at commit)
+## Session Summary — 2026-09-06 [fb41c7a..18ac574]
 - Completed: 0 planned tasks — `/debug 82` session, no todo plan; fix shipped on
   branch `Joaovsales/task-tracking-config-a-pointer-to-a-missing-file`
 - Pending: 0 active; 2 deferred externally (#97, #98) unchanged

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -448,3 +448,9 @@ Not executed by `/build`. Listed so the frontier shows the real dependency graph
 
 - [ ] task-registry: github provider reports native_hierarchy/native_dependencies false, but gh now exposes parent, subIssues, blockedBy and blocking <!-- task-id: task-registry.github-native-hierarchy-and-dependencies --> — The github provider hardcodes native_hierarchy=False and native_dependencies=False, so link_parent and add_dependency d… ([#97](https://github.com/Joaovsales/jplugin-agentic-development/issues/97))
 - [ ] routines: implement the `build` routine (deferred from the first category-routines PR) <!-- task-id: routines.build-routine --> — specs/category-routines.md defines four routines. Three (plan, fix, improve) ship in the first PR. `build` is deferred… ([#98](https://github.com/Joaovsales/jplugin-agentic-development/issues/98)) (blocked-by: task-registry.github-native-hierarchy-and-dependencies)
+
+## Session Summary — 2026-09-06 fb41c7a..HEAD (sha range closes at commit)
+- Completed: 0 planned tasks — `/debug 82` session, no todo plan; fix shipped on
+  branch `Joaovsales/task-tracking-config-a-pointer-to-a-missing-file`
+- Pending: 0 active; 2 deferred externally (#97, #98) unchanged
+- Carry-forward: none from this session

--- a/tests/test-doc-conventions.sh
+++ b/tests/test-doc-conventions.sh
@@ -326,8 +326,24 @@ assert_file_contains "CLAUDE.md" '`/task-registry`' \
   "task-registry: CLAUDE.md skills table lists the skill"
 assert_file_contains "CLAUDE.md" "## Task Tracking" \
   "task-registry: CLAUDE.md defines the task-tracking section"
-assert_file_contains "CLAUDE.md" "Task tracking instructions: docs/task-tracking.md" \
-  "task-registry: CLAUDE.md carries the configuration pointer the loader looks for"
+# The convention is documented, but CLAUDE.md must not itself emit a live
+# pointer. It is template-managed and ships to every consumer, while `docs/` is
+# outside every syncable root — so a bare `Task tracking instructions: <file>`
+# here is a pointer whose target the template can never deliver, and the loader
+# refuses a pointer with no target (#82). The loader's POINTER_RE stops at a
+# backtick or `<` but does not require one, so a backticked concrete path still
+# matches: only the `<path>` placeholder is inert. Any live pointer that does
+# appear must resolve to a file this repository ships.
+assert_file_contains "CLAUDE.md" '`Task tracking instructions: <path>`' \
+  "task-registry: CLAUDE.md documents the pointer convention"
+assert_file_contains "CLAUDE.md" "templates/task-tracking.md" \
+  "task-registry: CLAUDE.md names the template a project starts its configuration from"
+claude_md_pointers="$(grep -oiE 'Task tracking instructions:[[:space:]]*[^[:space:]`<>]+' CLAUDE.md \
+  | sed -E 's/^[^:]*:[[:space:]]*//' || true)"
+for target in $claude_md_pointers; do
+  assert_eq "present" "$([ -f "$target" ] && echo present || echo missing)" \
+    "task-registry: live pointer in CLAUDE.md resolves to a shipped file ($target)"
+done
 assert_prose_contains "CLAUDE.md" "is an **index**, not the detailed source of truth" \
   "task-registry: CLAUDE.md states that tasks/todo.md is an index"
 assert_not_contains "$(flatten CLAUDE.md)" \

--- a/tests/test-task-registry.sh
+++ b/tests/test-task-registry.sh
@@ -408,6 +408,129 @@ unkprov_code=$?
 assert_eq "1" "$unkprov_code" "Config: an unknown provider exits non-zero"
 assert_contains "$unkprov_out" "unknown provider 'trello'" "Config: the failure names the bad provider"
 
+# Three pointer states, and only the first is silent (#82). "No pointer" is an
+# unconfigured project and defaults silently. "Pointer -> existing file" loads
+# it. "Pointer -> missing file" is a CONFIGURED project, broken: folding it into
+# the first state made every consumer run on defaults while its own project
+# instructions claimed otherwise, and nothing said so.
+F_NOPTR="$(new_fixture)"
+write_index "$F_NOPTR"
+noptr_out="$(run doctor --repo "$F_NOPTR" 2>&1)"
+noptr_code=$?
+assert_eq "0" "$noptr_code" "Pointer states: no pointer — defaults, exit 0"
+assert_contains "$noptr_out" "configuration:  none (defaults + local fallback)" \
+  "Pointer states: no pointer — reported as none"
+assert_not_contains "$noptr_out" "BROKEN" \
+  "Pointer states: no pointer — no new noise on the common path"
+
+F_PTROK="$(new_fixture)"
+write_index "$F_PTROK"
+printf '# T\n\n```ini\n[tracker]\nprovider = local\n```\n' > "$F_PTROK/docs/tracking.md"
+printf 'Task tracking instructions: docs/tracking.md\n' > "$F_PTROK/CLAUDE.md"
+ptrok_out="$(run doctor --repo "$F_PTROK" 2>&1)"
+ptrok_code=$?
+assert_eq "0" "$ptrok_code" "Pointer states: pointer to an existing file — exit 0"
+assert_contains "$ptrok_out" "configuration:  docs/tracking.md" \
+  "Pointer states: pointer to an existing file — that file is loaded"
+
+F_PTRMISS="$(new_fixture)"
+write_index "$F_PTRMISS"
+printf 'Task tracking instructions: docs/tracking.md\n' > "$F_PTRMISS/CLAUDE.md"
+ptrmiss_doctor="$(run doctor --repo "$F_PTRMISS" 2>&1)"
+ptrmiss_code=$?
+assert_eq "1" "$ptrmiss_code" "Pointer states: pointer to a missing file — doctor exits non-zero"
+assert_contains "$ptrmiss_doctor" "configuration:  BROKEN" \
+  "Pointer states: pointer to a missing file — doctor reports BROKEN, not none"
+assert_contains "$ptrmiss_doctor" "CLAUDE.md declares" \
+  "Pointer states: the fault names where the pointer was declared"
+assert_contains "$ptrmiss_doctor" "'docs/tracking.md' does not exist" \
+  "Pointer states: the fault names the declared path"
+assert_contains "$ptrmiss_doctor" "templates/task-tracking.md" \
+  "Pointer states: the fault says how to fix it"
+assert_contains "$ptrmiss_doctor" "Every command except this one refuses to run until it is fixed." \
+  "Pointer states: doctor says the fault blocks every other command"
+assert_contains "$ptrmiss_doctor" "provider:" \
+  "Pointer states: the rest of the diagnosis still renders"
+assert_not_contains "$ptrmiss_doctor" "MISCONFIGURED" \
+  "Pointer states: the fault sits on the configuration line, not the routines line"
+assert_eq "different" "$([ "$noptr_out" = "$ptrmiss_doctor" ] && echo same || echo different)" \
+  "Pointer states: a broken declaration is distinguishable from no declaration"
+ptrmiss_rec="$(run reconcile --repo "$F_PTRMISS" 2>&1)"
+ptrmiss_rec_code=$?
+assert_eq "1" "$ptrmiss_rec_code" \
+  "Pointer states: every command except doctor refuses to run on a broken pointer"
+assert_contains "$ptrmiss_rec" "task-registry: CLAUDE.md declares" \
+  "Pointer states: the refusal carries the same fault text"
+
+# First pointer wins, broken or not: a dangling project-owned pointer is not
+# rescued by a valid template-managed one further down the search order. The
+# most authoritative declaration is the one that is wrong, and that is what the
+# user must hear.
+F_PTRPREC="$(new_fixture)"
+write_index "$F_PTRPREC"
+mkdir -p "$F_PTRPREC/.claude"
+printf '# T\n\n```ini\n[tracker]\nprovider = local\n```\n' > "$F_PTRPREC/docs/tracking.md"
+printf 'Task tracking instructions: docs/missing.md\n' > "$F_PTRPREC/.claude/project.md"
+printf 'Task tracking instructions: docs/tracking.md\n' > "$F_PTRPREC/CLAUDE.md"
+ptrprec_out="$(run reconcile --repo "$F_PTRPREC" 2>&1)"
+ptrprec_code=$?
+assert_eq "1" "$ptrprec_code" \
+  "Pointer states: a broken project-owned pointer is not rescued by a later valid one"
+assert_contains "$ptrprec_out" ".claude/project.md declares" \
+  "Pointer states: the refusal names the project-owned file, not the template one"
+
+# The refusal is the only place repository text reaches a terminal or an agent's
+# context unparsed, so the declared path is echoed escaped (repr), the way
+# `confine` already renders an escaping pointer — an ESC byte the regex admits
+# must not pass through raw. And a target that exists but is a directory is
+# named as such: "does not exist — create it" would send the user to create
+# something that is already there.
+F_PTRDIR="$(new_fixture)"
+write_index "$F_PTRDIR"
+printf 'Task tracking instructions: docs\n' > "$F_PTRDIR/CLAUDE.md"
+ptrdir_out="$(run doctor --repo "$F_PTRDIR" 2>&1)"
+assert_contains "$ptrdir_out" "'docs' exists but is not a file" \
+  "Pointer states: a pointer to a directory is not reported as missing"
+assert_not_contains "$ptrdir_out" "does not exist" \
+  "Pointer states: a directory target never gets the create-it advice"
+F_PTRESC="$(new_fixture)"
+write_index "$F_PTRESC"
+printf 'Task tracking instructions: \033[31mdocs/x.md\n' > "$F_PTRESC/CLAUDE.md"
+ptresc_out="$(run doctor --repo "$F_PTRESC" 2>&1)"
+assert_contains "$ptresc_out" "'\\x1b[31mdocs/x.md' does not exist" \
+  "Pointer states: the declared path is echoed escaped, never raw"
+assert_eq "0" "$(printf '%s' "$ptresc_out" | grep -c $'\033' || true)" \
+  "Pointer states: no raw ESC byte reaches the output"
+
+# A refusal is only earned by a genuine declaration. The regex admits any
+# non-space run after the colon, so a prose mention that ends its sentence —
+# `...: docs/tracking.md.` — must name `docs/tracking.md`, not `docs/tracking.md.`;
+# otherwise a project that worked yesterday refuses today over a full stop.
+F_PTRPROSE="$(new_fixture)"
+write_index "$F_PTRPROSE"
+mkdir -p "$F_PTRPROSE/.claude"
+printf '# T\n\n```ini\n[tracker]\nprovider = local\n```\n' > "$F_PTRPROSE/docs/tracking.md"
+printf 'See the Task tracking instructions: docs/tracking.md. It is optional.\n' > "$F_PTRPROSE/.claude/project.md"
+ptrprose_out="$(run doctor --repo "$F_PTRPROSE" 2>&1)"
+ptrprose_code=$?
+assert_eq "0" "$ptrprose_code" \
+  "Pointer states: sentence punctuation after the path is not part of the path"
+assert_contains "$ptrprose_out" "configuration:  docs/tracking.md" \
+  "Pointer states: the prose mention resolves to the file it names"
+
+# A run that is nothing but punctuation (`Task tracking instructions: ...`) is a
+# sentence fragment, not a path — it must read as "no pointer", not as a
+# pointer to a file called `...`.
+F_PTRDOTS="$(new_fixture)"
+write_index "$F_PTRDOTS"
+printf 'Task tracking instructions: ...\n' > "$F_PTRDOTS/CLAUDE.md"
+ptrdots_out="$(run doctor --repo "$F_PTRDOTS" 2>&1)"
+ptrdots_code=$?
+assert_eq "0" "$ptrdots_code" \
+  "Pointer states: a punctuation-only pointer is no pointer — exit 0"
+assert_contains "$ptrdots_out" "configuration:  none (defaults + local fallback)" \
+  "Pointer states: a punctuation-only pointer falls back to defaults"
+
 # =============================================================================
 # 4. Provider selection precedence
 # =============================================================================
@@ -1343,16 +1466,26 @@ assert_contains "$cfg_reg" "transport https://jira.example.com = allowed" \
 assert_contains "$cfg_reg" "transport-optout=True" \
   "Config: an operator can override the transport floor from the environment"
 
-# A pointer that escapes the repository must not be followed.
+# A pointer that escapes the repository must not be followed — and must not be
+# silently skipped either. It is a declared intent with a broken target, the
+# same shape as a missing file (#82), and the configuration guide already
+# documents escapes as refused. The declared string is echoed, never opened.
 F_ESC="$(new_fixture)"
 printf 'Task tracking instructions: ../../../etc/passwd\n' > "$F_ESC/AGENTS.md"
 esc_out="$(cd "$F_ESC" && pyreg <<'EOF'
-from registry.config import find_config_path
-print("resolved=" + str(find_config_path(".")))
+from registry.config import ConfigError, find_config_path
+try:
+    print("resolved=" + str(find_config_path(".")))
+except ConfigError as exc:
+    print("refused=" + str(exc))
 EOF
 )"
-assert_contains "$esc_out" "resolved=None" \
-  "Config: a pointer resolving outside the project root is not followed"
+assert_contains "$esc_out" "refused=" \
+  "Config: a pointer resolving outside the project root is refused, not silently skipped"
+assert_contains "$esc_out" "AGENTS.md" \
+  "Config: the refusal names the file that declared the escaping pointer"
+assert_contains "$esc_out" "outside the project root" \
+  "Config: the refusal says why"
 
 # Approval is a floor: a repository file may add it, never remove it.
 F_FLOOR="$(new_fixture)"


### PR DESCRIPTION
Closes #82.

## What changed

`find_config_path()` treated a `Task tracking instructions: <path>` line whose target did not exist exactly like no pointer at all: it fell through to defaults and `doctor` reported `configuration: none`. The template `CLAUDE.md` shipped such a pointer (`docs/task-tracking.md` was never delivered, and `docs/` is outside every syncable root), so every downstream project ran on defaults while declaring a configuration it could not read.

- **Three pointer states, only the first silent.** No pointer → defaults, exit 0 (unchanged). Pointer → existing file → loaded (unchanged). Pointer → missing target, directory, or path escaping the root → `ConfigPointerError`; every command refuses with exit 1, naming the declaring file, the declared path (repr-escaped, so repository text never reaches a terminal raw), and the remedy.
- **`doctor` diagnoses instead of refusing.** It loads non-strict, prints `configuration:  BROKEN — …` followed by `Every command except this one refuses to run until it is fixed.`, and exits 1.
- **`load_config(root, strict=True)`** replaces `validate_routines`. Non-strict covers exactly the pointer fault and selector validation; a target that exists but cannot be parsed still raises.
- **Prose-safe parsing.** Sentence punctuation after the path is stripped, so `…: docs/x.md.` names `docs/x.md`; a punctuation-only run is no pointer.
- **`CLAUDE.md`** documents the convention without a bare parseable pointer. The template now says to put the pointer in `.claude/project.md` or `AGENTS.md`, never in `CLAUDE.md`.
- **Guards.** `tests/test-doc-conventions.sh` asserts the convention is documented and that any live pointer in the three pointer files resolves. `tests/test-task-registry.sh` covers the three states plus directory, escape, prose, and punctuation-only pointers.

Both skill trees (`.agents/` canonical, `.claude/` mirror) are byte-identical.

## Rollout note

A downstream project that pulls this `task-registry` skill via `/sync` "Pick files" **without** also taking the new `CLAUDE.md` keeps the old live pointer, and the new engine refuses it: every command exits 1 with `CLAUDE.md declares … but 'docs/task-tracking.md' does not exist`. That refusal is the intended behaviour, not a regression. The remedy is to re-run `/sync` so `CLAUDE.md` is replaced, not to hand-edit `CLAUDE.md` (which `/sync` overwrites).

## Review notes

Four review passes ran; three dispatched agents completed, one (test coverage) stalled and its lens was completed inline. One `owner: human` finding is carried here rather than applied: when the declaring file is `CLAUDE.md`, the refusal could additionally name `/sync` as the remedy (or `/sync` Step 6 could note it), since the user should not edit a template-managed file. Left for a follow-up if wanted.

Pre-existing and out of scope: a pointer to a file that exists but has no ` ```ini ` block still tracebacks under `doctor` on `master`; the non-strict docstring now states that limit.

## Test plan

- [x] `bash tests/run.sh` — all 36 test files pass
- [x] `bash tests/test-task-registry.sh` — 317 assertions, pointer-state block green
- [x] `bash tests/test-doc-conventions.sh` — 431 assertions, live-pointer guard green
- [x] `bash tests/test-skill-parity.sh` — trees byte-identical
- [x] Live `doctor` on six throwaway projects (none / ok / missing / dir / prose / escape) recorded in `tasks/e2e-log.md`
- [x] This repository: `doctor` reports `configuration:  none`, exit 0 — `CLAUDE.md` carries no live pointer
