### PR TITLE
fix(memory-maintain): count alternate session history headings

### DIFF
--- a/.agents/skills/memory-maintain/SKILL.md
+++ b/.agents/skills/memory-maintain/SKILL.md
@@ -39,8 +39,16 @@ not swallow the one sweep that install exists to trigger.**
 
 ### Heavy pass — every 5 sessions (gated)
 
-Count session entries in `tasks/history.md` (lines matching `^### \[\d{4}-\d{2}-\d{2}`):
-- Run the full sweep below (Phases 1–4) if the count is a multiple of 5
+Count session entries in `tasks/history.md`, accepting both `### [YYYY-MM-DD]`
+and `## YYYY-MM-DD` headings. Keep writing the canonical `/learn` format;
+existing history can contain either. Use the same pattern as the session-start hook:
+
+```bash
+grep -Ec '^(### \[[0-9]{4}-[0-9]{2}-[0-9]{2}\]|## [0-9]{4}-[0-9]{2}-[0-9]{2})([[:space:]]|$)' tasks/history.md
+```
+
+Missing history means zero sessions; grep exit 1 means zero matches.
+- Run the full sweep below (Phases 1–4) if the count is a positive multiple of 5
   (5, 10, 15, …) OR --force flag passed
 - If neither condition met: skip the heavy pass (the light pass above still ran)
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -177,7 +177,7 @@ fi
 # The /memory-maintain skill is also called every session start via CLAUDE.md
 # step 4 — the skill self-gates, so this nudge is a belt-and-suspenders signal.
 if [ -f "tasks/history.md" ]; then
-  SESSION_COUNT=$(grep -c '^### \[[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' tasks/history.md 2>/dev/null || true)
+  SESSION_COUNT=$(grep -Ec '^(### \[[0-9]{4}-[0-9]{2}-[0-9]{2}\]|## [0-9]{4}-[0-9]{2}-[0-9]{2})([[:space:]]|$)' tasks/history.md 2>/dev/null || true)
   if [ "${SESSION_COUNT:-0}" -gt 0 ] && [ $(( SESSION_COUNT % 5 )) -eq 0 ]; then
     echo ""
     echo "🔧  MEMORY MAINTENANCE DUE ($SESSION_COUNT sessions) — /memory-maintain will run at session start."

--- a/.claude/skills/memory-maintain/SKILL.md
+++ b/.claude/skills/memory-maintain/SKILL.md
@@ -39,8 +39,16 @@ not swallow the one sweep that install exists to trigger.**
 
 ### Heavy pass — every 5 sessions (gated)
 
-Count session entries in `tasks/history.md` (lines matching `^### \[\d{4}-\d{2}-\d{2}`):
-- Run the full sweep below (Phases 1–4) if the count is a multiple of 5
+Count session entries in `tasks/history.md`, accepting both `### [YYYY-MM-DD]`
+and `## YYYY-MM-DD` headings. Keep writing the canonical `/learn` format;
+existing history can contain either. Use the same pattern as the session-start hook:
+
+```bash
+grep -Ec '^(### \[[0-9]{4}-[0-9]{2}-[0-9]{2}\]|## [0-9]{4}-[0-9]{2}-[0-9]{2})([[:space:]]|$)' tasks/history.md
+```
+
+Missing history means zero sessions; grep exit 1 means zero matches.
+- Run the full sweep below (Phases 1–4) if the count is a positive multiple of 5
   (5, 10, 15, …) OR --force flag passed
 - If neither condition met: skip the heavy pass (the light pass above still ran)
 

