### PR TITLE
Fix task-registry legacy row publishing

### DIFF
--- a/.agents/skills/task-registry/scripts/registry/index.py
+++ b/.agents/skills/task-registry/scripts/registry/index.py
@@ -42,6 +42,7 @@ STATUS_TO_BOX = {
 ROW_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<bullet>[-*]\s+)?\[(?P<box>.?)\](?P<rest>.*)$")
 TASK_ID_RE = re.compile(r"<!--\s*task-id:\s*(?P<id>[^\s>]+?)\s*-->")
 TASK_KIND_RE = re.compile(r"<!--\s*task-kind:\s*(?P<kind>[^\s>]+?)\s*-->")
+COMMENT_MARKER_RE = re.compile(r"<!--|-->")
 LINK_RE = re.compile(
     r"\((?P<label>\[[^\]]+\])\((?P<url>[^)\s]+)\)\)"  # the ([#42](url)) shape we render
     r"|\[(?P<bare>[^\]]+)\]\((?P<bare_url>[^)\s]+)\)"  # a bare [#42](url) a human typed
@@ -50,6 +51,12 @@ DEPS_RE = re.compile(
     r"[(\[]\s*(?:blocked-by|depends-on|deps)\s*:\s*(?P<ids>[^)\]]+)[)\]]", re.IGNORECASE
 )
 SUMMARY_SPLIT = re.compile(r"\s+[—–]\s+")
+LEGACY_TDD_RE = re.compile(
+    r"^TDD:\s*`(?P<title>[^`]+)`\s*->\s*(?P<summary>.+)$", re.IGNORECASE
+)
+ARROW_SPLIT = re.compile(r"(?<!-)->")
+TRAILING_CONJUNCTION = re.compile(r"(?:^|\s+)(?:and|or|then)$", re.IGNORECASE)
+MAX_LOGICAL_ROW_CHARS = 60_000
 #: A reference id ends up as a positional argument to `gh` and as a path segment
 #: in a Jira URL. Anything outside this set is a malformed row, reported like any
 #: other (AC-19) rather than forwarded to a subprocess or an HTTP client.
@@ -73,6 +80,7 @@ class Problem:
 class IndexRow:
     task: Task
     line: int  # 1-based, matching what an editor and a Problem report
+    end_line: int  # inclusive physical span owned by this logical row
     raw: str
     legacy: bool  # no stable ID present in the source row
     indent: str = ""  # leading whitespace, so a rewrite preserves nesting
@@ -86,6 +94,7 @@ class TaskIndex:
         self.relative_path = relative_path or path
         self._lines = text.splitlines()
         self._trailing_newline = text.endswith("\n") if text else True
+        self._replacements: dict[int, str] = {}
         self.rows: List[IndexRow] = []
         self.problems: List[Problem] = []
         self._parse()
@@ -97,15 +106,25 @@ class TaskIndex:
             match = ROW_RE.match(line)
             if not match:
                 continue
+            detail, end_line = _continuation_lines(
+                self._lines, number - 1, len(match.group("indent") or "")
+            )
             try:
-                row = self._parse_row(match, number, line)
+                row = self._parse_row(match, number, end_line, line, detail)
             except TaskModelError as exc:
                 self.problems.append(Problem(self.relative_path, number, str(exc), line))
                 continue
             if row is not None:
                 self.rows.append(row)
 
-    def _parse_row(self, match: "re.Match[str]", number: int, line: str) -> Optional[IndexRow]:
+    def _parse_row(
+        self,
+        match: "re.Match[str]",
+        number: int,
+        end_line: int,
+        line: str,
+        detail: Sequence[str],
+    ) -> Optional[IndexRow]:
         box = match.group("box")
         if box not in BOX_TO_STATUS:
             self.problems.append(
@@ -120,11 +139,36 @@ class TaskIndex:
             return None
 
         rest = match.group("rest")
+        if _has_unbalanced_comment((rest, *detail)):
+            self.problems.append(
+                Problem(
+                    self.relative_path,
+                    number,
+                    "unbalanced HTML comment in logical task row",
+                    line,
+                )
+            )
+            return None
+        if len(rest) + sum(len(item) + 1 for item in detail) > MAX_LOGICAL_ROW_CHARS:
+            self.problems.append(
+                Problem(
+                    self.relative_path,
+                    number,
+                    f"logical task row exceeds the {MAX_LOGICAL_ROW_CHARS}-character publish limit",
+                    line,
+                )
+            )
+            return None
         task_id, rest = _extract_id(rest)
         task_kind, rest = _extract_kind(rest)
         depends_on, rest = _extract_dependencies(rest)
         external, rest = _extract_link(rest)
-        title, summary = _split_title_summary(rest)
+        title, summary, publish_error = _split_title_summary(rest)
+        summary = " ".join(part for part in (summary, *detail) if part)
+
+        if publish_error:
+            self.problems.append(Problem(self.relative_path, number, publish_error, line))
+            return None
 
         if not title:
             self.problems.append(
@@ -145,6 +189,7 @@ class TaskIndex:
         return IndexRow(
             task=task,
             line=number,
+            end_line=end_line,
             raw=line,
             legacy=not task_id,
             indent=match.group("indent") or "",
@@ -153,17 +198,26 @@ class TaskIndex:
     # ---------------------------------------------------------------- writing
 
     def replace_row(self, line: int, new_text: str) -> None:
+        self._replacements[line] = new_text
+
+    def replace_line(self, line: int, new_text: str) -> None:
         self._lines[line - 1] = new_text
 
     def row_text(self, line: int) -> str:
         """The current text of a line, including edits made this run."""
-        return self._lines[line - 1]
+        return self._replacements.get(line, self._lines[line - 1])
 
     def append_row(self, task: Task) -> None:
         self._lines.append(render_row(task))
 
     def render(self) -> str:
-        text = "\n".join(self._lines)
+        row_ends = {row.line: row.end_line for row in self.rows}
+        rendered = []
+        line = 1
+        while line <= len(self._lines):
+            rendered.append(self._replacements.get(line, self._lines[line - 1]))
+            line = row_ends.get(line, line) + 1 if line in self._replacements else line + 1
+        text = "\n".join(rendered)
         return text + "\n" if self._trailing_newline and text else text
 
     def save(self) -> None:
@@ -214,15 +268,78 @@ def _extract_link(rest: str) -> Tuple[Optional[ExternalRef], str]:
     return ref, (rest[: match.start()] + rest[match.end() :])
 
 
-def _split_title_summary(rest: str) -> Tuple[str, str]:
+def _continuation_lines(
+    lines: Sequence[str], row_index: int, indent: int
+) -> Tuple[List[str], int]:
+    detail = []
+    end_line = row_index + 1
+    for candidate_index in range(row_index + 1, len(lines)):
+        line = lines[candidate_index]
+        leading = len(line) - len(line.lstrip(" \t"))
+        if not line.strip():
+            continue
+        if ROW_RE.match(line) or leading <= indent:
+            break
+        detail.append(line.strip())
+        end_line = candidate_index + 1
+    return detail, end_line
+
+
+def _has_unbalanced_comment(parts: Sequence[str]) -> bool:
+    opened = False
+    for marker in COMMENT_MARKER_RE.findall("\n".join(parts)):
+        if marker == "<!--":
+            if opened:
+                return True
+            opened = True
+        elif not opened:
+            return True
+        else:
+            opened = False
+    return opened
+
+
+def _split_title_summary(rest: str) -> Tuple[str, str, Optional[str]]:
     cleaned = re.sub(r"\s{2,}", " ", rest).strip()
-    parts = SUMMARY_SPLIT.split(cleaned, maxsplit=1)
-    # Only whitespace is stripped: ROW_RE already consumed the bullet, so
-    # stripping dashes here would silently rewrite a legitimate title such as
-    # "-fno-strict-aliasing crashes the build".
-    title = parts[0].strip()
-    summary = parts[1].strip() if len(parts) > 1 else ""
-    return title, summary
+    arrows = list(ARROW_SPLIT.finditer(cleaned))
+    tdd = LEGACY_TDD_RE.match(cleaned)
+    if tdd and len(arrows) == 1:
+        title = tdd.group("title").strip()
+        summary = tdd.group("summary").strip()
+        return title, summary, _legacy_publish_error(cleaned, title, summary)
+    canonical = _canonical_summary(cleaned, arrows)
+    if canonical is not None:
+        return canonical[0], canonical[1], None
+    if len(arrows) > 1:
+        return cleaned, "", "cannot publish legacy row: multiple '->' delimiters are ambiguous"
+    if arrows:
+        return _split_legacy_arrow(cleaned, arrows[0])
+    return cleaned, "", None
+
+
+def _canonical_summary(
+    cleaned: str, arrows: Sequence["re.Match[str]"]
+) -> Optional[Tuple[str, str]]:
+    separator = SUMMARY_SPLIT.search(cleaned)
+    if separator is None or (arrows and arrows[0].start() < separator.start()):
+        return None
+    return cleaned[: separator.start()].strip(), cleaned[separator.end() :].strip()
+
+
+def _split_legacy_arrow(
+    cleaned: str, arrow: "re.Match[str]"
+) -> Tuple[str, str, Optional[str]]:
+    title = TRAILING_CONJUNCTION.sub("", cleaned[: arrow.start()].strip()).strip()
+    summary = cleaned[arrow.end() :].strip()
+    return title or cleaned, summary, _legacy_publish_error(cleaned, title, summary)
+
+
+def _legacy_publish_error(cleaned: str, title: str, summary: str) -> Optional[str]:
+    if cleaned.lower().startswith("tdd:") and (not title or not summary or "``" in title):
+        return "cannot publish legacy TDD row: expected a quoted test name and detail after '->'"
+    if not title or not summary:
+        return "cannot publish legacy row: expected a clean title and detail around '->'"
+    return None
 
 
 def render_row(task: Task, indent: str = "", include_kind: bool = False) -> str:

--- a/.agents/skills/task-registry/scripts/registry/migrate.py
+++ b/.agents/skills/task-registry/scripts/registry/migrate.py
@@ -212,7 +212,7 @@ def apply_migration(config, plan: MigrationPlan) -> List[str]:
         row = next((candidate for candidate in index.rows if candidate.line == entry.line), None)
         if row is None:  # pragma: no cover - index re-read is identical
             continue
-        index.replace_row(row.line, _insert_id(row.raw, entry.task_id))
+        index.replace_line(row.line, _insert_id(row.raw, entry.task_id))
         written += 1
     rewritten = _rewrite_dependencies(index, plan)
     if written or rewritten:
@@ -277,7 +277,7 @@ def _rewrite_dependencies(index: TaskIndex, plan: MigrationPlan) -> int:
                 r"(?<=[:,\s])" + re.escape(old) + r"(?=\s*[,)\]])", new, updated
             )
         if updated != raw:
-            index.replace_row(row.line, updated)
+            index.replace_line(row.line, updated)
             rewritten += 1
     return rewritten
 

--- a/.agents/skills/task-registry/scripts/registry/reconcile.py
+++ b/.agents/skills/task-registry/scripts/registry/reconcile.py
@@ -410,6 +410,8 @@ class Registry:
         report.applied = apply
         index = self.local_index()
         report.problems.extend(index.problems)
+        if index.problems:
+            return report
         external = self.external_tasks(report)
         if apply and report.provider_status is not None and not report.provider_status.available:
             # Degrading a *read* to local-only is a service. Degrading a write is

--- a/.agents/skills/task-registry/templates/task-tracking.md
+++ b/.agents/skills/task-registry/templates/task-tracking.md
@@ -151,3 +151,16 @@ export JIRA_PROJECT=REG          # optional; `project =` above wins
 ```
 
 GitHub uses whatever `gh auth status` reports. No token is read from this file.
+
+## Naming conventions
+
+Adapt these examples to the repository's existing issue corpus:
+
+- Title: `<PLAN-ID>: <lowercase deliverable phrase>`; use a work-type prefix
+  such as `E2E:` or `Unit tests:` when verification is the deliverable, and a
+  plain sentence when there is no parent plan.
+- Never publish raw plan text. The `->` implementation clause belongs in the
+  issue body, not its title.
+- Labels: choose exactly one `area/*`, one priority tier, and one kind when the
+  repository maps those vocabularies. Keep verification-work labels consistent
+  with the repository's established convention.

--- a/.claude/skills/task-registry/scripts/registry/index.py
+++ b/.claude/skills/task-registry/scripts/registry/index.py
@@ -42,6 +42,7 @@ STATUS_TO_BOX = {
 ROW_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<bullet>[-*]\s+)?\[(?P<box>.?)\](?P<rest>.*)$")
 TASK_ID_RE = re.compile(r"<!--\s*task-id:\s*(?P<id>[^\s>]+?)\s*-->")
 TASK_KIND_RE = re.compile(r"<!--\s*task-kind:\s*(?P<kind>[^\s>]+?)\s*-->")
+COMMENT_MARKER_RE = re.compile(r"<!--|-->")
 LINK_RE = re.compile(
     r"\((?P<label>\[[^\]]+\])\((?P<url>[^)\s]+)\)\)"  # the ([#42](url)) shape we render
     r"|\[(?P<bare>[^\]]+)\]\((?P<bare_url>[^)\s]+)\)"  # a bare [#42](url) a human typed
@@ -50,6 +51,12 @@ DEPS_RE = re.compile(
     r"[(\[]\s*(?:blocked-by|depends-on|deps)\s*:\s*(?P<ids>[^)\]]+)[)\]]", re.IGNORECASE
 )
 SUMMARY_SPLIT = re.compile(r"\s+[—–]\s+")
+LEGACY_TDD_RE = re.compile(
+    r"^TDD:\s*`(?P<title>[^`]+)`\s*->\s*(?P<summary>.+)$", re.IGNORECASE
+)
+ARROW_SPLIT = re.compile(r"(?<!-)->")
+TRAILING_CONJUNCTION = re.compile(r"(?:^|\s+)(?:and|or|then)$", re.IGNORECASE)
+MAX_LOGICAL_ROW_CHARS = 60_000
 #: A reference id ends up as a positional argument to `gh` and as a path segment
 #: in a Jira URL. Anything outside this set is a malformed row, reported like any
 #: other (AC-19) rather than forwarded to a subprocess or an HTTP client.
@@ -73,6 +80,7 @@ class Problem:
 class IndexRow:
     task: Task
     line: int  # 1-based, matching what an editor and a Problem report
+    end_line: int  # inclusive physical span owned by this logical row
     raw: str
     legacy: bool  # no stable ID present in the source row
     indent: str = ""  # leading whitespace, so a rewrite preserves nesting
@@ -86,6 +94,7 @@ class TaskIndex:
         self.relative_path = relative_path or path
         self._lines = text.splitlines()
         self._trailing_newline = text.endswith("\n") if text else True
+        self._replacements: dict[int, str] = {}
         self.rows: List[IndexRow] = []
         self.problems: List[Problem] = []
         self._parse()
@@ -97,15 +106,25 @@ class TaskIndex:
             match = ROW_RE.match(line)
             if not match:
                 continue
+            detail, end_line = _continuation_lines(
+                self._lines, number - 1, len(match.group("indent") or "")
+            )
             try:
-                row = self._parse_row(match, number, line)
+                row = self._parse_row(match, number, end_line, line, detail)
             except TaskModelError as exc:
                 self.problems.append(Problem(self.relative_path, number, str(exc), line))
                 continue
             if row is not None:
                 self.rows.append(row)
 
-    def _parse_row(self, match: "re.Match[str]", number: int, line: str) -> Optional[IndexRow]:
+    def _parse_row(
+        self,
+        match: "re.Match[str]",
+        number: int,
+        end_line: int,
+        line: str,
+        detail: Sequence[str],
+    ) -> Optional[IndexRow]:
         box = match.group("box")
         if box not in BOX_TO_STATUS:
             self.problems.append(
@@ -120,11 +139,36 @@ class TaskIndex:
             return None
 
         rest = match.group("rest")
+        if _has_unbalanced_comment((rest, *detail)):
+            self.problems.append(
+                Problem(
+                    self.relative_path,
+                    number,
+                    "unbalanced HTML comment in logical task row",
+                    line,
+                )
+            )
+            return None
+        if len(rest) + sum(len(item) + 1 for item in detail) > MAX_LOGICAL_ROW_CHARS:
+            self.problems.append(
+                Problem(
+                    self.relative_path,
+                    number,
+                    f"logical task row exceeds the {MAX_LOGICAL_ROW_CHARS}-character publish limit",
+                    line,
+                )
+            )
+            return None
         task_id, rest = _extract_id(rest)
         task_kind, rest = _extract_kind(rest)
         depends_on, rest = _extract_dependencies(rest)
         external, rest = _extract_link(rest)
-        title, summary = _split_title_summary(rest)
+        title, summary, publish_error = _split_title_summary(rest)
+        summary = " ".join(part for part in (summary, *detail) if part)
+
+        if publish_error:
+            self.problems.append(Problem(self.relative_path, number, publish_error, line))
+            return None
 
         if not title:
             self.problems.append(
@@ -145,6 +189,7 @@ class TaskIndex:
         return IndexRow(
             task=task,
             line=number,
+            end_line=end_line,
             raw=line,
             legacy=not task_id,
             indent=match.group("indent") or "",
@@ -153,17 +198,26 @@ class TaskIndex:
     # ---------------------------------------------------------------- writing
 
     def replace_row(self, line: int, new_text: str) -> None:
+        self._replacements[line] = new_text
+
+    def replace_line(self, line: int, new_text: str) -> None:
         self._lines[line - 1] = new_text
 
     def row_text(self, line: int) -> str:
         """The current text of a line, including edits made this run."""
-        return self._lines[line - 1]
+        return self._replacements.get(line, self._lines[line - 1])
 
     def append_row(self, task: Task) -> None:
         self._lines.append(render_row(task))
 
     def render(self) -> str:
-        text = "\n".join(self._lines)
+        row_ends = {row.line: row.end_line for row in self.rows}
+        rendered = []
+        line = 1
+        while line <= len(self._lines):
+            rendered.append(self._replacements.get(line, self._lines[line - 1]))
+            line = row_ends.get(line, line) + 1 if line in self._replacements else line + 1
+        text = "\n".join(rendered)
         return text + "\n" if self._trailing_newline and text else text
 
     def save(self) -> None:
@@ -214,15 +268,78 @@ def _extract_link(rest: str) -> Tuple[Optional[ExternalRef], str]:
     return ref, (rest[: match.start()] + rest[match.end() :])
 
 
-def _split_title_summary(rest: str) -> Tuple[str, str]:
+def _continuation_lines(
+    lines: Sequence[str], row_index: int, indent: int
+) -> Tuple[List[str], int]:
+    detail = []
+    end_line = row_index + 1
+    for candidate_index in range(row_index + 1, len(lines)):
+        line = lines[candidate_index]
+        leading = len(line) - len(line.lstrip(" \t"))
+        if not line.strip():
+            continue
+        if ROW_RE.match(line) or leading <= indent:
+            break
+        detail.append(line.strip())
+        end_line = candidate_index + 1
+    return detail, end_line
+
+
+def _has_unbalanced_comment(parts: Sequence[str]) -> bool:
+    opened = False
+    for marker in COMMENT_MARKER_RE.findall("\n".join(parts)):
+        if marker == "<!--":
+            if opened:
+                return True
+            opened = True
+        elif not opened:
+            return True
+        else:
+            opened = False
+    return opened
+
+
+def _split_title_summary(rest: str) -> Tuple[str, str, Optional[str]]:
     cleaned = re.sub(r"\s{2,}", " ", rest).strip()
-    parts = SUMMARY_SPLIT.split(cleaned, maxsplit=1)
-    # Only whitespace is stripped: ROW_RE already consumed the bullet, so
-    # stripping dashes here would silently rewrite a legitimate title such as
-    # "-fno-strict-aliasing crashes the build".
-    title = parts[0].strip()
-    summary = parts[1].strip() if len(parts) > 1 else ""
-    return title, summary
+    arrows = list(ARROW_SPLIT.finditer(cleaned))
+    tdd = LEGACY_TDD_RE.match(cleaned)
+    if tdd and len(arrows) == 1:
+        title = tdd.group("title").strip()
+        summary = tdd.group("summary").strip()
+        return title, summary, _legacy_publish_error(cleaned, title, summary)
+    canonical = _canonical_summary(cleaned, arrows)
+    if canonical is not None:
+        return canonical[0], canonical[1], None
+    if len(arrows) > 1:
+        return cleaned, "", "cannot publish legacy row: multiple '->' delimiters are ambiguous"
+    if arrows:
+        return _split_legacy_arrow(cleaned, arrows[0])
+    return cleaned, "", None
+
+
+def _canonical_summary(
+    cleaned: str, arrows: Sequence["re.Match[str]"]
+) -> Optional[Tuple[str, str]]:
+    separator = SUMMARY_SPLIT.search(cleaned)
+    if separator is None or (arrows and arrows[0].start() < separator.start()):
+        return None
+    return cleaned[: separator.start()].strip(), cleaned[separator.end() :].strip()
+
+
+def _split_legacy_arrow(
+    cleaned: str, arrow: "re.Match[str]"
+) -> Tuple[str, str, Optional[str]]:
+    title = TRAILING_CONJUNCTION.sub("", cleaned[: arrow.start()].strip()).strip()
+    summary = cleaned[arrow.end() :].strip()
+    return title or cleaned, summary, _legacy_publish_error(cleaned, title, summary)
+
+
+def _legacy_publish_error(cleaned: str, title: str, summary: str) -> Optional[str]:
+    if cleaned.lower().startswith("tdd:") and (not title or not summary or "``" in title):
+        return "cannot publish legacy TDD row: expected a quoted test name and detail after '->'"
+    if not title or not summary:
+        return "cannot publish legacy row: expected a clean title and detail around '->'"
+    return None
 
 
 def render_row(task: Task, indent: str = "", include_kind: bool = False) -> str:

--- a/.claude/skills/task-registry/scripts/registry/migrate.py
+++ b/.claude/skills/task-registry/scripts/registry/migrate.py
@@ -212,7 +212,7 @@ def apply_migration(config, plan: MigrationPlan) -> List[str]:
         row = next((candidate for candidate in index.rows if candidate.line == entry.line), None)
         if row is None:  # pragma: no cover - index re-read is identical
             continue
-        index.replace_row(row.line, _insert_id(row.raw, entry.task_id))
+        index.replace_line(row.line, _insert_id(row.raw, entry.task_id))
         written += 1
     rewritten = _rewrite_dependencies(index, plan)
     if written or rewritten:
@@ -277,7 +277,7 @@ def _rewrite_dependencies(index: TaskIndex, plan: MigrationPlan) -> int:
                 r"(?<=[:,\s])" + re.escape(old) + r"(?=\s*[,)\]])", new, updated
             )
         if updated != raw:
-            index.replace_row(row.line, updated)
+            index.replace_line(row.line, updated)
             rewritten += 1
     return rewritten
 

--- a/.claude/skills/task-registry/scripts/registry/reconcile.py
+++ b/.claude/skills/task-registry/scripts/registry/reconcile.py
@@ -410,6 +410,8 @@ class Registry:
         report.applied = apply
         index = self.local_index()
         report.problems.extend(index.problems)
+        if index.problems:
+            return report
         external = self.external_tasks(report)
         if apply and report.provider_status is not None and not report.provider_status.available:
             # Degrading a *read* to local-only is a service. Degrading a write is

--- a/.claude/skills/task-registry/templates/task-tracking.md
+++ b/.claude/skills/task-registry/templates/task-tracking.md
@@ -151,3 +151,16 @@ export JIRA_PROJECT=REG          # optional; `project =` above wins
 ```
 
 GitHub uses whatever `gh auth status` reports. No token is read from this file.
+
+## Naming conventions
+
+Adapt these examples to the repository's existing issue corpus:
+
+- Title: `<PLAN-ID>: <lowercase deliverable phrase>`; use a work-type prefix
+  such as `E2E:` or `Unit tests:` when verification is the deliverable, and a
+  plain sentence when there is no parent plan.
+- Never publish raw plan text. The `->` implementation clause belongs in the
+  issue body, not its title.
+- Labels: choose exactly one `area/*`, one priority tier, and one kind when the
+  repository maps those vocabularies. Keep verification-work labels consistent
+  with the repository's established convention.

--- a/specs/task-registry.md
+++ b/specs/task-registry.md
@@ -119,8 +119,15 @@ copied into `tasks/todo.md`.
 - **External task edited by a human** → `pull` updates only the registry-owned
   metadata block and the local row; body, comments, labels, and hierarchy survive.
 - **Row without an ID** → parsed, reported, never silently rewritten.
-- **Malformed row** (unbalanced comment, empty title, unknown status char) → reported
-  on stderr with the file:line, counted in the exit summary, never dropped silently.
+- **Legacy multi-line row** → an indented continuation belongs to the preceding
+  task. For ``TDD: `name` -> detail``, the quoted name becomes the provider title
+  and the complete implementation clause becomes its body; migration preserves
+  the physical continuation until the logical row is deliberately rewritten.
+- **Malformed or unsafe-to-publish row** (unbalanced comment, empty title,
+  unknown status char, ambiguous `->` split, or a logical row over 60,000
+  characters) → reported on stderr with the file:line, counted in the exit
+  summary, never truncated or dropped; publication refuses the entire local
+  batch before reading from or writing to the provider.
 - **A GitHub label the mapping does not know** → preserved verbatim, and the task
   still gets a kind (`task` by default).
 - **`in_progress` / `blocked`** → never inferred from GitHub's open/closed state.
@@ -158,16 +165,17 @@ copied into `tasks/todo.md`.
 - AC-13 — Duplicate detection never uses title equality alone.
 - AC-14 — `tasks/todo.md` rows carry only checkbox, title, ID, link, one-line
       summary, optional dependency marker; no acceptance criteria, no issue body.
-- AC-15 — Legacy checkbox-only rows keep parsing; `migrate` is dry-run first and
-      leaves an audit trail.
+- AC-15 — Legacy checkbox-only rows keep parsing; indented continuation detail
+      remains part of the same logical row, and `migrate` is dry-run first,
+      preserves that detail, and leaves an audit trail.
 - AC-16 — Migration groups tightly coupled work and does not emit one external
       issue per historical `[x]` checkbox.
 - AC-17 — Unresolved work is never deleted; stale/superseded entries are
       classified and reported, not removed.
 - AC-18 — `frontier` orders by dependency and names the blocker for each blocked
       task.
-- AC-19 — Malformed input is reported with file:line and a non-zero exit, never
-      swallowed.
+- AC-19 — Malformed or unsafe-to-publish input is reported with file:line and a
+      non-zero exit before any provider write, never swallowed or truncated.
 - AC-20 — Workflow skills (`/plan`, `/build`, `/verify`, `/quality-gate`,
       `/wrap-up-session`) reach tracking only through this capability — no direct
       `gh`/Jira calls for task state.

--- a/tasks/checkpoint.md
+++ b/tasks/checkpoint.md
@@ -4,15 +4,16 @@
 - Branch: `Joaovsales/task-registry-publish-a-legacy-prose-row-becomes`
 - Base: `origin/master` at `bbef230`
 - Functional commit: `7aedccb`
-- Active issue: #90, complete and awaiting PR review
+- Active issue: #90, complete in PR #110 and awaiting review
 - Active spec: `specs/task-registry.md`
 
 ## Verification
 - `bash tests/test-task-registry.sh`: 348 assertions passed
 - `bash tests/run.sh`: all 36 test files passed
+- GitHub Actions: PASS on rerun (the first run had a transient, unrelated
+  sync-retirement fixture failure)
 - Critic re-review: GO, no findings
 - Security scan: PASS, no findings
 
-## Remaining wrap-up
-- Commit this task bookkeeping.
-- Push the branch and open the PR with `Fixes #90`.
+## Remaining work
+- None in this session. Merge PR #110 to close issue #90.

--- a/tasks/checkpoint.md
+++ b/tasks/checkpoint.md
@@ -1,43 +1,18 @@
-# Checkpoint — 2026-09-06T23:40:31Z
+# Checkpoint — 2026-09-07
 
-> Auto-written by PreCompact hook (trigger: auto). Re-read on resume.
+## State
+- Branch: `Joaovsales/task-registry-publish-a-legacy-prose-row-becomes`
+- Base: `origin/master` at `bbef230`
+- Functional commit: `7aedccb`
+- Active issue: #90, complete and awaiting PR review
+- Active spec: `specs/task-registry.md`
 
-## Git
-- Branch: Joaovsales/task-tracking-config-a-pointer-to-a-missing-file
+## Verification
+- `bash tests/test-task-registry.sh`: 348 assertions passed
+- `bash tests/run.sh`: all 36 test files passed
+- Critic re-review: GO, no findings
+- Security scan: PASS, no findings
 
-```
- M .agents/skills/task-registry/SKILL.md
- M .agents/skills/task-registry/references/configuration.md
- M .agents/skills/task-registry/scripts/registry/config.py
- M .agents/skills/task-registry/scripts/task-registry.py
- M .agents/skills/task-registry/templates/task-tracking.md
- M .claude/skills/task-registry/SKILL.md
- M .claude/skills/task-registry/references/configuration.md
- M .claude/skills/task-registry/scripts/registry/config.py
- M .claude/skills/task-registry/scripts/task-registry.py
- M .claude/skills/task-registry/templates/task-tracking.md
- M CLAUDE.md
- M specs/task-registry.md
- M tasks/checkpoint.md
- M tasks/e2e-log.md
- M tasks/history.md
- M tasks/solutions/bugs/grep-zero-matches-aborts-hooks-under-set-e-pipefail.md
- M tasks/solutions/process/issue-lane-routing-e2e-gap.md
- M tasks/todo.md
- M tests/test-doc-conventions.sh
- M tests/test-task-registry.sh
-?? tasks/solutions/bugs/task-tracking-pointer-to-a-missing-file-was-indistinguishable-from-no-pointer.md
-?? tasks/solutions/patterns/a-declared-intent-with-a-broken-target-is-not-an-absent-one.md
-```
-
-## In-Progress & Pending Tasks (tasks/todo.md)
-(none)
-
-## Active Spec
-- specs/category-routines.md
-
-## How to Resume
-1. Read this file and `tasks/todo.md`
-2. Read `tasks/memory.md` for project context
-3. Continue from the first `[~]` (or `[ ]`) item in `tasks/todo.md`
-rst `[~]` (or `[ ]`) item in `tasks/todo.md`
+## Remaining wrap-up
+- Commit this task bookkeeping.
+- Push the branch and open the PR with `Fixes #90`.

--- a/tasks/e2e-log.md
+++ b/tasks/e2e-log.md
@@ -282,3 +282,74 @@ AC4–AC6 are the test suite (`tests/test-task-registry.sh` "Pointer states",
 a pointer to a file that exists but has no ` ```ini ` block still tracebacks under
 `doctor` — pre-existing on `master`, unchanged here, and the non-strict docstring
 now says so rather than claiming otherwise.
+
+---
+
+## E2E Walkthrough — task-registry legacy-row publication — 2026-09-06 51afded
+
+Spec: no spec — the user explicitly waived the redundant `/plan` gate for bug #90
+Commit: working tree based on `51afded886851c6e2c9b49bf64a6c8967a94b7fe`
+Browser: not applicable — non-browser CLI integration
+Harness: `tests/test-task-registry.sh`, invoking the real task-registry CLI against
+an isolated repository and fake `gh` process boundary
+
+### AC-1: A multi-line legacy row preserves its detail in the provider body
+
+Tier: CLI-FUNCTIONAL
+Journey: parse a migrated-shaped TDD row, invoke publication rendering, and inspect
+the body passed across the provider boundary.
+Steps executed:
+  ✓ Parsed the quoted deliverable as the title.
+  ✓ Collapsed the arrow clause and indented continuations into the body summary.
+  ✓ Kept the following task and section outside the logical row.
+  ✓ Replaced the complete logical span without duplicating continuation text.
+Negative: a malformed TDD row exits non-zero and never invokes `gh issue create` ✓
+Result: PASS
+
+### AC-2: Legacy titles exclude implementation guidance
+
+Tier: CLI-FUNCTIONAL
+Journey: parse both quoted TDD and ordinary arrow rows through the public index
+model used by `publish`.
+Steps executed:
+  ✓ Preferred the backtick-quoted TDD deliverable.
+  ✓ Split ordinary legacy titles at `->`.
+  ✓ Removed a dangling conjunction before the arrow.
+Negative: an empty quoted name is reported as unpublishable ✓
+Result: PASS
+
+### AC-3: The shipped configuration template documents naming conventions
+
+Tier: CLI-FUNCTIONAL
+Journey: validate both canonical and compatibility skill trees through the
+repository's documentation and parity checks.
+Steps executed:
+  ✓ Found the `## Naming conventions` stub.
+  ✓ Found the rule that raw `->` plan text belongs in the issue body.
+  ✓ Confirmed both skill trees are byte-identical.
+Negative: parity detects a one-tree-only template change ✓
+Result: PASS
+
+---
+
+## E2E Addendum — task-registry legacy publication boundary — 2026-09-07 7aedccb
+
+Spec: `specs/task-registry.md` (AC-14, AC-15, AC-19)
+Commit: `7aedccb`
+Browser: not applicable — non-browser CLI integration
+Harness: `tests/test-task-registry.sh`, real `task-registry publish --apply`
+against the fake-`gh` process boundary
+
+This addendum extends the preceding walkthrough after living-spec reconciliation
+and adversarial review. A valid multi-line legacy row containing both `->` and an
+em dash was published through the CLI. The captured `gh issue create` invocation
+carried the exact derived title (`recover active thread`) and complete body
+(`extend composer — preserve attachments across reloads`), and the local index
+was rewritten as one canonical linked row with no orphaned continuation.
+
+Negative journeys also crossed the CLI boundary: an ambiguous multiple-arrow row,
+an empty quoted TDD row, and unbalanced HTML comments made the entire mixed batch
+exit non-zero before any provider read or write. Exact 60,000-character input was
+accepted; 60,001 was refused without truncation.
+
+Result: PASS

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -364,3 +364,7 @@ a file that never shipped and cannot (`docs/` is not syncable).
   documented as refused).
 - Learnings captured: `tasks/solutions/bugs/task-tracking-pointer-to-a-missing-file-was-indistinguishable-from-no-pointer.md`,
   `tasks/solutions/patterns/a-declared-intent-with-a-broken-target-is-not-an-absent-one.md`
+### [2026-09-07] — Legacy row publishing
+- Key changes: task-registry now parses and rewrites complete multi-line logical rows, derives clean legacy titles, rejects malformed or oversized provider-bound rows, and ships naming-convention guidance.
+- Key changes: issue #107 recorded the redundant routed `/plan` gate; after the session rebased, merged PR #105 had deleted `/route` and defined the `fix` routine as `/debug` directly into `/build`/TDD, so #107 was closed as superseded.
+- Learnings captured: [task-registry publish lost legacy row detail](solutions/bugs/task-registry-publish-lost-legacy-row-detail.md) and [logical text records must own their rewrite span](solutions/patterns/logical-text-records-must-own-their-rewrite-span.md).

--- a/tasks/solutions/bugs/task-registry-publish-lost-legacy-row-detail.md
+++ b/tasks/solutions/bugs/task-registry-publish-lost-legacy-row-detail.md
@@ -1,0 +1,38 @@
+---
+title: Task registry publish lost legacy row detail
+date: 2026-09-06
+problem_type: bug
+module: .agents/skills/task-registry/scripts/registry
+tags: [task-registry, legacy-rows, parsing, github-publish, data-loss]
+symptoms: Publishing a migrated multi-line prose row produced a truncated title and an issue body with no human-readable detail
+root_cause: TaskIndex parsed each physical checkbox line independently, so indented continuation text never entered Task and arrow-delimited implementation prose remained in the title
+resolution: Parsed logical row spans, derived arrow and quoted-TDD titles from the header, preserved continuation detail as summary, rejected malformed or oversized rows before any provider call, and made rewrites consume the owned span
+---
+
+**Status**: fixed — 2026-09-07
+**Regression test**: `tests/test-task-registry.sh` — legacy multi-line parsing, logical-span rewrite, malformed-row refusal, size bound, and provider-boundary assertions
+
+Issue #90 was reproduced with a migrated-shaped row carrying a stable ID. The
+controlled test failed only the new title and body assertions while the other 289
+task-registry assertions passed, establishing Level 1 evidence for the parser as
+the lossy stage.
+
+The parser now records the inclusive physical span of each logical row and joins
+only its indented continuation lines into the summary
+(`.agents/skills/task-registry/scripts/registry/index.py:80-86`,
+`.agents/skills/task-registry/scripts/registry/index.py:104-118`, and
+`.agents/skills/task-registry/scripts/registry/index.py:271-299`). Canonical
+rewrites replace that span, while migration uses the explicit physical-line edit
+operation so minting an ID does not delete continuation prose
+(`.agents/skills/task-registry/scripts/registry/index.py:200-221` and
+`.agents/skills/task-registry/scripts/registry/migrate.py:205-220`).
+
+GitHub rendering was disconfirmed: it emits a non-empty body whenever summary or
+criteria exist. Migration was also disconfirmed as the lossy stage: it preserved
+the continuation and only made the publish path reachable. Malformed and
+oversized logical rows now become explicit parser problems, and one bad row
+refuses the whole publish batch before provider discovery or writes
+(`.agents/skills/task-registry/scripts/registry/index.py:141-170` and
+`.agents/skills/task-registry/scripts/registry/reconcile.py:408-415`).
+
+Related pattern: [Logical text records must own their rewrite span](../patterns/logical-text-records-must-own-their-rewrite-span.md).

--- a/tasks/solutions/patterns/consume-structured-records-before-rendering-human-summaries.md
+++ b/tasks/solutions/patterns/consume-structured-records-before-rendering-human-summaries.md
@@ -26,3 +26,6 @@ is unchanged, which is the point — the pattern survives its first consumer.
 Use the CLI summary for humans and semantic inspection; use the structured operation
 for policy. This keeps provider selection and failure degradation inside the module
 that owns them.
+
+When one structured record spans multiple physical lines, the same losslessness
+rule extends to replacement: [Logical text records must own their rewrite span](logical-text-records-must-own-their-rewrite-span.md).

--- a/tasks/solutions/patterns/logical-text-records-must-own-their-rewrite-span.md
+++ b/tasks/solutions/patterns/logical-text-records-must-own-their-rewrite-span.md
@@ -1,0 +1,22 @@
+---
+title: Logical text records must own their rewrite span
+date: 2026-09-06
+problem_type: pattern
+module: text-backed registries and indexes
+tags: [logical-records, multiline-parsing, span-ownership, lossless-rewrite]
+applies_when: A parser combines multiple physical lines into one record that later code can canonicalize or replace
+---
+
+Parsing a multi-line record and rewriting only its first physical line leaves the
+old continuation behind. The next read can then duplicate detail or associate
+orphaned prose with the wrong record.
+
+Make the parsed record own an explicit source span and let canonical replacement
+consume that complete span. If a separate operation intentionally edits only the
+header, expose that distinction in the interface rather than teaching callers
+which line offsets are safe. Task registry rows follow this split through
+`IndexRow.end_line`, `TaskIndex.replace_row`, and `TaskIndex.replace_line`
+(`.agents/skills/task-registry/scripts/registry/index.py:80-86` and
+`.agents/skills/task-registry/scripts/registry/index.py:200-221`).
+
+Cross-link: [Consume structured records before rendering human summaries](consume-structured-records-before-rendering-human-summaries.md).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,7 @@
+# Active issue
+
+- [x] task-registry publish: a legacy prose row becomes an issue with a truncated title and an empty body <!-- task-id: task-registry-publish-a-legacy-prose-row-becomes-an-issue-with-a-truncated-title-and-an-empty-body --> <!-- task-kind: bug --> — Preserve legacy multi-line plan detail, derive a clean title, and refuse unpublishable rows. ([#90](https://github.com/Joaovsales/jplugin-agentic-development/issues/90))
+
 # Yolo iteration 1 — qwen spend guardrails
 
 - [x] TDD: spec written (specs/qwen-spend-guardrails.md) — config task, no test suite; validation = JSON parse + doctor + API GET
@@ -454,3 +458,11 @@ Not executed by `/build`. Listed so the frontier shows the real dependency graph
   branch `Joaovsales/task-tracking-config-a-pointer-to-a-missing-file`
 - Pending: 0 active; 2 deferred externally (#97, #98) unchanged
 - Carry-forward: none from this session
+- [x] route/debug: bug lanes should enter TDD directly after root-cause confirmation <!-- task-id: route.debug-bug-lane-plan-gate --> — resolved by PR #105: `/route` was deleted and the `fix` routine now runs `/debug` directly into `/build`/TDD ([#107](https://github.com/Joaovsales/jplugin-agentic-development/issues/107))
+
+## Session Summary — 2026-09-07 [bbef230..7aedccb]
+- Completed: 1 bug fix — issue #90 preserves complete legacy-row detail and clean
+  provider titles through publication and canonical rewrite.
+- Pending: 0 tasks from this session; issue #107 was closed as superseded by PR #105.
+- Carry-forward: pre-existing task-registry reconciliation findings remain outside
+  this session's scope.

--- a/tests/test-task-registry.sh
+++ b/tests/test-task-registry.sh
@@ -259,8 +259,9 @@ EOF
 cp "$F_INDEX/tasks/todo.md" "$F_INDEX/todo.before"
 
 index_out="$(cd "$F_INDEX" && pyreg <<'EOF'
-from registry.index import TaskIndex, load_index, render_row
+from registry.index import MAX_LOGICAL_ROW_CHARS, TaskIndex, load_index, render_row
 from registry.model import ExternalRef, Task
+from registry.providers.github import _seed_body
 
 index = load_index("tasks/todo.md", "tasks/todo.md")
 print("rows=" + str(len(index.rows)))
@@ -288,6 +289,67 @@ kind_row = render_row(Task(id="bug.routing", title="Preserve kind", kind="bug"),
 kind_task = TaskIndex("tasks/todo.md", kind_row + "\n").rows[0].task
 print("kind-row=" + kind_row)
 print("kind-roundtrip=" + kind_task.kind)
+
+legacy_multiline = TaskIndex(
+    "tasks/todo.md",
+    """[ ] TDD: `agent chat attachment starts recovery in the active owned thread` -> extend the composer and <!-- task-id: chat.recovery -->
+    authenticated route using the existing protocol; record the file turn,
+
+    restore state on reload.
+- [ ] A later task <!-- task-id: later.task --> — remains separate
+## A later section
+    section prose is not task detail
+""",
+)
+print("multiline-rows=" + str(len(legacy_multiline.rows)))
+print("multiline-next=" + legacy_multiline.rows[1].task.title)
+legacy_multiline = legacy_multiline.rows[0].task
+print("multiline-title=" + legacy_multiline.title)
+print("multiline-body=" + _seed_body(legacy_multiline).replace("\n", "|"))
+detail_dash = TaskIndex(
+    "tasks/todo.md",
+    "[ ] TDD: `recover active thread` -> extend composer <!-- task-id: recovery.dash -->\n"
+    "    preserve reloads — including attachments\n",
+).rows[0].task
+print("detail-dash=" + detail_dash.title + "|" + detail_dash.summary)
+multiline_index = TaskIndex(
+    "tasks/todo.md", "[ ] Ship recovery -> preserve state <!-- task-id: recovery.span -->\n    across reloads\n\n    after reconnect\n"
+)
+multiline_index.replace_row(1, "- [ ] Ship recovery <!-- task-id: recovery.span --> — preserve state across reloads")
+print("multiline-rewrite=" + multiline_index.render().replace("\n", "|"))
+generic_arrow = TaskIndex(
+    "tasks/todo.md", "[ ] Ship recovery and -> preserve reload state <!-- task-id: recovery.ship -->\n"
+).rows[0].task
+print("generic-arrow=" + generic_arrow.title + "|" + generic_arrow.summary)
+tight_arrow = TaskIndex(
+    "tasks/todo.md", "[ ] TDD: `tight recovery`->preserve state <!-- task-id: recovery.tight -->\n"
+).rows[0].task
+print("tight-arrow=" + tight_arrow.title + "|" + tight_arrow.summary)
+for label, canonical_text in (
+    ("canonical-spaced", "[ ] Document transition <!-- task-id: docs.spaced --> — explain pending -> active behavior\n"),
+    ("canonical-tight", "[ ] Document syntax <!-- task-id: docs.tight --> — explain a->b notation\n"),
+):
+    canonical = TaskIndex("tasks/todo.md", canonical_text).rows[0].task
+    print(label + "=" + canonical.title + "|" + canonical.summary)
+exact_rest = " Exact -> detail <!-- task-id: exact.limit -->"
+oversized_detail = "x" * (MAX_LOGICAL_ROW_CHARS - len(exact_rest))
+oversized = TaskIndex("tasks/todo.md", "[ ]" + exact_rest + "\n    " + oversized_detail + "\n")
+print("oversized=" + "|".join(problem.message for problem in oversized.problems))
+exact_detail = "x" * (MAX_LOGICAL_ROW_CHARS - len(exact_rest) - 1)
+exact = TaskIndex("tasks/todo.md", "[ ]" + exact_rest + "\n    " + exact_detail + "\n")
+print("exact-limit-rows=" + str(len(exact.rows)))
+unbalanced_detail = TaskIndex(
+    "tasks/todo.md",
+    "[ ] Valid identity -> initial detail <!-- task-id: comment.balance -->\n"
+    "    continuation <!-- unfinished\n",
+)
+print("unbalanced-detail=" + "|".join(problem.message for problem in unbalanced_detail.problems))
+for label, malformed_comment in (
+    ("stray-close", "[ ] Stray close -> detail -->\n"),
+    ("nested-open", "[ ] Nested -> detail <!-- outer <!-- inner -->\n"),
+):
+    malformed = TaskIndex("tasks/todo.md", malformed_comment)
+    print(label + "=" + "|".join(problem.message for problem in malformed.problems))
 EOF
 )"
 
@@ -309,6 +371,41 @@ assert_contains "$index_out" "kind-row=- [ ] Preserve kind <!-- task-id: bug.rou
   "Index: candidate registration can opt into a canonical task-kind marker"
 assert_contains "$index_out" "kind-roundtrip=bug" \
   "Index: an opted-in task kind survives the compact-row round trip"
+assert_contains "$index_out" \
+  "multiline-title=agent chat attachment starts recovery in the active owned thread" \
+  "Index: a legacy TDD row derives its title from the quoted deliverable"
+assert_contains "$index_out" \
+  "multiline-body=extend the composer and authenticated route using the existing protocol; record the file turn, restore state on reload." \
+  "Index: a legacy row carries its complete implementation clause into the provider body"
+assert_contains "$index_out" \
+  "detail-dash=recover active thread|extend composer preserve reloads — including attachments" \
+  "Index: punctuation in continuation detail cannot override header title derivation"
+assert_contains "$index_out" "multiline-rows=2" \
+  "Index: continuation capture stops before the next task and section"
+assert_contains "$index_out" "multiline-next=A later task" \
+  "Index: a task after legacy continuation detail remains independently parseable"
+multiline_rewrite="$(printf '%s\n' "$index_out" | sed -n 's/^multiline-rewrite=//p')"
+assert_eq "- [ ] Ship recovery <!-- task-id: recovery.span --> — preserve state across reloads|" \
+  "$multiline_rewrite" \
+  "Index: replacing a logical row consumes its original continuation span"
+assert_contains "$index_out" "generic-arrow=Ship recovery|preserve reload state" \
+  "Index: a non-TDD legacy arrow row separates detail and drops a dangling conjunction"
+assert_contains "$index_out" "tight-arrow=tight recovery|preserve state" \
+  "Index: a tight legacy arrow cannot bypass title and body derivation"
+assert_contains "$index_out" "canonical-spaced=Document transition|explain pending -> active behavior" \
+  "Index: a spaced arrow inside a canonical summary remains body text"
+assert_contains "$index_out" "canonical-tight=Document syntax|explain a->b notation" \
+  "Index: a tight arrow inside a canonical summary remains body text"
+assert_contains "$index_out" "oversized=logical task row exceeds the 60000-character publish limit" \
+  "Index: provider-bound logical rows have an explicit non-truncating size limit"
+assert_contains "$index_out" "exact-limit-rows=1" \
+  "Index: the 60000-character logical-row boundary remains publishable"
+assert_contains "$index_out" "unbalanced-detail=unbalanced HTML comment in logical task row" \
+  "Index: a valid ID cannot hide an unfinished comment in continuation detail"
+assert_contains "$index_out" "stray-close=unbalanced HTML comment in logical task row" \
+  "Index: a stray HTML comment close marker is refused"
+assert_contains "$index_out" "nested-open=unbalanced HTML comment in logical task row" \
+  "Index: nested HTML comment open markers are refused"
 assert_files_identical "$F_INDEX/tasks/todo.md" "$F_INDEX/todo.before" \
   "Index: parsing never writes to the file it read"
 
@@ -793,6 +890,55 @@ assert_not_contains "$todo_after_local" "8-bit sources load" \
 # =============================================================================
 # 7. GitHub provider — label vocabulary, status, identity, gated writes
 # =============================================================================
+F_GH_LEGACY="$(new_fixture)"
+write_github_config "$F_GH_LEGACY"
+install_gh_mock "$F_GH_LEGACY"
+: > "$F_GH_LEGACY/gh.log"
+cat > "$F_GH_LEGACY/tasks/todo.md" <<'EOF'
+[ ] TDD: `recover active thread` -> extend composer — preserve attachments <!-- task-id: recovery.legacy -->
+    across reloads
+EOF
+gh_legacy_code=0
+gh_legacy="$(cd "$F_GH_LEGACY" && PATH="$F_GH_LEGACY/bin:$PATH" \
+  GH_MOCK_DIR="$F_GH_LEGACY/ghdata" GH_MOCK_LOG="$F_GH_LEGACY/gh.log" \
+  run publish --repo "$F_GH_LEGACY" --apply --approve 2>&1)" || gh_legacy_code=$?
+assert_eq "0" "$gh_legacy_code" \
+  "GitHub: a valid multi-line legacy row publishes through the real CLI"
+gh_legacy_log="$(cat "$F_GH_LEGACY/gh.log")"
+assert_contains "$gh_legacy_log" \
+  "issue create --repo fixture-owner/fixture-repo --title recover active thread --body extend composer — preserve attachments across reloads" \
+  "GitHub: legacy publication sends the derived title and complete body to gh"
+assert_file_contains "$F_GH_LEGACY/tasks/todo.md" \
+  "- [ ] recover active thread <!-- task-id: recovery.legacy --> — extend composer — preserve attachments across reloads ([#100](https://github.com/fixture-owner/fixture-repo/issues/100))" \
+  "GitHub: successful publication rewrites the complete logical row with its issue link"
+
+F_GH_REFUSE="$(new_fixture)"
+write_github_config "$F_GH_REFUSE"
+install_gh_mock "$F_GH_REFUSE"
+: > "$F_GH_REFUSE/gh.log"
+printf '[ ] Valid sibling -> must not publish <!-- task-id: valid.sibling -->\n[ ] TDD: `` -> <!-- task-id: malformed.legacy -->\n[ ] and -> implement recovery <!-- task-id: malformed.generic -->\n[ ] Ship -> first -> second — extra detail <!-- task-id: malformed.ambiguous -->\n[ ] Broken metadata -> detail <!-- task-id: malformed.comment\n' \
+  > "$F_GH_REFUSE/tasks/todo.md"
+gh_refuse_code=0
+gh_refuse="$(cd "$F_GH_REFUSE" && PATH="$F_GH_REFUSE/bin:$PATH" \
+  GH_MOCK_DIR="$F_GH_REFUSE/ghdata" GH_MOCK_LOG="$F_GH_REFUSE/gh.log" \
+  run publish --repo "$F_GH_REFUSE" --apply --approve 2>&1)" || gh_refuse_code=$?
+assert_eq "1" "$gh_refuse_code" \
+  "GitHub: publish refuses a stable-id legacy row with no clean title or body"
+assert_contains "$gh_refuse" "cannot publish legacy TDD row" \
+  "GitHub: an unpublishable legacy row gets an actionable finding"
+assert_contains "$gh_refuse" "cannot publish legacy row: expected a clean title" \
+  "GitHub: clean-title validation applies to non-TDD legacy rows"
+assert_contains "$gh_refuse" "expected a quoted test name and detail after '->'" \
+  "GitHub: a TDD row with no quoted title or arrow detail is refused"
+assert_contains "$gh_refuse" "multiple '->' delimiters" \
+  "GitHub: ambiguous implementation delimiters are refused"
+assert_contains "$gh_refuse" "unbalanced HTML comment in logical task row" \
+  "GitHub: unbalanced task identity metadata is refused"
+assert_not_contains "$(cat "$F_GH_REFUSE/gh.log")X" "issue create" \
+  "GitHub: one malformed row makes the whole publish batch fail before external writes"
+assert_eq "" "$(cat "$F_GH_REFUSE/gh.log")" \
+  "GitHub: malformed local input is refused before any provider read"
+
 F_GH="$(new_fixture)"
 write_index "$F_GH"
 write_github_config "$F_GH"
@@ -1180,6 +1326,7 @@ cat > "$F_MIG/tasks/todo.md" <<'EOF'
 > Spec: specs/pending/morph-recipes.md
 
 - [ ] Morph live grid recipe — ship the live grid morph
+    through the existing renderer
 - [ ] Colour LUT loader — palette mapping for 8-bit sources
 - [!] Verify nightly render deploy — smoke the rollout after each release
 - [ ] Decide dither strategy — pick one before the next recipe lands
@@ -1202,12 +1349,15 @@ printf '# Still motion\n\nshipped\n' > "$F_MIG/specs/completed/still-motion.md"
 printf '# Orphaned plan\n\nnothing points here\n' > "$F_MIG/specs/pending/orphaned-plan.md"
 
 mig_before="$(cd "$F_MIG" && find . -type f | sort)"
+todo_before_mig="$(cat "$F_MIG/tasks/todo.md")"
 mig_dry="$(run migrate --repo "$F_MIG" 2>&1)"
 mig_dry_code=$?
 mig_after_dry="$(cd "$F_MIG" && find . -type f | sort)"
 assert_eq "0" "$mig_dry_code" "Migrate: the dry run exits 0"
 assert_contains "$mig_dry" "DRY RUN (nothing written)" "Migrate: dry-run is the default and says so"
 assert_eq "$mig_before" "$mig_after_dry" "Migrate: the dry run writes nothing"
+assert_eq "$todo_before_mig" "$(cat "$F_MIG/tasks/todo.md")" \
+  "Migrate: dry-run preserves every physical continuation line byte-for-byte"
 assert_contains "$mig_dry" "completed (history, no external task): 3" \
   "Migrate: the three ticked rows are classified as history"
 assert_contains "$mig_dry" "stale (open in a closed plan): 1" \
@@ -1235,6 +1385,8 @@ assert_contains "$mig_apply" "minted" "Migrate: --apply reports how many ids it 
 assert_file_contains "$F_MIG/tasks/todo.md" \
   "- [ ] Morph live grid recipe <!-- task-id: recipe-morphs.morph-live-grid-recipe --> — ship the live grid morph" \
   "Migrate: the id is inserted after the title, leaving the rest of the row untouched"
+assert_file_contains "$F_MIG/tasks/todo.md" "    through the existing renderer" \
+  "Migrate: applying ids preserves indented legacy continuation detail"
 assert_file_contains "$F_MIG/tasks/todo.md" "[x] TDD: living texture flow -> impl" \
   "Migrate: completed history rows are left exactly as they were"
 completed_ids="$(grep -c 'TDD: living texture flow -> impl <!-- task-id' "$F_MIG/tasks/todo.md" || true)"
@@ -1941,5 +2093,12 @@ assert_contains "$crash_out" "credentials masked" \
   "CLI: an unexpected failure says the trace was scrubbed"
 assert_not_contains "$crash_out" "ZmFrZTpsZWFrZWR0b2tlbnZhbHVl" \
   "CLI: an Authorization header in a traceback never reaches the terminal"
+
+assert_file_contains "$SKILL/templates/task-tracking.md" "## Naming conventions" \
+  "Template: projects get a stub for provider-facing title and label conventions"
+assert_file_contains "$SKILL/templates/task-tracking.md" "Never publish raw plan text" \
+  "Template: legacy implementation clauses are documented as provider body content"
+assert_not_contains "$(cat "$SKILL/templates/task-tracking.md")" '<PLAN-ID> —' \
+  "Template: the recommended title separator cannot collide with row summary serialization"
 
 finish


### PR DESCRIPTION
Fixes #90

## Summary
- parse indented legacy task detail as one bounded logical row
- derive clean titles and complete provider bodies from quoted TDD and legacy arrow syntax
- reject malformed or ambiguous batches before provider access, while preserving continuation text during migration and canonical rewrite
- document provider-facing naming conventions in the shipped task-tracking template

## Verification
- `bash tests/test-task-registry.sh` — 348 assertions passed
- `bash tests/run.sh` — all 36 test files passed
- CLI E2E publishes through a fake `gh` boundary and verifies exact title, body, and local rewrite
- canonical and `.claude` compatibility copies are byte-identical
- security scan passed with no findings

## Review
Four separately dispatched review lenses covered consistency, defensive behavior, edge-case coverage, and adversarial spec compliance. All findings were fixed; final critic re-review: GO with no findings.

## Remote refresh
Rebased onto `origin/master` at `bbef230`, including PRs #105 and #109. The debug-plan follow-up #107 was closed as already resolved by #105.