--- a/specs/memory-maintain-history-count.md
+++ b/specs/memory-maintain-history-count.md
@@ -1,0 +1,58 @@
+---
+implementation_paths:
+  - .agents/skills/memory-maintain/SKILL.md
+  - .claude/skills/memory-maintain/SKILL.md
+  - .claude/hooks/session-start.sh
+  - tests/test-memory-maintain-doc.sh
+  - tests/test-session-start.sh
+---
+
+# Spec: Memory maintenance history counting
+
+## Behavior
+
+The heavy-pass gate and session-start reminder count both session heading formats
+already present in history: `### [YYYY-MM-DD] — title` and `## YYYY-MM-DD — title`.
+New entries continue to use the canonical `/learn` template. Existing narrative
+history does not require rewriting.
+
+The cadence remains a positive multiple of five sessions. `--force` bypasses the
+skill's cadence gate. The light pass and pending-glossary bootstrap retain their
+current behavior. Catch-up and duplicate-sweep prevention are separate cadence
+changes, outside this heading-recognition repair.
+
+## Inputs
+
+`tasks/history.md`, session-start hook input, and the skill's `--force` flag.
+
+## Outputs
+
+A consistent count in the skill and hook; the existing reminder at positive
+multiples of five.
+
+## Edge Cases
+
+- Missing or empty history yields zero sessions and no reminder.
+- Unrelated headings, prose dates, and malformed date headings do not count.
+- Separate sessions on the same date count separately.
+- Counts immediately below and above a multiple of five remain silent.
+
+## Acceptance Criteria
+
+- AC1: Five canonical entries trigger the real session-start reminder.
+- AC2: Five alternate entries and five mixed-format entries each trigger the
+  reminder with an accurate count; both fixtures fail on the original hook.
+- AC3: Missing/empty history, four sessions, and six sessions remain silent;
+  unrelated headings and malformed dates do not inflate the count.
+- AC4: The skill and hook use equivalent recognition for both formats and the
+  same positive-multiple-of-five gate; both skill copies remain byte-identical.
+- AC5: Forced maintenance, the light pass, and glossary bootstrap are preserved;
+  relevant tests and the full repository suite pass.
+
+## Implementation Paths
+
+- `.agents/skills/memory-maintain/SKILL.md` — canonical counting contract.
+- `.claude/skills/memory-maintain/SKILL.md` — compatibility copy.
+- `.claude/hooks/session-start.sh` — executable session counter and reminder.
+- `tests/test-session-start.sh` — behavioral fixture regressions.
+- `tests/test-memory-maintain-doc.sh` — skill contract and parity guards.

--- a/tasks/e2e-log.md
+++ b/tasks/e2e-log.md
@@ -651,3 +651,77 @@ bytes, 21 expected command exits and all recorded runtime removals checked.
 Review independence: four passes dispatched; no confidence promotion needed.
 Review totals: 0 MUST-FIX, 1 SHOULD-FIX fixed deliberately, 0 unresolved/skipped.
 No configured deployment targets; interactive non-routine branch.
+
+
+## E2E Walkthrough — Memory maintenance history counting — 2026-09-09 9017248
+
+Spec: specs/memory-maintain-history-count.md
+Source: uncommitted implementation on base 9017248f0311b5980a4a1cdf075c1aea6aec45d2.
+Hook SHA-256: 5bf409d75c0c2125c2b31187b9371b0b8b77286fb356aaf678e66403c803e0ae.
+Driver: Bash lifecycle hook, invoked from a Python driver in a real PTY.
+Each scenario creates an owned temporary project containing only its history;
+executes the absolute repository `.claude/hooks/session-start.sh` with stdin
+`{"source":"startup"}`, `CCW_SESSION_GUARD=0`, and a fixture-local
+`CLAUDE_SESSION_SENTINEL`; captures stdout/stderr and exit status; and requires
+`SKILLS AVAILABLE` to prove that a missing reminder was not an aborted banner.
+This is a lifecycle-hook integration walkthrough, not an agent-triggering test.
+
+### AC1 — Canonical history
+
+Five `### [2026-09-09] — session` entries: exit 0, full banner, reminder at 5.
+Negative: four entries produce no reminder. PASS.
+
+### AC2 — Alternate and mixed history
+
+Five `## 2026-09-09 — session` entries and four canonical plus one alternate
+entry: each exits 0, full banner, reminder at 5. Before implementation both
+new regression assertions failed. Ten separate same-date alternate entries
+produce a reminder at 10. PASS.
+
+### AC3 — Boundaries and invalid headings
+
+Four/six canonical entries, empty/missing history, and four canonical entries
+plus `## 2026-09-09suffix — invalid`: exit 0, full banner, no reminder in every
+case. Regression suite additionally checks eight malformed/unrelated headings,
+individually added to four valid sessions. PASS.
+
+### AC4 — Counting contract
+
+`bash tests/test-memory-maintain-doc.sh`: 15 assertions passed, including
+hook/skill pattern agreement and byte-identical mirrors. The complete current
+history counts 22 before appending this session, versus 19 with the old pattern.
+PASS (contract test plus live grep).
+
+### AC5 — Preserved behavior and regression suite
+
+Source diff confines the skill change to heading recognition and makes its
+existing positive-five gate explicit. `--force`, light-pass work, and glossary
+bootstrap branches are preserved by inspection; no forced store sweep was run.
+`env -u TASK_REGISTRY_TRUSTED_CONFIG bash tests/run.sh </dev/null`:
+38 files, 3,589 assertions passed. The unset applies only to the test process:
+the inherited trusted-config override caused a pre-existing Doctor test failure.
+`bash -n` and `git diff --check` pass. PASS.
+
+Cleanup: owned runtime removed; stdout/stderr for all nine live scenarios and
+source identity retained in `/tmp/memory-maintain-walkthrough/`. The observations
+above are the durable record. Isolated mutation probes each went red: missing
+alternate format (3 failures), missing date boundary (2), zero allowed (1), and
+modulo bypassed (10). No mutation touched the working implementation.
+
+Review: quality-gate structural/anti-pattern passes inline; APOSD dispatched,
+GO. Four wrap-up passes separately dispatched: consistency, defensive/security,
+test coverage, adversarial critic. All report zero findings; no confidence
+promotion used. Reported, not applied: none. Security checklist: fixed regex and
+quoted file inputs; no history text is evaluated as code, no new authentication,
+secret, disclosure, cryptographic, dependency, or network surface.
+
+Verification-map maintenance: clean / not applicable; the only local recipe,
+verify-task-registry, declares the Python task-registry CLI. This change alters
+its surrounding agent lifecycle hook, with no changed CLI feature entry point.
+
+Spec reconciliation: six candidates, all unchanged after comparison with the
+scoped heading-count diff: specs/compound-engineering-adoption.md,
+specs/context-memory-management.md, specs/memory-maintain-history-count.md,
+specs/pstack-verification-skill-integration.md, specs/separate-project-config.md,
+specs/sweep-routines.md. The legacy context-memory spec's old store vocabulary
+predates this fix; its cadence contract is unaffected. No deferred reconciliation.

--- a/tasks/e2e-log.md
+++ b/tasks/e2e-log.md
@@ -725,3 +725,14 @@ specs/context-memory-management.md, specs/memory-maintain-history-count.md,
 specs/pstack-verification-skill-integration.md, specs/separate-project-config.md,
 specs/sweep-routines.md. The legacy context-memory spec's old store vocabulary
 predates this fix; its cadence contract is unaffected. No deferred reconciliation.
+
+
+### Committed verification identity — 2026-09-09 ca8142d
+
+Spec: specs/memory-maintain-history-count.md
+Commit: ca8142d85b6182d935ab1a14ddd8749a74f39ec0
+The committed hook's SHA-256 matches the source exercised in all nine scenarios
+above (5bf409d75c0c2125c2b31187b9371b0b8b77286fb356aaf678e66403c803e0ae).
+All five AC results and review findings above apply to this source commit.
+Final full suite: 38 files / 3,589 assertions, exit 0, zero failures.
+This follow-up changes only the verification identity and wrap-up fingerprint.

--- a/tasks/history.md
+++ b/tasks/history.md
@@ -534,3 +534,13 @@ back vacuous and was repaired.
 - Exercised actual local CLI writes and read-back through isolated PTYs; retained command/output/exit evidence after owned-runtime cleanup.
 - Coverage excludes GitHub, installation, and complete agent routines; derived source/spec entry points passed after correcting an unsupported source read-back expectation during wrap-up.
 - Learnings captured: updated [stdin ownership](solutions/bugs/test-suite-hangs-when-stdin-is-an-open-pipe.md).
+
+
+### [2026-09-09] — Maintenance heading count
+
+- Key changes: memory maintenance and its startup reminder count canonical and
+  alternate session headings; added mixed-history, boundary, and pattern-parity
+  regressions. Preserved the positive-multiple-of-five cadence.
+- Verification: 38 test files / 3,589 assertions passed; nine isolated live-hook
+  scenarios, four mutation probes, and five dispatched review passes completed.
+- Learnings captured: [History heading drift](solutions/bugs/memory-maintain-history-heading-drift.md).

--- a/tasks/solutions/bugs/memory-maintain-history-heading-drift.md
+++ b/tasks/solutions/bugs/memory-maintain-history-heading-drift.md
@@ -1,0 +1,65 @@
+---
+title: Memory maintenance ignores alternate session history headings
+date: 2026-09-09
+problem_type: bug
+module: .agents/skills/memory-maintain, .claude/hooks/session-start.sh
+tags: [memory-maintain, history, session-count, heading-drift]
+symptoms: Five alternate-format history entries produce no maintenance reminder
+root_cause: Both counters recognize only bracketed level-three dates while actual history also uses unbracketed level-two dates
+resolution: Recognize both existing heading formats in the hook and mirrored skill, with behavioral regressions and a shared-pattern contract test
+---
+
+**Status**: fixed — 2026-09-09
+**Regression test**: Alternate and mixed fixtures in tests/test-session-start.sh; pattern parity in tests/test-memory-maintain-doc.sh
+
+## Reproduction
+
+Create a temporary `tasks/history.md` with five `## 2026-09-0N — session`
+headings, N=1..5. Run the repository's absolute `.claude/hooks/session-start.sh`
+path from that directory with `CCW_SESSION_GUARD=0` and stdin
+`{"source":"startup"}`. Exit is zero, but `MEMORY MAINTENANCE DUE` is absent.
+Changing only the headings to `### [2026-09-0N] — session` produces the reminder.
+A mix of four canonical entries and one alternate entry also fails.
+
+Evidence level 1: reproduced before implementation in the primary context and
+independently by a dispatched code-debugger.
+
+## Original root cause and alternatives (before the fix)
+
+- `.claude/hooks/session-start.sh:180` counts only bracketed level-three dates.
+- `.agents/skills/memory-maintain/SKILL.md:42` specifies the same restriction.
+- `tasks/history.md:405`, `:432`, and `:460` contain excluded session headings.
+  Current history has 19 recognized entries plus three excluded entries.
+- `tests/test-session-start.sh:185` covers only the canonical heading format.
+
+A conflicting writer template is ruled out: `/learn` at
+`.agents/skills/learn/SKILL.md:65` prescribes the canonical format. Actual writes
+drifted from it. Startup suppression is ruled out by disabling the guard and
+running a successful canonical control in the same environment.
+
+This established undercounting, not that maintenance was due at the observed total
+of 22 or that no previous heavy pass ever ran. Missed thresholds and repeated
+sweeps are separate limitations of the documented modulo cadence.
+
+## Resolution and verification
+
+The hook at `.claude/hooks/session-start.sh:180` and the canonical skill's
+command at `.agents/skills/memory-maintain/SKILL.md:47` now recognize both
+formats. Complete brackets and a whitespace/end boundary exclude partial dates.
+The date check is syntactic; it does not validate calendar dates.
+
+The new alternate/mixed regressions failed on the original hook, then passed.
+`tests/test-session-start.sh` passes 95 assertions; the documentation contract
+passes 15. Four isolated mutations (drop the alternate format, remove the date
+boundary, allow zero, bypass modulo) each fail the corresponding assertions.
+Live-hook walkthrough observations are retained in `tasks/e2e-log.md`.
+
+Full suite: 38 files, 3,589 assertions passed with
+`env -u TASK_REGISTRY_TRUSTED_CONFIG bash tests/run.sh </dev/null`.
+This session inherited `TASK_REGISTRY_TRUSTED_CONFIG=1`, which made the existing
+Doctor approval-floor test fail before implementation; clearing that override
+for the test process restored its expected environment. No registry code changed.
+
+Prevention: include fixtures drawn from actual persisted history, not only the
+writer's template; otherwise both the writer-shaped test and narrow reader can
+agree while excluding real records.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,14 @@
 # Active issue
 
+## Plan: Memory maintenance history counting
+> Spec: specs/memory-maintain-history-count.md
+> Approved 2026-09-09; all four tasks completed and independently reviewed.
+
+- [x] TDD: alternate and mixed history fixtures in tests/test-session-start.sh fail on the original hook -> recognize both existing session heading formats in the hook counter.
+- [x] TDD: missing/empty history, four/six sessions, unrelated headings, and malformed dates -> preserve the positive-multiple-of-five boundary without false counts.
+- [x] TDD: memory-maintain counting contract and skill parity -> align both skill copies with the hook while preserving force, light-pass, and glossary behavior.
+- [x] TDD: relevant tests and full suite -> review the change, record hook walkthrough evidence in tasks/e2e-log.md, and update the bug document with verified results.
+
 - [x] task-registry publish: a legacy prose row becomes an issue with a truncated title and an empty body <!-- task-id: task-registry-publish-a-legacy-prose-row-becomes-an-issue-with-a-truncated-title-and-an-empty-body --> <!-- task-kind: bug --> — Preserve legacy multi-line plan detail, derive a clean title, and refuse unpublishable rows. ([#90](https://github.com/Joaovsales/jplugin-agentic-development/issues/90))
 
 # Plan: sweep routines — `janitor` and `architect` producers, cheap-model consumers

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -710,3 +710,17 @@ reverse.
 - Completed: create-verification-skill invocation — mirrored verify-task-registry, three feature maps, live local CLI walkthrough and durable evidence.
 - Pending: no remaining work for the requested skill creation; GitHub, installation, and full agent routines remain outside verified coverage; derived source/spec entry points passed during wrap-up.
 - Carry-forward: use /maintain-verification-skill --scope changed after changes to mapped CLI behavior.
+
+
+## Session Summary — 2026-09-09 [9017248..ca8142d]
+- Completed: all four memory-maintenance history-count tasks. Hook and mirrored
+  skill recognize canonical and alternate history headings; added boundary and
+  pattern-parity regressions.
+- Verification: 38 files / 3,589 assertions pass with the inherited
+  TASK_REGISTRY_TRUSTED_CONFIG override cleared for tests. Nine live-hook cases,
+  four mutation probes, five dispatched review passes; zero findings.
+- Pending: none for this fix. Catch-up and duplicate-sweep prevention remain
+  outside the approved heading-recognition scope.
+- Carry-forward: specs/memory-maintain-history-count.md; diagnosis in
+  tasks/solutions/bugs/memory-maintain-history-heading-drift.md;
+  walkthrough in tasks/e2e-log.md.

--- a/tests/test-memory-maintain-doc.sh
+++ b/tests/test-memory-maintain-doc.sh
@@ -7,6 +7,7 @@ cd "$REPO"
 
 A=".agents/skills/memory-maintain/SKILL.md"
 C=".claude/skills/memory-maintain/SKILL.md"
+history_pattern=$(sed -n "s/.*grep -Ec '\([^']*\)' tasks\/history\.md.*/\1/p" .claude/hooks/session-start.sh)
 
 for f in "$A" "$C"; do
   assert_file_contains "$f" "Light pass — every session" "P4: $f documents per-session light pass"
@@ -15,6 +16,9 @@ for f in "$A" "$C"; do
   assert_file_contains "$f" "tasks/solutions" "M3: $f sweeps the typed store"
   assert_file_contains "$f" "needs_review" "M3: $f resolves needs_review documents"
   assert_file_contains "$f" "Contradicted" "M3: $f handles contradicted documents"
+  # The duplicated command is executable contract, not a snapshot of its prose.
+  assert_file_contains "$f" "grep -Ec '$history_pattern' tasks/history.md" \
+    "$f: history heading pattern matches the real hook"
 done
 
 assert_files_identical "$A" "$C" "P4: memory-maintain byte-identical across both trees"

--- a/tests/test-session-start.sh
+++ b/tests/test-session-start.sh
@@ -182,20 +182,68 @@ assert_contains "$out_none" "No learning store yet" \
 cd "$REPO"
 rm -rf "$tmpN"
 
-# --- M3: maintenance nudge fires on a multiple of 5 history entries ---------
+# --- Maintenance counts both session heading formats found in history ------
+assert_maintenance_notice() {
+  local expected="$1" label="$2" output status
+  output=$(printf '{"source":"startup"}' | CCW_SESSION_GUARD=0 \
+    CLAUDE_SESSION_SENTINEL="$PWD/session-active" bash "$HOOK" 2>&1)
+  status=$?
+  assert_eq "0" "$status" "$label: hook succeeds"
+  assert_contains "$output" "SKILLS AVAILABLE" "$label: full banner runs"
+  if [ -n "$expected" ]; then
+    assert_contains "$output" "MEMORY MAINTENANCE DUE ($expected sessions)" "$label: reminder counts sessions"
+  else
+    assert_not_contains "$output" "MEMORY MAINTENANCE DUE" "$label: no reminder"
+  fi
+}
+
 tmpM=$(mktemp -d)
 cd "$tmpM"
 mkdir -p tasks/solutions/patterns
 for d in 01 02 03 04 05; do
   printf '### [2026-08-%s] — session %s\n- Key changes: x\n\n' "$d" "$d" >> tasks/history.md
 done
-out_five=$(printf '{"source":"startup"}' | CCW_SESSION_GUARD=0 bash "$HOOK" 2>/dev/null)
-assert_contains "$out_five" "MEMORY MAINTENANCE DUE (5 sessions)" \
-  "M3: nudge fires at 5 bracketed-date history entries"
+assert_maintenance_notice 5 "five canonical entries"
 printf '### [2026-08-06] — session 06\n- Key changes: x\n\n' >> tasks/history.md
-out_six=$(printf '{"source":"startup"}' | CCW_SESSION_GUARD=0 bash "$HOOK" 2>/dev/null)
-assert_not_contains "$out_six" "MEMORY MAINTENANCE DUE" \
-  "M3: nudge stays silent off the multiple of 5"
+assert_maintenance_notice '' "six canonical entries"
+
+for format in alternate mixed; do
+  : > tasks/history.md
+  for d in 01 02 03 04 05; do
+    if [ "$format" = mixed ] && [ "$d" != 05 ]; then
+      printf '### [2026-08-%s] — session\n' "$d" >> tasks/history.md
+    else
+      printf '## 2026-08-%s — session\n' "$d" >> tasks/history.md
+    fi
+  done
+  assert_maintenance_notice 5 "five $format entries"
+done
+
+head -n 4 tasks/history.md > four-sessions.md
+cp four-sessions.md tasks/history.md
+assert_maintenance_notice '' "four sessions"
+for heading in \
+  '### Round 2 review (2026-08-05)' \
+  'A prose date: 2026-08-05' \
+  '#### [2026-08-05] — nested heading' \
+  '### [2026-08-05 — missing bracket' \
+  '### [2026-08-05]suffix — missing separator' \
+  '## 2026-08-05suffix — missing separator' \
+  '## 2026-8-05 — short month' \
+  '### [2026-08-5] — short day'; do
+  cp four-sessions.md tasks/history.md
+  printf '%s\n' "$heading" >> tasks/history.md
+  assert_maintenance_notice '' "four sessions plus $heading"
+done
+
+: > tasks/history.md
+assert_maintenance_notice '' "empty history"
+rm tasks/history.md
+assert_maintenance_notice '' "missing history"
+for ((session=0; session<10; session++)); do
+  printf '## 2026-08-05 — session %s\n' "$session" >> tasks/history.md
+done
+assert_maintenance_notice 10 "ten sessions on the same date"
 cd "$REPO"
 rm -rf "$tmpM"
 


### PR DESCRIPTION
Session history using `## YYYY-MM-DD` was excluded from the memory-maintenance gate and startup reminder, so five such entries never triggered maintenance. Recognize that existing format alongside `### [YYYY-MM-DD]` in the hook and both skill copies, preserving the positive-multiple-of-five cadence.

Adds real-hook regressions for alternate and mixed histories, boundary counts, malformed headings, and repeated dates, plus a contract test keeping the skill and hook patterns aligned.

Validation: `env -u TASK_REGISTRY_TRUSTED_CONFIG bash tests/run.sh </dev/null` — 38 files, 3,589 assertions passed. The environment override is cleared because the existing Doctor approval-floor test assumes an untrusted configuration. Nine standalone hook scenarios and four mutation probes passed; five independent review passes found no introduced issues.

Spec: `specs/memory-maintain-history-count.md`. Reproduction and diagnosis: `tasks/solutions/bugs/memory-maintain-history-heading-drift.md`. Walkthrough: `tasks/e2e-log.md`.
